### PR TITLE
Change recommended version of  TSLint extension for VSCode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-    "recommendations": ["eg2.tslint", "EditorConfig.EditorConfig", "esbenp.prettier-vscode"]
+    "recommendations": ["ms-vscode.vscode-typescript-tslint-plugin", "EditorConfig.EditorConfig", "esbenp.prettier-vscode"]
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

The recommended version of TSLint extension is [deprecated](https://marketplace.visualstudio.com/items?itemName=eg2.tslint). This PR updates recommendation to use [version](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin) from Microsoft.

### Checklists

VSCode editor config only, no changes to types.

<!-- Put an 'x' inside the '[ ]' next to each completed items 

- [ ] Test passed
- [ ] Coding style (indentation, etc)
- [ ] Edits have been made to `src/` files not `index.d.ts`
- [ ] Run `npm run dtslint` to update `index.d.ts`
-->