### PR TITLE
Spawn options +directions

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3280,6 +3280,11 @@ interface SpawnOptions {
      * If dryRun is <code>true</code>, the operation will only check if it is possible to create a creep.
      */
     dryRun?: boolean;
+    /**
+     * Set desired directions where the creep should move when spawned.
+     * An array with the direction constants.
+     */
+    directions?: DirectionConstant[];
 }
 
 interface SpawningConstructor extends _Constructor<Spawning>, _ConstructorById<Spawning> {

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3167,7 +3167,7 @@ interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
      *  * TOUGH
      *  * CLAIM
      * @param {string} name The name of a new creep. It must be a unique creep name, i.e. the Game.creeps object should not contain another creep with the same name (hash key).
-     * @param {{memory?: CreepMemory; energyStructures?: (StructureSpawn | StructureExtension)[]; dryRun?: boolean}} opts An object with additional options for the spawning process.
+     * @param {SpawnOptions} opts An object with additional options for the spawning process.
      * @returns {ScreepsReturnCode} One of the following codes:
      * ```
      * OK                       0   The operation has been scheduled successfully.
@@ -3179,7 +3179,7 @@ interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
      * ERR_RCL_NOT_ENOUGH       -14 Your Room Controller level is insufficient to use this spawn.
      * ```
      */
-    spawnCreep(body: BodyPartConstant[], name: string, opts?: { memory?: CreepMemory, energyStructures?: Array<(StructureSpawn | StructureExtension)>, dryRun?: boolean }): ScreepsReturnCode;
+    spawnCreep(body: BodyPartConstant[], name: string, opts?: SpawnOptions): ScreepsReturnCode;
 
     /**
      * Destroy this spawn immediately.
@@ -3261,6 +3261,25 @@ interface Spawning {
      * @param directions An array with the spawn directions
      */
     setDirections(directions: DirectionConstant[]): ScreepsReturnCode & (OK | ERR_NOT_OWNER | ERR_INVALID_ARGS);
+}
+
+/**
+ * An object with additional options for the spawning process.
+ */
+interface SpawnOptions {
+    /**
+     * Memory of the new creep. If provided, it will be immediately stored into Memory.creeps[name].
+     */
+    memory?: CreepMemory;
+    /**
+     * Array of spawns/extensions from which to draw energy for the spawning process.
+     * Structures will be used according to the array order.
+     */
+    energyStructures?: Array<StructureSpawn | StructureExtension>;
+    /**
+     * If dryRun is <code>true</code>, the operation will only check if it is possible to create a creep.
+     */
+    dryRun?: boolean;
 }
 
 interface SpawningConstructor extends _Constructor<Spawning>, _ConstructorById<Spawning> {

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -193,6 +193,11 @@ interface SpawnOptions {
      * If dryRun is <code>true</code>, the operation will only check if it is possible to create a creep.
      */
     dryRun?: boolean;
+    /**
+     * Set desired directions where the creep should move when spawned.
+     * An array with the direction constants.
+     */
+    directions?: DirectionConstant[];
 }
 
 interface SpawningConstructor extends _Constructor<Spawning>, _ConstructorById<Spawning> {

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -80,7 +80,7 @@ interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
      *  * TOUGH
      *  * CLAIM
      * @param {string} name The name of a new creep. It must be a unique creep name, i.e. the Game.creeps object should not contain another creep with the same name (hash key).
-     * @param {{memory?: CreepMemory; energyStructures?: (StructureSpawn | StructureExtension)[]; dryRun?: boolean}} opts An object with additional options for the spawning process.
+     * @param {SpawnOptions} opts An object with additional options for the spawning process.
      * @returns {ScreepsReturnCode} One of the following codes:
      * ```
      * OK                       0   The operation has been scheduled successfully.
@@ -92,7 +92,7 @@ interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
      * ERR_RCL_NOT_ENOUGH       -14 Your Room Controller level is insufficient to use this spawn.
      * ```
      */
-    spawnCreep(body: BodyPartConstant[], name: string, opts?: { memory?: CreepMemory, energyStructures?: Array<(StructureSpawn | StructureExtension)>, dryRun?: boolean }): ScreepsReturnCode;
+    spawnCreep(body: BodyPartConstant[], name: string, opts?: SpawnOptions): ScreepsReturnCode;
 
     /**
      * Destroy this spawn immediately.
@@ -174,6 +174,25 @@ interface Spawning {
      * @param directions An array with the spawn directions
      */
     setDirections(directions: DirectionConstant[]): ScreepsReturnCode & (OK | ERR_NOT_OWNER | ERR_INVALID_ARGS);
+}
+
+/**
+ * An object with additional options for the spawning process.
+ */
+interface SpawnOptions {
+    /**
+     * Memory of the new creep. If provided, it will be immediately stored into Memory.creeps[name].
+     */
+    memory?: CreepMemory;
+    /**
+     * Array of spawns/extensions from which to draw energy for the spawning process.
+     * Structures will be used according to the array order.
+     */
+    energyStructures?: Array<StructureSpawn | StructureExtension>;
+    /**
+     * If dryRun is <code>true</code>, the operation will only check if it is possible to create a creep.
+     */
+    dryRun?: boolean;
 }
 
 interface SpawningConstructor extends _Constructor<Spawning>, _ConstructorById<Spawning> {


### PR DESCRIPTION
### Brief Description

The declaration of options in `StructureSpawn.spawnCreep` is extracted to an own interface `SpawnOptions`. A new property `directions` is added (see http://docs.screeps.com/api/#StructureSpawn.spawnCreep)

### Checklists

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
