### PR TITLE
Update lineStyle to allow "solid" value

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2741,7 +2741,7 @@ interface LineStyle {
     /**
      * Either undefined (solid line), dashed, or dotted.Default is undefined.
      */
-    lineStyle?: "dashed" | "dotted";
+    lineStyle?: "dashed" | "dotted" | "solid";
 }
 
 interface PolyStyle {
@@ -2764,7 +2764,7 @@ interface PolyStyle {
     /**
      * Either undefined (solid line), dashed, or dotted.Default is undefined.
      */
-    lineStyle?: "dashed" | "dotted";
+    lineStyle?: "dashed" | "dotted" | "solid";
 }
 
 interface CircleStyle extends PolyStyle {

--- a/src/room-visual.ts
+++ b/src/room-visual.ts
@@ -124,7 +124,7 @@ interface LineStyle {
     /**
      * Either undefined (solid line), dashed, or dotted.Default is undefined.
      */
-    lineStyle?: "dashed" | "dotted";
+    lineStyle?: "dashed" | "dotted" | "solid";
 }
 
 interface PolyStyle {
@@ -147,7 +147,7 @@ interface PolyStyle {
     /**
      * Either undefined (solid line), dashed, or dotted.Default is undefined.
      */
-    lineStyle?: "dashed" | "dotted";
+    lineStyle?: "dashed" | "dotted" | "solid";
 }
 
 interface CircleStyle extends PolyStyle {


### PR DESCRIPTION

<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

The Screeps documentation is incorrect. The default line style is "dashed", not "solid". Specifying "solid" explicitly is needed in order to get a solid line. Thus, it should be allowed as a lineStyle.

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
