### PR TITLE
Nullable hash lookup results

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1090,11 +1090,11 @@ interface Game {
     /**
      * A hash containing all your creeps with creep names as hash keys.
      */
-    creeps: { [creepName: string]: Creep };
+    creeps: { [creepName: string]: Creep | undefined };
     /**
      * A hash containing all your flags with flag names as hash keys.
      */
-    flags: { [flagName: string]: Flag };
+    flags: { [flagName: string]: Flag | undefined };
     /**
      * Your Global Control Level.
      */
@@ -1115,20 +1115,20 @@ interface Game {
      * A hash containing all the rooms available to you with room names as hash keys.
      * A room is visible if you have a creep or an owned structure in it.
      */
-    rooms: { [roomName: string]: Room };
+    rooms: { [roomName: string]: Room | undefined };
     /**
      * A hash containing all your spawns with spawn names as hash keys.
      */
-    spawns: { [spawnName: string]: StructureSpawn };
+    spawns: { [spawnName: string]: StructureSpawn | undefined };
     /**
      * A hash containing all your structures with structure id as hash keys.
      */
-    structures: { [structureId: string]: Structure };
+    structures: { [structureId: string]: Structure | undefined };
 
     /**
      * A hash containing all your construction sites with their id as hash keys.
      */
-    constructionSites: { [constructionSiteId: string]: ConstructionSite };
+    constructionSites: { [constructionSiteId: string]: ConstructionSite | undefined };
 
     /**
      * An object describing the world shard where your script is currently being executed in.
@@ -2131,7 +2131,7 @@ interface Market {
     /**
      * An object with your active and inactive buy/sell orders on the market.
      */
-    orders: { [key: string]: Order };
+    orders: { [key: string]: Order | undefined };
     /**
      * An array of the last 100 outgoing transactions from your terminals
      */
@@ -2251,10 +2251,10 @@ interface OrderFilter {
 }
 interface Memory {
     [name: string]: any;
-    creeps: { [name: string]: CreepMemory };
-    flags: { [name: string]: FlagMemory };
-    rooms: { [name: string]: RoomMemory };
-    spawns: { [name: string]: SpawnMemory };
+    creeps: { [name: string]: CreepMemory | undefined };
+    flags: { [name: string]: FlagMemory | undefined };
+    rooms: { [name: string]: RoomMemory | undefined };
+    spawns: { [name: string]: SpawnMemory | undefined };
 }
 
 interface CreepMemory {}

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -9,14 +9,14 @@
 
 // Sample inputs
 
-const creep: Creep = Game.creeps.sampleCreep;
-const room: Room = Game.rooms.W10S10;
-const flag: Flag = Game.flags.Flag1;
-const spawn: StructureSpawn = Game.spawns.Spawn1;
+const creep: Creep = Game.creeps.sampleCreep!;
+const room: Room = Game.rooms.W10S10!;
+const flag: Flag = Game.flags.Flag1!;
+const spawn: StructureSpawn = Game.spawns.Spawn1!;
 const body: BodyPartConstant[] = [WORK, WORK, CARRY, MOVE];
 
 // Sample inputs for Game.map.findRoute testing
-const anotherRoomName: Room = Game.rooms.W10S11;
+const anotherRoomName: Room = Game.rooms.W10S11!;
 
 // Sample memory extensions
 interface CreepMemory {
@@ -37,24 +37,24 @@ function keys<T>(o: T): Array<keyof T> {
 
 {
     for (const i in Game.creeps) {
-        Game.creeps[i].moveTo(flag);
+        Game.creeps[i]!.moveTo(flag);
     }
 }
 
 // Game.flags
 
 {
-    creep.moveTo(Game.flags.Flag1);
+    creep.moveTo(Game.flags.Flag1!);
 }
 
 // Game.spawns
 
 {
     for (const i in Game.spawns) {
-        Game.spawns[i].createCreep(body);
+        Game.spawns[i]!.createCreep(body);
 
         // Test StructureSpawn.Spawning
-        let creep: Spawning | null = Game.spawns[i].spawning;
+        let creep: Spawning | null = Game.spawns[i]!.spawning;
         if (creep) {
             const name: string = creep.name;
             const needTime: number = creep.needTime;
@@ -118,7 +118,7 @@ function keys<T>(o: T): Array<keyof T> {
 }
 
 {
-    if (Game.spawns["Spawn1"].energy === 0) {
+    if (Game.spawns["Spawn1"]!.energy === 0) {
         Game.notify(
             "Spawn1 is out of energy",
             180, // group these notifications for 3 hours
@@ -196,7 +196,7 @@ function keys<T>(o: T): Array<keyof T> {
             const parsed = /^[WE]([0-9]+)[NS]([0-9]+)$/.exec(roomName);
             if (parsed !== null) {
                 const isHighway = parseInt(parsed[1], 10) % 10 === 0 || parseInt(parsed[2], 10) % 10 === 0;
-                const isMyRoom = Game.rooms[roomName] && Game.rooms[roomName].controller && Game.rooms[roomName].controller!.my;
+                const isMyRoom = Game.rooms[roomName] && Game.rooms[roomName]!.controller && Game.rooms[roomName]!.controller!.my;
                 if (isHighway || isMyRoom) {
                     return 1;
                 } else {
@@ -314,7 +314,7 @@ function keys<T>(o: T): Array<keyof T> {
 // PathFinder
 
 {
-    const pfCreep = Game.creeps.John;
+    const pfCreep = Game.creeps.John!;
 
     // tslint:disable-next-line:newline-per-chained-call
     const goals = pfCreep.room.find(FIND_SOURCES).map(source => {
@@ -553,7 +553,7 @@ function keys<T>(o: T): Array<keyof T> {
     // test discriminated union
     switch (unowned.structureType) {
         case STRUCTURE_TOWER:
-            unowned.heal(Game.creeps.myCreep);
+            unowned.heal(Game.creeps.myCreep!);
             break;
         case STRUCTURE_CONTAINER:
         case STRUCTURE_STORAGE:
@@ -567,14 +567,14 @@ function keys<T>(o: T): Array<keyof T> {
     }
 
     // test discriminated union using filter functions on find
-    const from = Game.rooms.myRoom.find(FIND_STRUCTURES, {
+    const from = Game.rooms.myRoom!.find(FIND_STRUCTURES, {
         filter: s => (s.structureType === STRUCTURE_CONTAINER || s.structureType === STRUCTURE_STORAGE) && s.store.energy > 0,
     })[0];
     const to = from.pos.findClosestByPath(FIND_MY_STRUCTURES, {
         filter: s => (s.structureType === STRUCTURE_SPAWN || s.structureType === STRUCTURE_EXTENSION) && s.energy < s.energyCapacity,
     });
 
-    Game.rooms.myRoom
+    Game.rooms.myRoom!
         .find(FIND_MY_STRUCTURES, {
             filter: s => s.structureType === STRUCTURE_RAMPART,
         })
@@ -583,7 +583,7 @@ function keys<T>(o: T): Array<keyof T> {
 
 {
     // Test that you can use signatures
-    EXTENSION_ENERGY_CAPACITY[Game.rooms.myRoom.controller!.level];
+    EXTENSION_ENERGY_CAPACITY[Game.rooms.myRoom!.controller!.level];
 
     REACTIONS[Object.keys(creep.carry)[0]];
 
@@ -599,7 +599,7 @@ function keys<T>(o: T): Array<keyof T> {
 
     tombstone.id;
 
-    const creep = Game.creeps["dave"];
+    const creep = Game.creeps["dave"]!;
     creep.withdraw(tombstone, RESOURCE_ENERGY);
 }
 
@@ -660,7 +660,7 @@ function keys<T>(o: T): Array<keyof T> {
 // Room.Terrain
 
 {
-    const room = Game.rooms[""];
+    const room = Game.rooms[""]!;
 
     const myTerrain = room.getTerrain();
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -9,11 +9,11 @@ interface Game {
     /**
      * A hash containing all your creeps with creep names as hash keys.
      */
-    creeps: { [creepName: string]: Creep };
+    creeps: { [creepName: string]: Creep | undefined };
     /**
      * A hash containing all your flags with flag names as hash keys.
      */
-    flags: { [flagName: string]: Flag };
+    flags: { [flagName: string]: Flag | undefined };
     /**
      * Your Global Control Level.
      */
@@ -34,20 +34,20 @@ interface Game {
      * A hash containing all the rooms available to you with room names as hash keys.
      * A room is visible if you have a creep or an owned structure in it.
      */
-    rooms: { [roomName: string]: Room };
+    rooms: { [roomName: string]: Room | undefined };
     /**
      * A hash containing all your spawns with spawn names as hash keys.
      */
-    spawns: { [spawnName: string]: StructureSpawn };
+    spawns: { [spawnName: string]: StructureSpawn | undefined };
     /**
      * A hash containing all your structures with structure id as hash keys.
      */
-    structures: { [structureId: string]: Structure };
+    structures: { [structureId: string]: Structure | undefined };
 
     /**
      * A hash containing all your construction sites with their id as hash keys.
      */
-    constructionSites: { [constructionSiteId: string]: ConstructionSite };
+    constructionSites: { [constructionSiteId: string]: ConstructionSite | undefined };
 
     /**
      * An object describing the world shard where your script is currently being executed in.

--- a/src/market.ts
+++ b/src/market.ts
@@ -14,7 +14,7 @@ interface Market {
     /**
      * An object with your active and inactive buy/sell orders on the market.
      */
-    orders: { [key: string]: Order };
+    orders: { [key: string]: Order | undefined };
     /**
      * An array of the last 100 outgoing transactions from your terminals
      */

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,9 +1,9 @@
 interface Memory {
     [name: string]: any;
-    creeps: { [name: string]: CreepMemory };
-    flags: { [name: string]: FlagMemory };
-    rooms: { [name: string]: RoomMemory };
-    spawns: { [name: string]: SpawnMemory };
+    creeps: { [name: string]: CreepMemory | undefined };
+    flags: { [name: string]: FlagMemory | undefined };
+    rooms: { [name: string]: RoomMemory | undefined };
+    spawns: { [name: string]: SpawnMemory | undefined };
 }
 
 interface CreepMemory {}


### PR DESCRIPTION
### Brief Description

To go with #107. Makes hash lookups nullable by adding `undefined` to the types. This is meant to provide better type safety for failed/missed hash lookups. (This is also kind of like how `Map` works.) For example:

```typescript
// "Game.flags" has type "{ [flagName: string]: Flag | undefined }"

let flag1 = Game.flags[nonExistentFlagName];

// "flag1" has type "Flag | undefined"
```

In the tests you can see that I had to add quite a few `!` non-null assertion operators. This might look a bit jarring at first, but I think that's just because the tests use many hard-coded names. I don't think "typical" Screeps code will require so many assertions.

(I know I said I would wait on a PR, but it ended up being easy so I just did it. Feedback on #107 would still be appreciated.)

### Checklists

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
