### PR TITLE
typed screeps version in template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -18,3 +18,4 @@
 
 - Node.js version: {Please write here}
 - TypeScript version: {Please write here}
+- {`typed-screeps` or `@types/screeps` delete as appropriate} version: {Please write here}


### PR DESCRIPTION
### Brief Description

Seeing as the `typed-screeps` version is rather important to debugging it should be in the issue template.

### Checklists

- [x] Test passed
- [x] Coding style (indentation, etc)
