### PR TITLE
Change `EventType` to an interface with a type argument

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1956,7 +1956,18 @@ interface EventItem<T extends EventConstant = EventConstant> {
 }
 
 interface EventData {
-    [key: number]: null | object;
+    [key: number]: null | {
+        targetId?: string;
+        damage?: number;
+        attackType?: EventAttackType;
+        amount?: number;
+        energySpent?: number;
+        type?: EventDestroyType;
+        healType?: EventHealType;
+        room?: string;
+        x?: number;
+        y?: number;
+    };
     1: { // EVENT_ATTACK
         targetId: string;
         damage: number;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1949,87 +1949,55 @@ type EVENT_HEAL_TYPE_RANGED = 2;
 
 type EventDestroyType = "creep" | StructureConstant;
 
-type EventItem =
-    | {
-          type: EVENT_ATTACK;
-          objectId: string;
-          data: {
-              targetId: string;
-              damage: number;
-              attackType: EventAttackType;
-          };
-      }
-    | {
-          type: EVENT_OBJECT_DESTROYED;
-          objectId: string;
-          data: {
-              type: EventDestroyType;
-          };
-      }
-    | {
-          type: EVENT_ATTACK_CONTROLLER;
-          objectId: string;
-      }
-    | {
-          type: EVENT_BUILD;
-          objectId: string;
-          data: {
-              targetId: string;
-              amount: number;
-              energySpent: number;
-          };
-      }
-    | {
-          type: EVENT_HARVEST;
-          objectId: string;
-          data: {
-              targetId: string;
-              amount: number;
-          };
-      }
-    | {
-          type: EVENT_HEAL;
-          objectId: string;
-          data: {
-              targetId: string;
-              amount: number;
-              healType: EventHealType;
-          };
-      }
-    | {
-          type: EVENT_REPAIR;
-          objectId: string;
-          data: {
-              targetId: string;
-              amount: number;
-              energySpent: number;
-          };
-      }
-    | {
-          type: EVENT_RESERVE_CONTROLLER;
-          objectId: string;
-          data: {
-              amount: number;
-          };
-      }
-    | {
-          type: EVENT_UPGRADE_CONTROLLER;
-          objectId: string;
-          data:
-              | {
-                    amount: number;
-                    energySpent: number;
-                }
-              | {
-                    type: EVENT_EXIT;
-                    objectId: string;
-                    data: {
-                        room: string;
-                        x: number;
-                        y: number;
-                    };
-                };
-      };
+interface EventItem<T extends EventConstant = EventConstant> {
+    event: T;
+    objectId: string;
+    data: EventData[T];
+}
+
+interface EventData {
+    [key: number]: null | object;
+    1: { // EVENT_ATTACK
+        targetId: string;
+        damage: number;
+        attackType: EventAttackType;
+    };
+    2: { // EVENT_OBJECT_DESTORYED
+        type: EventDestroyType;
+    };
+    3: null; // EVENT_ATTACK_CONTROLLER
+    4: { // EVENT_BUILD
+        targetId: string;
+        amount: number;
+        energySpent: number;
+    };
+    5: { // EVENT_HARVEST
+        targetId: string;
+        amount: number;
+    };
+    6: { // EVENT_HEAL
+        targetId: string;
+        amount: number;
+        healType: EventHealType;
+    };
+    7: { // EVENT_REPAIR
+        targetId: string;
+        amount: number;
+        energySpent: number;
+    };
+    8: { // EVENT_RESERVE_CONTROLLER
+        amount: number;
+    };
+    9: { // EVENT_UPGRADE_CONTROLLER
+        amount: number;
+        energySpent: number;
+    };
+    10: { // EVENT_EXIT
+        room: string;
+        x: number;
+        y: number;
+    };
+}
 /**
  * The options that can be accepted by `findRoute()` and friends.
  */

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -655,6 +655,12 @@ function keys<T>(o: T): Array<keyof T> {
 {
     room.getEventLog();
     room.getEventLog(true);
+
+    const events = room.getEventLog();
+
+    const event = events[0] as EventItem<EVENT_ATTACK>;
+
+    event.data.attackType;
 }
 
 // Room.Terrain

--- a/src/literals.ts
+++ b/src/literals.ts
@@ -445,84 +445,52 @@ type EVENT_HEAL_TYPE_RANGED = 2;
 
 type EventDestroyType = "creep" | StructureConstant;
 
-type EventItem =
-    | {
-          type: EVENT_ATTACK;
-          objectId: string;
-          data: {
-              targetId: string;
-              damage: number;
-              attackType: EventAttackType;
-          };
-      }
-    | {
-          type: EVENT_OBJECT_DESTROYED;
-          objectId: string;
-          data: {
-              type: EventDestroyType;
-          };
-      }
-    | {
-          type: EVENT_ATTACK_CONTROLLER;
-          objectId: string;
-      }
-    | {
-          type: EVENT_BUILD;
-          objectId: string;
-          data: {
-              targetId: string;
-              amount: number;
-              energySpent: number;
-          };
-      }
-    | {
-          type: EVENT_HARVEST;
-          objectId: string;
-          data: {
-              targetId: string;
-              amount: number;
-          };
-      }
-    | {
-          type: EVENT_HEAL;
-          objectId: string;
-          data: {
-              targetId: string;
-              amount: number;
-              healType: EventHealType;
-          };
-      }
-    | {
-          type: EVENT_REPAIR;
-          objectId: string;
-          data: {
-              targetId: string;
-              amount: number;
-              energySpent: number;
-          };
-      }
-    | {
-          type: EVENT_RESERVE_CONTROLLER;
-          objectId: string;
-          data: {
-              amount: number;
-          };
-      }
-    | {
-          type: EVENT_UPGRADE_CONTROLLER;
-          objectId: string;
-          data:
-              | {
-                    amount: number;
-                    energySpent: number;
-                }
-              | {
-                    type: EVENT_EXIT;
-                    objectId: string;
-                    data: {
-                        room: string;
-                        x: number;
-                        y: number;
-                    };
-                };
-      };
+interface EventItem<T extends EventConstant = EventConstant> {
+    event: T;
+    objectId: string;
+    data: EventData[T];
+}
+
+interface EventData {
+    [key: number]: null | object;
+    1: { // EVENT_ATTACK
+        targetId: string;
+        damage: number;
+        attackType: EventAttackType;
+    };
+    2: { // EVENT_OBJECT_DESTORYED
+        type: EventDestroyType;
+    };
+    3: null; // EVENT_ATTACK_CONTROLLER
+    4: { // EVENT_BUILD
+        targetId: string;
+        amount: number;
+        energySpent: number;
+    };
+    5: { // EVENT_HARVEST
+        targetId: string;
+        amount: number;
+    };
+    6: { // EVENT_HEAL
+        targetId: string;
+        amount: number;
+        healType: EventHealType;
+    };
+    7: { // EVENT_REPAIR
+        targetId: string;
+        amount: number;
+        energySpent: number;
+    };
+    8: { // EVENT_RESERVE_CONTROLLER
+        amount: number;
+    };
+    9: { // EVENT_UPGRADE_CONTROLLER
+        amount: number;
+        energySpent: number;
+    };
+    10: { // EVENT_EXIT
+        room: string;
+        x: number;
+        y: number;
+    };
+}

--- a/src/literals.ts
+++ b/src/literals.ts
@@ -452,7 +452,18 @@ interface EventItem<T extends EventConstant = EventConstant> {
 }
 
 interface EventData {
-    [key: number]: null | object;
+    [key: number]: null | {
+        targetId?: string;
+        damage?: number;
+        attackType?: EventAttackType;
+        amount?: number;
+        energySpent?: number;
+        type?: EventDestroyType;
+        healType?: EventHealType;
+        room?: string;
+        x?: number;
+        y?: number;
+    };
     1: { // EVENT_ATTACK
         targetId: string;
         damage: number;


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

Change `EventType` to an interface with a type argument so that the `data` attribute can be typed implicitly. For example, once you set the event type to `EventType<EVENT_ATTACK>` the data takes on the type `EventData[EVENT_ATTACK]`. This also lets the type of data be addressable so you can write functions that expect a certain type of event data.

This also fixes #109 as `EventType` incorrectly used _type_ instead of _event_.

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
