### PR TITLE
fix definition of RawMemory.segments

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2330,7 +2330,7 @@ interface RawMemory {
    * An object with asynchronous memory segments available on this tick. Each object key is the segment ID with data in string values.
    * Use RawMemory.setActiveSegments to fetch segments on the next tick. Segments data is saved automatically in the end of the tick.
    */
-  segments: string[];
+  segments: {[segmentId: number]: string};
 
   /**
    * An object with a memory segment of another player available on this tick. Use `setActiveForeignSegment` to fetch segments on the next tick.

--- a/src/raw-memory.ts
+++ b/src/raw-memory.ts
@@ -6,7 +6,7 @@ interface RawMemory {
    * An object with asynchronous memory segments available on this tick. Each object key is the segment ID with data in string values.
    * Use RawMemory.setActiveSegments to fetch segments on the next tick. Segments data is saved automatically in the end of the tick.
    */
-  segments: string[];
+  segments: {[segmentId:number]: string};
 
   /**
    * An object with a memory segment of another player available on this tick. Use `setActiveForeignSegment` to fetch segments on the next tick.

--- a/src/raw-memory.ts
+++ b/src/raw-memory.ts
@@ -6,7 +6,7 @@ interface RawMemory {
    * An object with asynchronous memory segments available on this tick. Each object key is the segment ID with data in string values.
    * Use RawMemory.setActiveSegments to fetch segments on the next tick. Segments data is saved automatically in the end of the tick.
    */
-  segments: {[segmentId:number]: string};
+  segments: {[segmentId: number]: string};
 
   /**
    * An object with a memory segment of another player available on this tick. Use `setActiveForeignSegment` to fetch segments on the next tick.


### PR DESCRIPTION
### Brief Description

fix definition of RawMemory.segments (type is modelled as object with keys rather than an array as per https://docs.screeps.com/api/#RawMemory)

### Checklists

- [x] Test passed
- [X] Coding style (indentation, etc)
- [X] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
