### PR TITLE
claimController() uses GCL, not RCL

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -795,7 +795,7 @@ interface Creep extends RoomObject {
      * @param target The target controller object.
      * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_FULL, ERR_NOT_IN_RANGE, ERR_NO_BODYPART, ERR_GCL_NOT_ENOUGH
      */
-    claimController(target: StructureController): CreepActionReturnCode | ERR_FULL | ERR_RCL_NOT_ENOUGH;
+    claimController(target: StructureController): CreepActionReturnCode | ERR_FULL | ERR_GCL_NOT_ENOUGH;
     /**
      * Dismantles any (even hostile) structure returning 50% of the energy spent on its repair.
      *

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-union": {
@@ -82,9 +82,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
         "chalk": {
@@ -93,11 +93,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         }
       }
@@ -120,7 +120,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -136,9 +136,9 @@
       "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.3.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -147,7 +147,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "supports-color": {
@@ -156,7 +156,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -185,7 +185,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -206,7 +206,7 @@
       "integrity": "sha1-cBauYCeLo/awtWE2j6IRFg5VbbU=",
       "dev": true,
       "requires": {
-        "async": "0.2.10"
+        "async": "~0.2.6"
       }
     },
     "concat-map": {
@@ -221,20 +221,20 @@
       "integrity": "sha512-v2O6JyzUf2lEFZdfL+zHKpkM1/N7+3OPBn8G7bUc/dyExb7EJ3u66QHXrsIJ2tsVStTUII9rkyMfk/HrQUfUiw==",
       "dev": true,
       "requires": {
-        "async-each": "1.0.1",
-        "bluebird": "3.5.1",
-        "extend-shallow": "2.0.1",
-        "file-contents": "0.3.2",
-        "glob-parent": "2.0.0",
-        "graceful-fs": "4.1.11",
-        "has-glob": "0.1.1",
-        "is-absolute": "0.2.6",
-        "lazy-cache": "2.0.2",
-        "log-ok": "0.1.1",
-        "matched": "0.4.4",
-        "mkdirp": "0.5.1",
-        "resolve-dir": "0.1.1",
-        "to-file": "0.2.0"
+        "async-each": "^1.0.0",
+        "bluebird": "^3.4.1",
+        "extend-shallow": "^2.0.1",
+        "file-contents": "^0.3.1",
+        "glob-parent": "^2.0.0",
+        "graceful-fs": "^4.1.4",
+        "has-glob": "^0.1.1",
+        "is-absolute": "^0.2.5",
+        "lazy-cache": "^2.0.1",
+        "log-ok": "^0.1.1",
+        "matched": "^0.4.1",
+        "mkdirp": "^0.5.1",
+        "resolve-dir": "^0.1.0",
+        "to-file": "^0.2.0"
       }
     },
     "core-util-is": {
@@ -249,15 +249,16 @@
       "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
       "dev": true,
       "requires": {
-        "is-descriptor": "0.1.6"
+        "is-descriptor": "^0.1.0"
       }
     },
     "definitelytyped-header-parser": {
       "version": "github:Microsoft/definitelytyped-header-parser#210b44cf9e7e5b9783a41df4f664695ade5325b1",
+      "from": "definitelytyped-header-parser@github:Microsoft/definitelytyped-header-parser#210b44cf9e7e5b9783a41df4f664695ade5325b1",
       "dev": true,
       "requires": {
-        "@types/parsimmon": "1.6.0",
-        "parsimmon": "1.6.2"
+        "@types/parsimmon": "^1.3.0",
+        "parsimmon": "^1.2.0"
       }
     },
     "diff": {
@@ -273,10 +274,10 @@
       "dev": true,
       "requires": {
         "definitelytyped-header-parser": "github:Microsoft/definitelytyped-header-parser#210b44cf9e7e5b9783a41df4f664695ade5325b1",
-        "fs-promise": "2.0.3",
-        "strip-json-comments": "2.0.1",
-        "tslint": "5.9.1",
-        "typescript": "2.7.0-dev.20171206"
+        "fs-promise": "^2.0.0",
+        "strip-json-comments": "^2.0.1",
+        "tslint": "^5.4.2",
+        "typescript": "next"
       },
       "dependencies": {
         "typescript": {
@@ -311,7 +312,7 @@
       "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.1"
       }
     },
     "extend-shallow": {
@@ -320,7 +321,7 @@
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "requires": {
-        "is-extendable": "0.1.1"
+        "is-extendable": "^0.1.0"
       }
     },
     "file-contents": {
@@ -329,18 +330,18 @@
       "integrity": "sha1-oJOf7RuM2hWAJm/Gt1OiMvtG3lM=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "file-stat": "0.2.3",
-        "fs-exists-sync": "0.1.0",
-        "graceful-fs": "4.1.11",
-        "is-buffer": "1.1.6",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "strip-bom-buffer": "0.1.1",
-        "strip-bom-string": "0.1.2",
-        "through2": "2.0.3",
-        "vinyl": "1.2.0"
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "file-stat": "^0.2.3",
+        "fs-exists-sync": "^0.1.0",
+        "graceful-fs": "^4.1.4",
+        "is-buffer": "^1.1.3",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "strip-bom-buffer": "^0.1.1",
+        "strip-bom-string": "^0.1.2",
+        "through2": "^2.0.1",
+        "vinyl": "^1.1.1"
       }
     },
     "file-stat": {
@@ -349,10 +350,10 @@
       "integrity": "sha1-Rpp+kn1pMAeWJM2zgQlAVFbLBqk=",
       "dev": true,
       "requires": {
-        "fs-exists-sync": "0.1.0",
-        "graceful-fs": "4.1.11",
-        "lazy-cache": "2.0.2",
-        "through2": "2.0.3"
+        "fs-exists-sync": "^0.1.0",
+        "graceful-fs": "^4.1.4",
+        "lazy-cache": "^2.0.1",
+        "through2": "^2.0.1"
       }
     },
     "fs-exists-sync": {
@@ -367,8 +368,8 @@
       "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0"
       }
     },
     "fs-promise": {
@@ -377,10 +378,10 @@
       "integrity": "sha1-9k5PhUvPaJqovdy6JokW2z20aFQ=",
       "dev": true,
       "requires": {
-        "any-promise": "1.3.0",
-        "fs-extra": "2.1.2",
-        "mz": "2.7.0",
-        "thenify-all": "1.6.0"
+        "any-promise": "^1.3.0",
+        "fs-extra": "^2.0.0",
+        "mz": "^2.6.0",
+        "thenify-all": "^1.6.0"
       }
     },
     "fs.realpath": {
@@ -395,12 +396,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-parent": {
@@ -409,7 +410,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "global-modules": {
@@ -418,8 +419,8 @@
       "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
       "dev": true,
       "requires": {
-        "global-prefix": "0.1.5",
-        "is-windows": "0.2.0"
+        "global-prefix": "^0.1.4",
+        "is-windows": "^0.2.0"
       }
     },
     "global-prefix": {
@@ -428,10 +429,10 @@
       "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.5",
-        "is-windows": "0.2.0",
-        "which": "1.3.0"
+        "homedir-polyfill": "^1.0.0",
+        "ini": "^1.3.4",
+        "is-windows": "^0.2.0",
+        "which": "^1.2.12"
       }
     },
     "graceful-fs": {
@@ -446,7 +447,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -461,7 +462,7 @@
       "integrity": "sha1-omHEwqbGZ+DHe3AKfyl8Oe86pYk=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.1"
       }
     },
     "homedir-polyfill": {
@@ -470,7 +471,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "1.0.0"
+        "parse-passwd": "^1.0.0"
       }
     },
     "husky": {
@@ -479,9 +480,9 @@
       "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
       "dev": true,
       "requires": {
-        "is-ci": "1.0.10",
-        "normalize-path": "1.0.0",
-        "strip-indent": "2.0.0"
+        "is-ci": "^1.0.10",
+        "normalize-path": "^1.0.0",
+        "strip-indent": "^2.0.0"
       }
     },
     "inflight": {
@@ -490,8 +491,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -512,8 +513,8 @@
       "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
       "dev": true,
       "requires": {
-        "is-relative": "0.2.1",
-        "is-windows": "0.2.0"
+        "is-relative": "^0.2.1",
+        "is-windows": "^0.2.0"
       }
     },
     "is-accessor-descriptor": {
@@ -522,7 +523,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -531,7 +532,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -548,7 +549,7 @@
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "dev": true,
       "requires": {
-        "ci-info": "1.1.1"
+        "ci-info": "^1.0.0"
       }
     },
     "is-data-descriptor": {
@@ -557,7 +558,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -566,7 +567,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -577,9 +578,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       }
     },
     "is-extendable": {
@@ -600,7 +601,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-relative": {
@@ -609,7 +610,7 @@
       "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
       "dev": true,
       "requires": {
-        "is-unc-path": "0.1.2"
+        "is-unc-path": "^0.1.1"
       }
     },
     "is-unc-path": {
@@ -618,7 +619,7 @@
       "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
       "dev": true,
       "requires": {
-        "unc-path-regex": "0.1.2"
+        "unc-path-regex": "^0.1.0"
       }
     },
     "is-utf8": {
@@ -672,8 +673,8 @@
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsonfile": {
@@ -682,7 +683,7 @@
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "kind-of": {
@@ -697,7 +698,7 @@
       "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
       "dev": true,
       "requires": {
-        "set-getter": "0.1.0"
+        "set-getter": "^0.1.0"
       }
     },
     "log-ok": {
@@ -706,8 +707,8 @@
       "integrity": "sha1-vqPdNqzQuKckDXhza1uXxlREozQ=",
       "dev": true,
       "requires": {
-        "ansi-green": "0.1.1",
-        "success-symbol": "0.1.0"
+        "ansi-green": "^0.1.1",
+        "success-symbol": "^0.1.0"
       }
     },
     "matched": {
@@ -716,15 +717,15 @@
       "integrity": "sha1-Vte36xgDPwz5vFLrIJD6x9weifo=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "async-array-reduce": "0.2.1",
-        "extend-shallow": "2.0.1",
-        "fs-exists-sync": "0.1.0",
-        "glob": "7.1.2",
-        "has-glob": "0.1.1",
-        "is-valid-glob": "0.3.0",
-        "lazy-cache": "2.0.2",
-        "resolve-dir": "0.1.1"
+        "arr-union": "^3.1.0",
+        "async-array-reduce": "^0.2.0",
+        "extend-shallow": "^2.0.1",
+        "fs-exists-sync": "^0.1.0",
+        "glob": "^7.0.5",
+        "has-glob": "^0.1.1",
+        "is-valid-glob": "^0.3.0",
+        "lazy-cache": "^2.0.1",
+        "resolve-dir": "^0.1.0"
       }
     },
     "minimatch": {
@@ -733,7 +734,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -757,9 +758,9 @@
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dev": true,
       "requires": {
-        "any-promise": "1.3.0",
-        "object-assign": "4.1.1",
-        "thenify-all": "1.6.0"
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
       }
     },
     "normalize-path": {
@@ -780,7 +781,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "os-homedir": {
@@ -831,13 +832,13 @@
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "replace-ext": {
@@ -852,7 +853,7 @@
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-dir": {
@@ -861,8 +862,8 @@
       "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
       "dev": true,
       "requires": {
-        "expand-tilde": "1.2.2",
-        "global-modules": "0.2.3"
+        "expand-tilde": "^1.2.2",
+        "global-modules": "^0.2.3"
       }
     },
     "rimraf": {
@@ -871,7 +872,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "safe-buffer": {
@@ -892,7 +893,7 @@
       "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
       "dev": true,
       "requires": {
-        "to-object-path": "0.3.0"
+        "to-object-path": "^0.3.0"
       }
     },
     "sprintf-js": {
@@ -907,7 +908,7 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -916,7 +917,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom-buffer": {
@@ -925,8 +926,8 @@
       "integrity": "sha1-yj3cSRnBP5/d8wsd/xAKmDUki00=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6",
-        "is-utf8": "0.2.1"
+        "is-buffer": "^1.1.0",
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-bom-string": {
@@ -965,7 +966,7 @@
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
       "dev": true,
       "requires": {
-        "any-promise": "1.3.0"
+        "any-promise": "^1.0.0"
       }
     },
     "thenify-all": {
@@ -974,7 +975,7 @@
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "dev": true,
       "requires": {
-        "thenify": "3.3.0"
+        "thenify": ">= 3.1.0 < 4"
       }
     },
     "through2": {
@@ -983,8 +984,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "to-file": {
@@ -993,14 +994,14 @@
       "integrity": "sha1-I2xsCIBl5XDe+9Fc9LTlZb5G6pM=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "file-contents": "0.2.4",
-        "glob-parent": "2.0.0",
-        "is-valid-glob": "0.3.0",
-        "isobject": "2.1.0",
-        "lazy-cache": "2.0.2",
-        "vinyl": "1.2.0"
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "file-contents": "^0.2.4",
+        "glob-parent": "^2.0.0",
+        "is-valid-glob": "^0.3.0",
+        "isobject": "^2.1.0",
+        "lazy-cache": "^2.0.1",
+        "vinyl": "^1.1.1"
       },
       "dependencies": {
         "file-contents": {
@@ -1009,13 +1010,13 @@
           "integrity": "sha1-BQb3uO/2KvpFrkXaTfnp1H30U8s=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "file-stat": "0.1.3",
-            "graceful-fs": "4.1.11",
-            "is-buffer": "1.1.6",
-            "is-utf8": "0.2.1",
-            "lazy-cache": "0.2.7",
-            "through2": "2.0.3"
+            "extend-shallow": "^2.0.0",
+            "file-stat": "^0.1.0",
+            "graceful-fs": "^4.1.2",
+            "is-buffer": "^1.1.0",
+            "is-utf8": "^0.2.0",
+            "lazy-cache": "^0.2.3",
+            "through2": "^2.0.0"
           },
           "dependencies": {
             "lazy-cache": {
@@ -1032,9 +1033,9 @@
           "integrity": "sha1-0PGWHX0QcykoEgpuaVVHHCpbVBE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "lazy-cache": "0.2.7",
-            "through2": "2.0.3"
+            "graceful-fs": "^4.1.2",
+            "lazy-cache": "^0.2.3",
+            "through2": "^2.0.0"
           },
           "dependencies": {
             "lazy-cache": {
@@ -1053,7 +1054,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -1062,7 +1063,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -1079,18 +1080,18 @@
       "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "builtin-modules": "1.1.1",
-        "chalk": "2.3.2",
-        "commander": "2.15.0",
-        "diff": "3.5.0",
-        "glob": "7.1.2",
-        "js-yaml": "3.11.0",
-        "minimatch": "3.0.4",
-        "resolve": "1.5.0",
-        "semver": "5.5.0",
-        "tslib": "1.9.0",
-        "tsutils": "2.22.2"
+        "babel-code-frame": "^6.22.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^3.2.0",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.7.0",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^2.12.1"
       }
     },
     "tsutils": {
@@ -1099,7 +1100,7 @@
       "integrity": "sha512-u06FUSulCJ+Y8a2ftuqZN6kIGqdP2yJjUPEngXqmdPND4UQfb04igcotH+dw+IFr417yP6muCLE8/5/Qlfnx0w==",
       "dev": true,
       "requires": {
-        "tslib": "1.9.0"
+        "tslib": "^1.8.1"
       }
     },
     "typescript": {
@@ -1126,8 +1127,8 @@
       "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
       "dev": true,
       "requires": {
-        "clone": "1.0.3",
-        "clone-stats": "0.0.1",
+        "clone": "^1.0.0",
+        "clone-stats": "^0.0.1",
         "replace-ext": "0.0.1"
       }
     },
@@ -1137,7 +1138,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "wrappy": {

--- a/src/creep.ts
+++ b/src/creep.ts
@@ -116,7 +116,7 @@ interface Creep extends RoomObject {
      * @param target The target controller object.
      * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_FULL, ERR_NOT_IN_RANGE, ERR_NO_BODYPART, ERR_GCL_NOT_ENOUGH
      */
-    claimController(target: StructureController): CreepActionReturnCode | ERR_FULL | ERR_RCL_NOT_ENOUGH;
+    claimController(target: StructureController): CreepActionReturnCode | ERR_FULL | ERR_GCL_NOT_ENOUGH;
     /**
      * Dismantles any (even hostile) structure returning 50% of the energy spent on its repair.
      *


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

Fixes the return code for `Creep.claimController()` to use `ERR_RCL_NOT_ENOUGH` instead of `ERR_GCL_NOT_ENOUGH`.

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
