### PR TITLE
Add missing properties to FindPathOpts

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1439,6 +1439,16 @@ interface FindPathOpts {
      * Path to within (range) tiles of target tile. The default is to path to the tile that the target is on (0).
      */
     range?: number;
+
+    /**
+     * Cost for walking on plain positions. The default is 1.
+     */
+    plainCost?: number;
+
+    /**
+     * Cost for walking on swamp positions. The default is 5.
+     */
+    swampCost?: number;
 }
 
 interface MoveToOpts extends FindPathOpts {
@@ -1499,7 +1509,7 @@ interface _Constructor<T> {
 }
 
 interface _ConstructorById<T> extends _Constructor<T> {
-    new (id: string): T;
+    new(id: string): T;
     (id: string): T;
 }
 /*

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -277,6 +277,16 @@ interface FindPathOpts {
      * Path to within (range) tiles of target tile. The default is to path to the tile that the target is on (0).
      */
     range?: number;
+                  
+    /**
+     * Cost for walking on plain positions. The default is 1.
+     */
+    plainCost?: number;
+
+    /**
+     * Cost for walking on swamp positions. The default is 5.
+     */
+    swampCost?: number;
 }
 
 interface MoveToOpts extends FindPathOpts {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -277,7 +277,7 @@ interface FindPathOpts {
      * Path to within (range) tiles of target tile. The default is to path to the tile that the target is on (0).
      */
     range?: number;
-                  
+
     /**
      * Cost for walking on plain positions. The default is 1.
      */
@@ -347,6 +347,6 @@ interface _Constructor<T> {
 }
 
 interface _ConstructorById<T> extends _Constructor<T> {
-    new (id: string): T;
+    new(id: string): T;
     (id: string): T;
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

Type `FindPathOpts` should recognize `plainCost` and `swampCost`, but they were not present in the master branch. This PR adds them to the typing declarations, in line with `https://docs.screeps.com/api/#Room.findPath`

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [ ] Test passed
- [ ] Coding style (indentation, etc)
- [ ] Edits have been made to `src/` files not `index.d.ts`
- [ ] Run `npm run dtslint` to update `index.d.ts`
