### PR TITLE
Improve structure types

### DIFF
--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -3175,3 +3175,11 @@ interface StructurePortal extends Structure<STRUCTURE_PORTAL> {
 interface StructurePortalConstructor extends _Constructor<StructurePortal>, _ConstructorById<StructurePortal> {
 }
 declare const StructurePortal: StructurePortalConstructor;
+/**
+ * A discriminated union on Structure.type of all owned structure types
+ */
+declare type AnyOwnedStructure = StructureController | StructureExtension | StructureExtractor | StructureKeeperLair | StructureLab | StructureLink | StructureNuker | StructureObserver | StructurePowerSpawn | StructureRampart | StructureSpawn | StructureStorage | StructureTerminal | StructureTower;
+/**
+ * A discriminated union on Structure.type of all structure types
+ */
+declare type AnyStructure = AnyOwnedStructure | StructureContainer | StructurePortal | StructurePowerBank | StructureRoad | StructureWall;

--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -1135,9 +1135,9 @@ interface FindTypes {
     105: Source;
     "-106": Resource<RESOURCE_ENERGY>;
     106: Resource;
-    107: Structure;
-    108: Structure;
-    109: Structure;
+    107: AnyStructure;
+    108: AnyOwnedStructure;
+    109: AnyOwnedStructure;
     110: Flag;
     111: ConstructionSite;
     112: StructureSpawn;

--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -684,7 +684,7 @@ interface Creep extends RoomObject {
      *
      * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART
      */
-    attackController(target: Controller): CreepActionReturnCode;
+    attackController(target: StructureController): CreepActionReturnCode;
     /**
      * Build a structure at the target construction site using carried energy.
      * Needs WORK and CARRY body parts.
@@ -706,7 +706,7 @@ interface Creep extends RoomObject {
      * @param target The target controller object.
      * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_FULL, ERR_NOT_IN_RANGE, ERR_NO_BODYPART, ERR_GCL_NOT_ENOUGH
      */
-    claimController(target: Controller): CreepActionReturnCode | ERR_FULL | ERR_RCL_NOT_ENOUGH;
+    claimController(target: StructureController): CreepActionReturnCode | ERR_FULL | ERR_RCL_NOT_ENOUGH;
     /**
      * Dismantles any (even hostile) structure returning 50% of the energy spent on its repair. Requires the WORK body part. If the creep has an empty CARRY body part, the energy is put into it; otherwise it is dropped on the ground. The target has to be at adjacent square to the creep.
      * @param target The target structure.
@@ -723,7 +723,7 @@ interface Creep extends RoomObject {
      * @param target The target room controller.
      * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_NOT_ENOUGH_RESOURCES, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE
      */
-    generateSafeMode(target: Controller): CreepActionReturnCode;
+    generateSafeMode(target: StructureController): CreepActionReturnCode;
     /**
      * Get the quantity of live body parts of the given type. Fully damaged parts do not count.
      * @param type A body part type, one of the following body part constants: MOVE, WORK, CARRY, ATTACK, RANGED_ATTACK, HEAL, TOUGH, CLAIM
@@ -798,7 +798,7 @@ interface Creep extends RoomObject {
      * @param target The target controller object to be reserved.
      * @return Result code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART
      */
-    reserveController(target: Controller): CreepActionReturnCode;
+    reserveController(target: StructureController): CreepActionReturnCode;
     /**
      * Display a visual speech balloon above the creep with the specified message. The message will disappear after a few seconds. Useful for debugging purposes. Only the creep's owner can see the speech message.
      * @param message The message to be displayed. Maximum length is 10 characters.
@@ -812,7 +812,7 @@ interface Creep extends RoomObject {
      * @param text The sign text. The maximum text length is 100 characters.
      * @returns Result Code: OK, ERR_BUSY, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE
      */
-    signController(target: Controller, text: string): OK | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE;
+    signController(target: StructureController, text: string): OK | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE;
     /**
      * Kill the creep immediately.
      */
@@ -828,7 +828,7 @@ interface Creep extends RoomObject {
      * Upgrade your controller to the next level using carried energy. Upgrading controllers raises your Global Control Level in parallel. Needs WORK and CARRY body parts. The target has to be at adjacent square to the creep. A fully upgraded level 8 controller can't be upgraded with the power over 15 energy units per tick regardless of creeps power. The cumulative effect of all the creeps performing upgradeController in the current tick is taken into account.
      * @param target The target controller object to be upgraded.
      */
-    upgradeController(target: Controller): ScreepsReturnCode;
+    upgradeController(target: StructureController): ScreepsReturnCode;
     /**
      * Withdraw resources from a structure. The target has to be at adjacent square to the creep. Multiple creeps can withdraw from the same structure in the same tick. Your creeps can withdraw resources from hostile structures as well, in case if there is no hostile rampart on top of it.
      * @param target The target object.
@@ -943,7 +943,7 @@ interface Game {
      * A hash containing all your spawns with spawn names as hash keys.
      */
     spawns: {
-        [spawnName: string]: Spawn;
+        [spawnName: string]: StructureSpawn;
     };
     /**
      * A hash containing all your structures with structure id as hash keys.
@@ -2331,7 +2331,7 @@ interface Room {
     /**
      * The Controller structure of this room, if present, otherwise undefined.
      */
-    controller?: Controller;
+    controller?: StructureController;
     /**
      * Total amount of energy available in all spawns and extensions in the room.
      */
@@ -2359,7 +2359,7 @@ interface Room {
     /**
      * The Terminal structure of this room, if present, otherwise undefined.
      */
-    terminal?: Terminal;
+    terminal?: StructureTerminal;
     /**
      * A RoomVisual object for this room. You can use this object to draw simple shapes (lines, circles, text labels) in the room.
      */
@@ -2656,19 +2656,6 @@ interface StructureSpawnConstructor extends _Constructor<StructureSpawn>, _Const
 }
 declare const StructureSpawn: StructureSpawnConstructor;
 declare const Spawn: StructureSpawnConstructor;
-declare type Controller = StructureController;
-declare type Extension = StructureExtension;
-declare type KeeperLair = StructureKeeperLair;
-declare type Lab = StructureLab;
-declare type Link = StructureLink;
-declare type Observer = StructureObserver;
-declare type PowerBank = StructurePowerBank;
-declare type PowerSpawn = StructurePowerSpawn;
-declare type Rampart = StructureRampart;
-declare type Terminal = StructureTerminal;
-declare type Container = StructureContainer;
-declare type Tower = StructureTower;
-declare type Spawn = StructureSpawn;
 /**
  * Parent object for structure classes
  */
@@ -2973,8 +2960,6 @@ interface StructureStorage extends OwnedStructure<STRUCTURE_STORAGE> {
     storeCapacity: number;
 }
 interface StructureStorageConstructor extends _Constructor<StructureStorage>, _ConstructorById<StructureStorage> {
-}
-interface Storage extends StructureStorage {
 }
 declare const StructureStorage: StructureStorageConstructor;
 /**

--- a/dist/screeps.d.ts
+++ b/dist/screeps.d.ts
@@ -2656,6 +2656,7 @@ interface StructureSpawnConstructor extends _Constructor<StructureSpawn>, _Const
 }
 declare const StructureSpawn: StructureSpawnConstructor;
 declare const Spawn: StructureSpawnConstructor;
+declare type Spawn = StructureSpawn;
 /**
  * Parent object for structure classes
  */

--- a/src/creep.ts
+++ b/src/creep.ts
@@ -85,7 +85,7 @@ interface Creep extends RoomObject {
      *
      * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART
      */
-    attackController(target: Controller): CreepActionReturnCode;
+    attackController(target: StructureController): CreepActionReturnCode;
     /**
      * Build a structure at the target construction site using carried energy.
      * Needs WORK and CARRY body parts.
@@ -107,7 +107,7 @@ interface Creep extends RoomObject {
      * @param target The target controller object.
      * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_FULL, ERR_NOT_IN_RANGE, ERR_NO_BODYPART, ERR_GCL_NOT_ENOUGH
      */
-    claimController(target: Controller): CreepActionReturnCode | ERR_FULL | ERR_RCL_NOT_ENOUGH;
+    claimController(target: StructureController): CreepActionReturnCode | ERR_FULL | ERR_RCL_NOT_ENOUGH;
     /**
      * Dismantles any (even hostile) structure returning 50% of the energy spent on its repair. Requires the WORK body part. If the creep has an empty CARRY body part, the energy is put into it; otherwise it is dropped on the ground. The target has to be at adjacent square to the creep.
      * @param target The target structure.
@@ -124,7 +124,7 @@ interface Creep extends RoomObject {
      * @param target The target room controller.
      * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_NOT_ENOUGH_RESOURCES, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE
      */
-    generateSafeMode(target: Controller): CreepActionReturnCode;
+    generateSafeMode(target: StructureController): CreepActionReturnCode;
     /**
      * Get the quantity of live body parts of the given type. Fully damaged parts do not count.
      * @param type A body part type, one of the following body part constants: MOVE, WORK, CARRY, ATTACK, RANGED_ATTACK, HEAL, TOUGH, CLAIM
@@ -197,7 +197,7 @@ interface Creep extends RoomObject {
      * @param target The target controller object to be reserved.
      * @return Result code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART
      */
-    reserveController(target: Controller): CreepActionReturnCode;
+    reserveController(target: StructureController): CreepActionReturnCode;
     /**
      * Display a visual speech balloon above the creep with the specified message. The message will disappear after a few seconds. Useful for debugging purposes. Only the creep's owner can see the speech message.
      * @param message The message to be displayed. Maximum length is 10 characters.
@@ -211,7 +211,7 @@ interface Creep extends RoomObject {
      * @param text The sign text. The maximum text length is 100 characters.
      * @returns Result Code: OK, ERR_BUSY, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE
      */
-    signController(target: Controller, text: string): OK | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE;
+    signController(target: StructureController, text: string): OK | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE;
     /**
      * Kill the creep immediately.
      */
@@ -227,7 +227,7 @@ interface Creep extends RoomObject {
      * Upgrade your controller to the next level using carried energy. Upgrading controllers raises your Global Control Level in parallel. Needs WORK and CARRY body parts. The target has to be at adjacent square to the creep. A fully upgraded level 8 controller can't be upgraded with the power over 15 energy units per tick regardless of creeps power. The cumulative effect of all the creeps performing upgradeController in the current tick is taken into account.
      * @param target The target controller object to be upgraded.
      */
-    upgradeController(target: Controller): ScreepsReturnCode;
+    upgradeController(target: StructureController): ScreepsReturnCode;
     /**
      * Withdraw resources from a structure. The target has to be at adjacent square to the creep. Multiple creeps can withdraw from the same structure in the same tick. Your creeps can withdraw resources from hostile structures as well, in case if there is no hostile rampart on top of it.
      * @param target The target object.

--- a/src/game.ts
+++ b/src/game.ts
@@ -38,7 +38,7 @@ interface Game {
     /**
      * A hash containing all your spawns with spawn names as hash keys.
      */
-    spawns: {[spawnName: string]: Spawn};
+    spawns: {[spawnName: string]: StructureSpawn};
     /**
      * A hash containing all your structures with structure id as hash keys.
      */

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -163,9 +163,9 @@ interface FindTypes {
   105: Source; // FIND_SOURCES
   "-106": Resource<RESOURCE_ENERGY>; // FIND_DROPPED_ENERGY
   106: Resource; // FIND_DROPPED_RESOURCES
-  107: Structure; // FIND_STRUCTURES
-  108: Structure; // FIND_MY_STRUCTURES
-  109: Structure; // FIND_HOSTILE_STRUCTURES
+  107: AnyStructure; // FIND_STRUCTURES
+  108: AnyOwnedStructure; // FIND_MY_STRUCTURES
+  109: AnyOwnedStructure; // FIND_HOSTILE_STRUCTURES
   110: Flag; // FIND_FLAGS
   111: ConstructionSite; // FIND_CONSTRUCTION_SITES
   112: StructureSpawn; // FIND_MY_SPAWNS

--- a/src/room.ts
+++ b/src/room.ts
@@ -7,7 +7,7 @@ interface Room {
     /**
      * The Controller structure of this room, if present, otherwise undefined.
      */
-    controller?: Controller;
+    controller?: StructureController;
     /**
      * Total amount of energy available in all spawns and extensions in the room.
      */
@@ -35,7 +35,7 @@ interface Room {
     /**
      * The Terminal structure of this room, if present, otherwise undefined.
      */
-    terminal?: Terminal;
+    terminal?: StructureTerminal;
     /**
      * A RoomVisual object for this room. You can use this object to draw simple shapes (lines, circles, text labels) in the room.
      */

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -113,3 +113,4 @@ interface StructureSpawnConstructor extends _Constructor<StructureSpawn>, _Const
 
 declare const StructureSpawn: StructureSpawnConstructor;
 declare const Spawn: StructureSpawnConstructor; // legacy alias
+declare type Spawn = StructureSpawn;

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -1,21 +1,4 @@
 ////////
-// Structure Types
-
-declare type Controller = StructureController;
-declare type Extension = StructureExtension;
-declare type KeeperLair = StructureKeeperLair;
-declare type Lab = StructureLab;
-declare type Link = StructureLink;
-declare type Observer = StructureObserver;
-declare type PowerBank = StructurePowerBank;
-declare type PowerSpawn = StructurePowerSpawn;
-declare type Rampart = StructureRampart;
-declare type Terminal = StructureTerminal;
-declare type Container = StructureContainer;
-declare type Tower = StructureTower;
-declare type Spawn = StructureSpawn; // Legacy Alias
-
-////////
 // Structures
 
 /**
@@ -372,9 +355,6 @@ interface StructureStorage extends OwnedStructure<STRUCTURE_STORAGE> {
 
 interface StructureStorageConstructor extends _Constructor<StructureStorage>, _ConstructorById<StructureStorage> {
 }
-
-// legacy alias
-interface Storage extends StructureStorage { }
 
 declare const StructureStorage: StructureStorageConstructor;
 

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -596,3 +596,13 @@ interface StructurePortalConstructor extends _Constructor<StructurePortal>, _Con
 }
 
 declare const StructurePortal: StructurePortalConstructor;
+
+/**
+ * A discriminated union on Structure.type of all owned structure types
+ */
+declare type AnyOwnedStructure = StructureController | StructureExtension | StructureExtractor | StructureKeeperLair | StructureLab | StructureLink | StructureNuker | StructureObserver | StructurePowerSpawn | StructureRampart | StructureSpawn | StructureStorage | StructureTerminal | StructureTower;
+
+/**
+ * A discriminated union on Structure.type of all structure types
+ */
+declare type AnyStructure = AnyOwnedStructure | StructureContainer | StructurePortal | StructurePowerBank | StructureRoad | StructureWall;

--- a/test/typed-screeps-tests.ts
+++ b/test/typed-screeps-tests.ts
@@ -517,4 +517,9 @@ interface CreepMemory {
     } else if (unowned.structureType === STRUCTURE_WALL || unowned.structureType === STRUCTURE_RAMPART) {
         const wallHp = unowned.hits / unowned.hitsMax;
     }
+
+    // test discriminated union using filter functions on find
+    const from = Game.rooms.myRoom.find(FIND_STRUCTURES, s => (s.structureType === STRUCTURE_CONTAINER || s.structureType === STRUCTURE_STORAGE) && s.store.energy > 0)[0];
+    const to = from.pos.findClosestByPath(FIND_MY_STRUCTURES, {filter: s => (s.structureType === STRUCTURE_SPAWN || s.structureType === STRUCTURE_EXTENSION) && s.energy < s.energyCapacity});
+
 }

--- a/test/typed-screeps-tests.ts
+++ b/test/typed-screeps-tests.ts
@@ -519,7 +519,8 @@ interface CreepMemory {
     }
 
     // test discriminated union using filter functions on find
-    const from = Game.rooms.myRoom.find(FIND_STRUCTURES, s => (s.structureType === STRUCTURE_CONTAINER || s.structureType === STRUCTURE_STORAGE) && s.store.energy > 0)[0];
-    const to = from.pos.findClosestByPath(FIND_MY_STRUCTURES, {filter: s => (s.structureType === STRUCTURE_SPAWN || s.structureType === STRUCTURE_EXTENSION) && s.energy < s.energyCapacity});
+    const from = Game.rooms.myRoom.find(FIND_STRUCTURES, (s) => (s.structureType === STRUCTURE_CONTAINER || s.structureType === STRUCTURE_STORAGE) && s.store.energy > 0)[0];
+    const to = from.pos.findClosestByPath(FIND_MY_STRUCTURES, {filter: (s) => (s.structureType === STRUCTURE_SPAWN || s.structureType === STRUCTURE_EXTENSION) && s.energy < s.energyCapacity});
 
+    Game.rooms.myRoom.find(FIND_MY_STRUCTURES, (s) => s.structureType === STRUCTURE_RAMPART).forEach((r) => r.notifyWhenAttacked(false));
 }

--- a/test/typed-screeps-tests.ts
+++ b/test/typed-screeps-tests.ts
@@ -498,3 +498,23 @@ interface CreepMemory {
     creeps[0].y;
     creeps[0].creep.move(TOP);
 }
+
+////////
+// Advanced Structure types
+{
+    const owned = Game.getObjectById<AnyOwnedStructure>("blah");
+    const owner = owned.owner.username;
+    owned.notifyWhenAttacked(false);
+
+    const unowned = Game.getObjectById<AnyStructure>("blah2");
+    const hp = unowned.hits / unowned.hitsMax;
+
+    // test discriminated union
+    if (unowned.structureType === STRUCTURE_TOWER) {
+        unowned.heal(Game.creeps.myCreep);
+    } else if (unowned.structureType === STRUCTURE_CONTAINER || unowned.structureType === STRUCTURE_STORAGE || unowned.structureType === STRUCTURE_TERMINAL) {
+        const energyPercent = unowned.store.energy / unowned.storeCapacity;
+    } else if (unowned.structureType === STRUCTURE_WALL || unowned.structureType === STRUCTURE_RAMPART) {
+        const wallHp = unowned.hits / unowned.hitsMax;
+    }
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

This PR adds discriminated unions for `AnyStructure` and `AnyOwnedStructure`, and uses them instead of `Structure` in `FindTypes`. This means that you can then use filters like `s => s.structureType === STRUCTURE_TOWER && s.energy < s.energyCapacity`. It also adds tests for cases like these.

This fixes [this issue](https://github.com/screepers/typed-screeps/issues/22#issuecomment-347610104).

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
