### PR TITLE
Allow `Game` interface to be extended

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1110,7 +1110,7 @@ interface Game {
     notify(message: string, groupInterval?: number): undefined;
 }
 
-declare const Game: Game;
+declare let Game: Game;
 interface _HasRoomPosition {
     pos: RoomPosition;
 }

--- a/src/game.ts
+++ b/src/game.ts
@@ -78,4 +78,4 @@ interface Game {
     notify(message: string, groupInterval?: number): undefined;
 }
 
-declare const Game: Game;
+declare let Game: Game;


### PR DESCRIPTION
Fixes #26.

<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

This changes `declare const Game: Game` to `declare let Game: Game` to allow the `Game` interface to be typed.

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
