### PR TITLE
Remove index signature from Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ yarn add @types/screeps
   interface RoomMemory { [name: string]: any };
   ```
 
+If you don't want to add types to the global `Memory` object, you will need to add the following interface along with the four above.
+
+Example:
+
+```Typescript
+interface Memory { [key: string]: any };
+```
+
 - Any place in code that uses a constant (ex `STRUCTURE_EXTENSION` or `FIND_MY_SPAWNS` is now constrained to use literal types. Here is the list of the new types:
 
   ```

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2249,7 +2249,6 @@ interface OrderFilter {
     price?: number;
 }
 interface Memory {
-    [name: string]: any;
     creeps: { [name: string]: CreepMemory };
     flags: { [name: string]: FlagMemory };
     rooms: { [name: string]: RoomMemory };

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,9 +1,8 @@
 interface Memory {
-    [name: string]: any;
-    creeps: { [name: string]: CreepMemory };
-    flags: { [name: string]: FlagMemory };
-    rooms: { [name: string]: RoomMemory };
-    spawns: { [name: string]: SpawnMemory };
+    creeps: {[name: string]: CreepMemory};
+    flags: {[name: string]: FlagMemory};
+    rooms: {[name: string]: RoomMemory};
+    spawns: {[name: string]: SpawnMemory};
 }
 
 interface CreepMemory {}


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description
Removes `[name: string]: any` from `Memory` as this may be unwanted.
Having the index signature removes any possibility of getting errors when mistyping memory access.
I personally want to specify the type of my memory exactly, and not have `any`.
If people want the old behavior, they can easily add the index signature.

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
