### PR TITLE
Type the find function at runtime

### DIFF
--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -1991,10 +1991,10 @@ interface RoomPosition {
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      * @returns An instance of a RoomObject.
      */
-    findClosestByPath<T extends FindConstant>(type: T, opts?: FindPathOpts & {
-        filter?: any | string;
+    findClosestByPath<T extends FindTypes[K], K extends FindConstant = K>(type: K, opts?: FindPathOpts & {
+        filter?: FilterFunction<K>;
         algorithm?: string;
-    }): FindTypes[T];
+    }): T;
     /**
      * Find the object with the shortest path from the given position. Uses A* search algorithm and Dijkstra's algorithm.
      * @param objects An array of RoomPositions or objects with a RoomPosition
@@ -2010,9 +2010,9 @@ interface RoomPosition {
      * @param type Any of the FIND_* constants.
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      */
-    findClosestByRange<T extends FindConstant>(type: T, opts?: {
-        filter: any | string;
-    }): FindTypes[T];
+    findClosestByRange<T extends FindTypes[K], K extends FindConstant = K>(type: K, opts?: {
+        filter: FilterFunction<K>;
+    }): T;
     /**
      * Find the object with the shortest linear distance from the given position.
      * @param objects An array of RoomPositions or objects with a RoomPosition.
@@ -2392,9 +2392,6 @@ interface Room {
      * @returns An array with the objects found.
      */
     find<T extends FindTypes[K], K extends FindConstant = K>(type: K, opts?: FilterOptions<K>): T[];
-    /**
-     * Typing in this way is depracted. find(FIND_CONSTANT) will now return correctly typed output
-     */
     /**
      * Find the exit direction en route to another room.
      * @param room Another room name or room object.

--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -1304,6 +1304,10 @@ declare type FIND_MY_CONSTRUCTION_SITES = 114;
 declare type FIND_HOSTILE_CONSTRUCTION_SITES = 115;
 declare type FIND_MINERALS = 116;
 declare type FIND_NUKES = 117;
+declare type FilterOptions<T extends FindConstant> = string | FilterFunction<T> | {
+    filter: FilterFunction<T>;
+};
+declare type FilterFunction<T extends FindConstant> = (object: FindTypes[T]) => boolean;
 declare type BodyPartConstant = MOVE | WORK | CARRY | ATTACK | RANGED_ATTACK | TOUGH | HEAL | CLAIM;
 declare type MOVE = "move";
 declare type WORK = "work";
@@ -2387,15 +2391,10 @@ interface Room {
      * @param opts An object with additional options
      * @returns An array with the objects found.
      */
-    find<T extends FindConstant>(type: T, opts?: {
-        filter: Object | Function | string;
-    }): Array<FindTypes[T]>;
+    find<T extends FindTypes[K], K extends FindConstant = K>(type: K, opts?: FilterOptions<K>): T[];
     /**
      * Typing in this way is depracted. find(FIND_CONSTANT) will now return correctly typed output
      */
-    find<T>(type: FindConstant, opts?: {
-        filter: Object | Function | string;
-    }): T[];
     /**
      * Find the exit direction en route to another room.
      * @param room Another room name or room object.

--- a/src/literals.ts
+++ b/src/literals.ts
@@ -119,6 +119,10 @@ type FIND_HOSTILE_CONSTRUCTION_SITES = 115;
 type FIND_MINERALS = 116;
 type FIND_NUKES = 117;
 
+type FilterOptions<T extends FindConstant> = string | FilterFunction<T> | { filter: FilterFunction<T> };
+
+type FilterFunction<T extends FindConstant> = (object: FindTypes[T]) => boolean;
+
 ////////
 // Body Part Constants
 

--- a/src/room-position.ts
+++ b/src/room-position.ts
@@ -34,7 +34,7 @@ interface RoomPosition {
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      * @returns An instance of a RoomObject.
      */
-    findClosestByPath<T extends FindConstant>(type: T, opts?: FindPathOpts & {filter?: any | string, algorithm?: string}): FindTypes[T];
+    findClosestByPath<T extends FindTypes[K], K extends FindConstant = K>(type: K, opts?: FindPathOpts & { filter?: FilterFunction<K>, algorithm?: string }): T;
     /**
      * Find the object with the shortest path from the given position. Uses A* search algorithm and Dijkstra's algorithm.
      * @param objects An array of RoomPositions or objects with a RoomPosition
@@ -47,7 +47,7 @@ interface RoomPosition {
      * @param type Any of the FIND_* constants.
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      */
-    findClosestByRange<T extends FindConstant>(type: T, opts?: {filter: any | string}): FindTypes[T];
+    findClosestByRange<T extends FindTypes[K], K extends FindConstant = K>(type: K, opts?: {filter: FilterFunction<K>}): T;
     /**
      * Find the object with the shortest linear distance from the given position.
      * @param objects An array of RoomPositions or objects with a RoomPosition.

--- a/src/room.ts
+++ b/src/room.ts
@@ -78,11 +78,11 @@ interface Room {
      * @param opts An object with additional options
      * @returns An array with the objects found.
      */
-    find<T extends FindConstant>(type: T, opts?: { filter: Object | Function | string }): Array<FindTypes[T]>;
+    find<T extends FindTypes[K], K extends FindConstant = K>(type: K, opts?: FilterOptions<K>): T[];
     /**
      * Typing in this way is depracted. find(FIND_CONSTANT) will now return correctly typed output
      */
-    find<T>(type: FindConstant, opts?: { filter: Object | Function | string }): T[];
+    // find<T>(type: FindConstant, opts?: { filter: Object | Function | string }): T[];
     /**
      * Find the exit direction en route to another room.
      * @param room Another room name or room object.

--- a/src/room.ts
+++ b/src/room.ts
@@ -80,10 +80,6 @@ interface Room {
      */
     find<T extends FindTypes[K], K extends FindConstant = K>(type: K, opts?: FilterOptions<K>): T[];
     /**
-     * Typing in this way is depracted. find(FIND_CONSTANT) will now return correctly typed output
-     */
-    // find<T>(type: FindConstant, opts?: { filter: Object | Function | string }): T[];
-    /**
      * Find the exit direction en route to another room.
      * @param room Another room name or room object.
      * @returns The room direction constant, one of the following: FIND_EXIT_TOP, FIND_EXIT_RIGHT, FIND_EXIT_BOTTOM, FIND_EXIT_LEFT

--- a/test/typed-screeps-tests.ts
+++ b/test/typed-screeps-tests.ts
@@ -267,6 +267,13 @@ interface CreepMemory {
 
     const creepsHere = room.lookForAt(LOOK_CREEPS, 10, 10);
     creepsHere[0].getActiveBodyparts(ATTACK);
+
+    const towers = room.find<StructureTower>(FIND_MY_STRUCTURES, {
+      filter: (structure) => {
+        return (structure.structureType === STRUCTURE_TOWER);
+      }
+    });
+    towers[0].attack(creeps[0]);
 }
 
 ////////

--- a/test/typed-screeps-tests.ts
+++ b/test/typed-screeps-tests.ts
@@ -285,6 +285,22 @@ interface CreepMemory {
 
     creep.say(hostileCreep.name);
 
+    const tower = creep.pos.findClosestByPath<StructureTower>(FIND_HOSTILE_STRUCTURES, {
+      filter: (structure) => {
+        return structure.structureType === STRUCTURE_TOWER;
+      }
+    });
+
+    tower.attack(creep);
+
+    const rampart = creep.pos.findClosestByRange<StructureRampart>(FIND_HOSTILE_STRUCTURES, {
+      filter: (structure) => {
+        return structure.structureType === STRUCTURE_RAMPART;
+      }
+    });
+
+    rampart.isPublic;
+
     // Should have type Creep[]
     const hostileCreeps = creep.pos.findInRange(FIND_HOSTILE_CREEPS, 10);
     hostileCreeps[0].saying;


### PR DESCRIPTION
This fixes a bug with setting the type on find functions.

```ts
room.find<StructureTower>(FIND_MY_STRUCTURES, {
  filter: (structure) => structure.structureType === STRUCTURE_TOWER
})
```

Will now work.

I also added a type so that the filter function is passed the right type.

I need to go through the edits in my first PR and make sure this will all work.