### PR TITLE
Fix result type of Room.lookAtArea

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1288,22 +1288,24 @@ type LookAtTypes = Partial<AllLookAtTypes>;
 type LookAtResult<K extends LookConstant = LookConstant> = Pick<LookAtTypes, K> & { type: K };
 
 type LookAtResultWithPos<K extends LookConstant = LookConstant> = LookAtResult<K> & {
-  x: number,
-  y: number,
+    x: number,
+    y: number,
 };
 
 interface LookAtResultMatrix<K extends LookConstant = LookConstant> {
-    [coord: number]: LookAtResultMatrix<K> | Array<LookAtResult<K>>;
+    [y: number]: {
+        [x: number]: Array<LookAtResult<K>>;
+    };
 }
 
 interface LookForAtAreaResultMatrix<T, K extends keyof LookAtTypes = keyof LookAtTypes> {
-  [x: number]: {
-    [y: number]: Array<LookForAtAreaResult<T, K>>;
-  };
+    [y: number]: {
+        [x: number]: Array<LookForAtAreaResult<T, K>>;
+    };
 }
 
 type LookForAtAreaResult<T, K extends keyof LookAtTypes = keyof LookAtTypes> = {type: K} & {
-  [P in K]: T;
+    [P in K]: T;
 };
 
 type LookForAtAreaResultWithPos<T, K extends keyof LookAtTypes = keyof LookAtTypes> = LookForAtAreaResult<T, K> & {x: number, y: number};
@@ -2967,7 +2969,17 @@ interface Room {
      * @param asArray Set to true if you want to get the result as a plain array.
      * @returns An object with all the objects in the specified area
      */
-    lookAtArea(top: number, left: number, bottom: number, right: number, asArray?: boolean): LookAtResultMatrix | LookAtResultWithPos[];
+    lookAtArea(top: number, left: number, bottom: number, right: number, asArray?: false): LookAtResultMatrix;
+    /**
+     * Get the list of objects at the specified room area. This method is more CPU efficient in comparison to multiple lookAt calls.
+     * @param top The top Y boundary of the area.
+     * @param left The left X boundary of the area.
+     * @param bottom The bottom Y boundary of the area.
+     * @param right The right X boundary of the area.
+     * @param asArray Set to true if you want to get the result as a plain array.
+     * @returns An object with all the objects in the specified area
+     */
+    lookAtArea(top: number, left: number, bottom: number, right: number, asArray: true): LookAtResultWithPos[];
     /**
      * Get the objects at the given position.
      * @param type One of the LOOK_* constants.

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -475,6 +475,18 @@ interface CreepMemory {
 // LookAt Finds
 
 {
+    const matrix = room.lookAtArea(10, 10, 20, 20, false);
+    for (const y in matrix) {
+        const row = matrix[y];
+        for (const x in row) {
+            const pos = new RoomPosition(+x, +y, room.name);
+            const objects = row[x];
+            if (objects.length > 0) {
+                objects.map((o) => o.type);
+            }
+        }
+    }
+
     const nukes = room.lookForAt(LOOK_NUKES, creep.pos);
 
     nukes[0].launchRoomName;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -157,22 +157,24 @@ type LookAtTypes = Partial<AllLookAtTypes>;
 type LookAtResult<K extends LookConstant = LookConstant> = Pick<LookAtTypes, K> & { type: K };
 
 type LookAtResultWithPos<K extends LookConstant = LookConstant> = LookAtResult<K> & {
-  x: number,
-  y: number,
+    x: number,
+    y: number,
 };
 
 interface LookAtResultMatrix<K extends LookConstant = LookConstant> {
-    [coord: number]: LookAtResultMatrix<K> | Array<LookAtResult<K>>;
+    [y: number]: {
+        [x: number]: Array<LookAtResult<K>>;
+    };
 }
 
 interface LookForAtAreaResultMatrix<T, K extends keyof LookAtTypes = keyof LookAtTypes> {
-  [x: number]: {
-    [y: number]: Array<LookForAtAreaResult<T, K>>;
-  };
+    [y: number]: {
+        [x: number]: Array<LookForAtAreaResult<T, K>>;
+    };
 }
 
 type LookForAtAreaResult<T, K extends keyof LookAtTypes = keyof LookAtTypes> = {type: K} & {
-  [P in K]: T;
+    [P in K]: T;
 };
 
 type LookForAtAreaResultWithPos<T, K extends keyof LookAtTypes = keyof LookAtTypes> = LookForAtAreaResult<T, K> & {x: number, y: number};

--- a/src/room.ts
+++ b/src/room.ts
@@ -155,7 +155,17 @@ interface Room {
      * @param asArray Set to true if you want to get the result as a plain array.
      * @returns An object with all the objects in the specified area
      */
-    lookAtArea(top: number, left: number, bottom: number, right: number, asArray?: boolean): LookAtResultMatrix | LookAtResultWithPos[];
+    lookAtArea(top: number, left: number, bottom: number, right: number, asArray?: false): LookAtResultMatrix;
+    /**
+     * Get the list of objects at the specified room area. This method is more CPU efficient in comparison to multiple lookAt calls.
+     * @param top The top Y boundary of the area.
+     * @param left The left X boundary of the area.
+     * @param bottom The bottom Y boundary of the area.
+     * @param right The right X boundary of the area.
+     * @param asArray Set to true if you want to get the result as a plain array.
+     * @returns An object with all the objects in the specified area
+     */
+    lookAtArea(top: number, left: number, bottom: number, right: number, asArray: true): LookAtResultWithPos[];
     /**
      * Get the objects at the given position.
      * @param type One of the LOOK_* constants.


### PR DESCRIPTION
### Brief Description

This PR fixes the result type of `Room.lookAtArea`. The resulting `LookAtResultMatrix` has two dimensions. First, the y-axis. Second, the x-axis containing an array of `LookAtResult` objects.
An overloaded method is introduced that uses the `asArray` parameter as an discriminator for the result type.

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
