### PR TITLE
Small fix to options of findInRange

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2535,7 +2535,7 @@ interface RoomPosition {
      * @param range The range distance.
      * @param opts See Room.find.
      */
-    findInRange<K extends FindConstant>(type: K, range: number, opts?: {filter: any| string}): Array<FindTypes[K]>;
+    findInRange<K extends FindConstant>(type: K, range: number, opts?: {filter: FilterFunction<K>}): Array<FindTypes[K]>;
     findInRange<T extends Structure>(type: FIND_STRUCTURES | FIND_MY_STRUCTURES | FIND_HOSTILE_STRUCTURES, range: number, opts?: {filter: FilterFunction<FIND_STRUCTURES>}): T[];
     /**
      * Find all objects in the specified linear range.

--- a/src/room-position.ts
+++ b/src/room-position.ts
@@ -89,7 +89,7 @@ interface RoomPosition {
      * @param range The range distance.
      * @param opts See Room.find.
      */
-    findInRange<K extends FindConstant>(type: K, range: number, opts?: {filter: any| string}): Array<FindTypes[K]>;
+    findInRange<K extends FindConstant>(type: K, range: number, opts?: {filter: FilterFunction<K>}): Array<FindTypes[K]>;
     findInRange<T extends Structure>(type: FIND_STRUCTURES | FIND_MY_STRUCTURES | FIND_HOSTILE_STRUCTURES, range: number, opts?: {filter: FilterFunction<FIND_STRUCTURES>}): T[];
     /**
      * Find all objects in the specified linear range.


### PR DESCRIPTION
To be consistent with the other definition of `findInRange` and `Room.find`.

<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

Use `FilterFunction<K>`instead of `any|string` so `findInRange` can infer the right type for the filter function. It seems that the previous `opts` type was an error.

It fixes the following problem which I ran into:

```
// This is ok:
creep.room.find(FIND_STRUCTURES, {
    filter: (s) => /* etc */
});
// This doesn't compile:
// semantic error TS7006 Parameter 's' implicitly has an 'any' type.
const s2 = creep.pos.findInRange(FIND_STRUCTURES, 2, {
    filter: (s) => /* etc */
});
```

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
