### PR TITLE
Allow controller sign to be undefined

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3259,7 +3259,7 @@ interface StructureController extends OwnedStructure<STRUCTURE_CONTROLLER> {
     /**
      * An object with the controller reservation info if present: username, ticksToEnd
      */
-    reservation: ReservationDefinition;
+    reservation: ReservationDefinition | undefined;
     /**
      * How many ticks of safe mode are remaining, or undefined.
      */

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3275,7 +3275,7 @@ interface StructureController extends OwnedStructure<STRUCTURE_CONTROLLER> {
     /**
      * An object with the controller sign info if present
      */
-    sign: SignDefinition;
+    sign: SignDefinition | undefined;
     /**
      * The amount of game ticks when this controller will lose one level. This timer can be reset by using Creep.upgradeController.
      */

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -94,7 +94,7 @@ interface StructureController extends OwnedStructure<STRUCTURE_CONTROLLER> {
     /**
      * An object with the controller reservation info if present: username, ticksToEnd
      */
-    reservation: ReservationDefinition;
+    reservation: ReservationDefinition | undefined;
     /**
      * How many ticks of safe mode are remaining, or undefined.
      */

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -110,7 +110,7 @@ interface StructureController extends OwnedStructure<STRUCTURE_CONTROLLER> {
     /**
      * An object with the controller sign info if present
      */
-    sign: SignDefinition;
+    sign: SignDefinition | undefined;
     /**
      * The amount of game ticks when this controller will lose one level. This timer can be reset by using Creep.upgradeController.
      */


### PR DESCRIPTION
### Brief Description

`StructureContoller.sign` can be undefined if the controller has not been signed before. This PR allows `sign` to be undefined as well.

### Checklists

- [x] Test passed
- [x] Coding style (indentation, etc)
