### PR TITLE
Overload the find functions so you can type the output.

### DIFF
--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -1994,8 +1994,12 @@ interface RoomPosition {
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      * @returns An instance of a RoomObject.
      */
-    findClosestByPath<T extends FindTypes[K], K extends FindConstant = K>(type: K, opts?: FindPathOpts & {
+    findClosestByPath<K extends FindConstant>(type: K, opts?: FindPathOpts & {
         filter?: FilterFunction<K>;
+        algorithm?: string;
+    }): FindTypes[K];
+    findClosestByPath<T extends Structure>(type: FIND_STRUCTURES | FIND_MY_STRUCTURES | FIND_HOSTILE_STRUCTURES, opts?: FindPathOpts & {
+        filter?: FilterFunction<FIND_STRUCTURES>;
         algorithm?: string;
     }): T;
     /**
@@ -2013,8 +2017,11 @@ interface RoomPosition {
      * @param type Any of the FIND_* constants.
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      */
-    findClosestByRange<T extends FindTypes[K], K extends FindConstant = K>(type: K, opts?: {
+    findClosestByRange<K extends FindConstant>(type: K, opts?: {
         filter: FilterFunction<K>;
+    }): FindTypes[K];
+    findClosestByRange<T extends Structure>(type: FIND_STRUCTURES | FIND_MY_STRUCTURES | FIND_HOSTILE_STRUCTURES, opts?: {
+        filter: FilterFunction<FIND_STRUCTURES>;
     }): T;
     /**
      * Find the object with the shortest linear distance from the given position.
@@ -2030,9 +2037,12 @@ interface RoomPosition {
      * @param range The range distance.
      * @param opts See Room.find.
      */
-    findInRange<T extends FindConstant>(type: T, range: number, opts?: {
+    findInRange<K extends FindConstant>(type: K, range: number, opts?: {
         filter: any | string;
-    }): Array<FindTypes[T]>;
+    }): Array<FindTypes[K]>;
+    findInRange<T extends Structure>(type: FIND_STRUCTURES | FIND_MY_STRUCTURES | FIND_HOSTILE_STRUCTURES, range: number, opts?: {
+        filter: FilterFunction<FIND_STRUCTURES>;
+    }): T[];
     /**
      * Find all objects in the specified linear range.
      * @param objects An array of room's objects or RoomPosition objects that the search should be executed against.
@@ -2394,7 +2404,8 @@ interface Room {
      * @param opts An object with additional options
      * @returns An array with the objects found.
      */
-    find<T extends FindTypes[K], K extends FindConstant = K>(type: K, opts?: FilterOptions<K>): T[];
+    find<K extends FindConstant>(type: K, opts?: FilterOptions<K>): Array<FindTypes[K]>;
+    find<T extends Structure>(type: FIND_STRUCTURES | FIND_MY_STRUCTURES | FIND_HOSTILE_STRUCTURES, opts?: FilterOptions<FIND_STRUCTURES>): T[];
     /**
      * Find the exit direction en route to another room.
      * @param room Another room name or room object.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,6 @@
   "name": "typed-screeps",
   "version": "1.0.4",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "ansi-regex": {
       "version": "2.1.1",
@@ -20,12 +19,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      }
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -37,11 +31,7 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
-      "requires": {
-        "balanced-match": "1.0.0",
-        "concat-map": "0.0.1"
-      }
+      "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -53,14 +43,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
-      }
+      "dev": true
     },
     "ci-info": {
       "version": "1.1.1",
@@ -72,10 +55,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.3"
-      }
+      "dev": true
     },
     "color-name": {
       "version": "1.1.3",
@@ -129,24 +109,13 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
+      "dev": true
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
+      "dev": true
     },
     "has-flag": {
       "version": "2.0.0",
@@ -158,23 +127,13 @@
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/husky/-/husky-0.13.4.tgz",
       "integrity": "sha1-SHhcUCjeNFKlHEjBLE+UshJKFAc=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "find-parent-dir": "0.3.0",
-        "is-ci": "1.0.10",
-        "normalize-path": "1.0.0"
-      }
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
+      "dev": true
     },
     "inherits": {
       "version": "2.0.3",
@@ -186,10 +145,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
-      "dev": true,
-      "requires": {
-        "ci-info": "1.1.1"
-      }
+      "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -201,10 +157,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "1.1.8"
-      }
+      "dev": true
     },
     "normalize-path": {
       "version": "1.0.0",
@@ -216,10 +169,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "1.0.2"
-      }
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -243,10 +193,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
-      "dev": true,
-      "requires": {
-        "path-parse": "1.0.5"
-      }
+      "dev": true
     },
     "rimraf": {
       "version": "2.6.2",
@@ -267,10 +214,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
+      "dev": true
     },
     "supports-color": {
       "version": "2.0.0",
@@ -289,48 +233,24 @@
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.8.0.tgz",
       "integrity": "sha1-H0mtWy53x2w69N3K5VKuTjYS6xM=",
       "dev": true,
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "builtin-modules": "1.1.1",
-        "chalk": "2.3.0",
-        "commander": "2.11.0",
-        "diff": "3.4.0",
-        "glob": "7.1.2",
-        "minimatch": "3.0.4",
-        "resolve": "1.5.0",
-        "semver": "5.4.1",
-        "tslib": "1.8.0",
-        "tsutils": "2.12.2"
-      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
+          "dev": true
         },
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
+          "dev": true
         },
         "supports-color": {
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -338,10 +258,7 @@
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.12.2.tgz",
       "integrity": "sha1-rVikhl0X7D3bZjG2ylO+FKVlb/M=",
-      "dev": true,
-      "requires": {
-        "tslib": "1.8.0"
-      }
+      "dev": true
     },
     "typescript": {
       "version": "2.6.1",

--- a/src/room-position.ts
+++ b/src/room-position.ts
@@ -34,7 +34,8 @@ interface RoomPosition {
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      * @returns An instance of a RoomObject.
      */
-    findClosestByPath<T extends FindTypes[K], K extends FindConstant = K>(type: K, opts?: FindPathOpts & { filter?: FilterFunction<K>, algorithm?: string }): T;
+    findClosestByPath<K extends FindConstant>(type: K, opts?: FindPathOpts & { filter?: FilterFunction<K>, algorithm?: string }): FindTypes[K];
+    findClosestByPath<T extends Structure>(type: FIND_STRUCTURES | FIND_MY_STRUCTURES | FIND_HOSTILE_STRUCTURES, opts?: FindPathOpts & { filter?: FilterFunction<FIND_STRUCTURES>, algorithm?: string}): T;
     /**
      * Find the object with the shortest path from the given position. Uses A* search algorithm and Dijkstra's algorithm.
      * @param objects An array of RoomPositions or objects with a RoomPosition
@@ -47,7 +48,8 @@ interface RoomPosition {
      * @param type Any of the FIND_* constants.
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      */
-    findClosestByRange<T extends FindTypes[K], K extends FindConstant = K>(type: K, opts?: {filter: FilterFunction<K>}): T;
+    findClosestByRange<K extends FindConstant>(type: K, opts?: {filter: FilterFunction<K>}): FindTypes[K];
+    findClosestByRange<T extends Structure>(type: FIND_STRUCTURES | FIND_MY_STRUCTURES | FIND_HOSTILE_STRUCTURES, opts?: {filter: FilterFunction<FIND_STRUCTURES>}): T;
     /**
      * Find the object with the shortest linear distance from the given position.
      * @param objects An array of RoomPositions or objects with a RoomPosition.
@@ -60,7 +62,8 @@ interface RoomPosition {
      * @param range The range distance.
      * @param opts See Room.find.
      */
-    findInRange<T extends FindConstant>(type: T, range: number, opts?: {filter: any| string}): Array<FindTypes[T]>;
+    findInRange<K extends FindConstant>(type: K, range: number, opts?: {filter: any| string}): Array<FindTypes[K]>;
+    findInRange<T extends Structure>(type: FIND_STRUCTURES | FIND_MY_STRUCTURES | FIND_HOSTILE_STRUCTURES, range: number, opts?: {filter: FilterFunction<FIND_STRUCTURES>} ): T[];
     /**
      * Find all objects in the specified linear range.
      * @param objects An array of room's objects or RoomPosition objects that the search should be executed against.

--- a/src/room.ts
+++ b/src/room.ts
@@ -78,7 +78,8 @@ interface Room {
      * @param opts An object with additional options
      * @returns An array with the objects found.
      */
-    find<T extends FindTypes[K], K extends FindConstant = K>(type: K, opts?: FilterOptions<K>): T[];
+    find<K extends FindConstant>(type: K, opts?: FilterOptions<K>): Array<FindTypes[K]>;
+    find<T extends Structure>(type: FIND_STRUCTURES | FIND_MY_STRUCTURES | FIND_HOSTILE_STRUCTURES, opts?: FilterOptions<FIND_STRUCTURES>): T[];
     /**
      * Find the exit direction en route to another room.
      * @param room Another room name or room object.

--- a/test/typed-screeps-tests.ts
+++ b/test/typed-screeps-tests.ts
@@ -261,10 +261,6 @@ interface CreepMemory {
     // Should have type (_HasRoomPosition | RoomPosition)[]
     const exits = room.find(FIND_EXIT);
 
-    // Should support the old way
-    const myCreeps = room.find<Creep>(FIND_MY_CREEPS);
-    myCreeps[0].drop(resources[0].resourceType);
-
     const creepsHere = room.lookForAt(LOOK_CREEPS, 10, 10);
     creepsHere[0].getActiveBodyparts(ATTACK);
 
@@ -304,6 +300,14 @@ interface CreepMemory {
     // Should have type Creep[]
     const hostileCreeps = creep.pos.findInRange(FIND_HOSTILE_CREEPS, 10);
     hostileCreeps[0].saying;
+
+    const labs = creep.pos.findInRange<StructureLab>(FIND_MY_STRUCTURES, 4, {
+      filter: (structure) => {
+        return structure.structureType === STRUCTURE_LAB;
+      }
+    });
+
+    labs[0].boostCreep(creep);
 }
 
 ////////


### PR DESCRIPTION
As I have discussed on slack find<Foo> is broken at the moment.

I was thinking about the output of `filter` in the finds and not everything needs an overload.

After filtering the output of
 - Exits
 - Creeps
 - Source
 - Flags
 - ConstructionSites
 - Nukes

Is all the same as the generic type so I see no need to overload it with typesetting.

 - Resource
 - Mineral

Can be typed only in typed screeps so I'm not sure if these need an overload. 

Structures are the only real place where the output of the filtered function needs to be typed. I've fixed that issue in this commit.