### PR TITLE
PowerBanks are owned by "Power Bank"

### DIFF
--- a/src/structure.ts
+++ b/src/structure.ts
@@ -615,6 +615,7 @@ type AnyOwnedStructure =
     StructureLink |
     StructureNuker |
     StructureObserver |
+    StructurePowerBank |
     StructurePowerSpawn |
     StructureRampart |
     StructureSpawn |
@@ -629,6 +630,5 @@ type AnyStructure =
     AnyOwnedStructure |
     StructureContainer |
     StructurePortal |
-    StructurePowerBank |
     StructureRoad |
     StructureWall;


### PR DESCRIPTION
### Brief Description

PowerBanks are considered to be owned structures (and are owned by "Power Bank");

### Checklists

- [ ] Test passed
- [ ] Coding style (indentation, etc)
