### PR TITLE
Add maxCost to PathFinderOpts

### DIFF
--- a/src/path-finder.ts
+++ b/src/path-finder.ts
@@ -75,6 +75,11 @@ interface PathFinderOpts {
      */
     maxRooms?: number;
     /**
+     * The maximum allowed cost of the path returned. If at any point the pathfinder detects that it is impossible to find
+     * a path with a cost less than or equal to maxCost it will immediately halt the search. The default is Infinity.
+     */
+    maxCost?: number;
+    /**
      * Weight to apply to the heuristic in the A* formula F = G + weight * H. Use this option only if you understand
      * the underlying A* algorithm mechanics! The default value is 1.
      */


### PR DESCRIPTION
This was missing, add it.
http://docs.screeps.com/api/#PathFinder.search