### PR TITLE
Reduce package size when installing via npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,6 @@
   "name": "typed-screeps",
   "version": "2.0.0",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "ansi-regex": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,16 @@
   "description": "Stronger TypeScript declarations for the game Screeps.",
   "repository": "screepers/typed-screeps",
   "types": "./dist/screeps.d.ts",
+  "files": [
+    "dist/screeps.d.ts"
+  ],
   "scripts": {
     "compile": "tsc",
     "compile-test": "tsc test/typed-screeps-tests.ts",
     "lint": "tslint 'src/**/*.ts'",
     "lint-test": "tslint 'test/**/*.ts'",
     "postcompile": "rimraf ./dist/screeps.js && node ./build/prependHeader.js",
+    "prepare": "npm test",
     "precommit": "npm run compile && git add dist/screeps.d.ts",
     "precompile": "rimraf dist",
     "test": "npm run compile && npm run lint && npm run lint-test && npm run compile-test"


### PR DESCRIPTION
### Brief Description

This reduces the package size by only including the necessary file `dist/screeps.d.ts` when installing the package via npm.

### Checklists

- [x] Test passed
- [x] Coding style (indentation, etc)
