### PR TITLE
Explicitly type game object Ids

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1022,7 +1022,7 @@ interface ConstructionSite<T extends BuildableStructureConstant = BuildableStruc
     /**
      * A unique object identifier. You can use `Game.getObjectById` method to retrieve an object instance by its `id`.
      */
-    id: string;
+    id: Id<this>;
     /**
      * Whether this is your own construction site.
      */
@@ -1090,7 +1090,7 @@ interface Creep extends RoomObject {
     /**
      * A unique object identifier. You can use `Game.getObjectById` method to retrieve an object instance by its `id`.
      */
-    id: string;
+    id: Id<this>;
     /**
      * A shorthand to `Memory.creeps[creep.name]`. You can use it for quick access the creep’s specific memory data object.
      */
@@ -1393,7 +1393,7 @@ interface Deposit extends RoomObject {
      * A unique object identificator.
      * You can use {@link Game.getObjectById} method to retrieve an object instance by its id.
      */
-    id: string;
+    id: Id<this>;
     /**
      * The amount of game ticks until the next harvest action is possible.
      */
@@ -1548,7 +1548,7 @@ interface Game {
      * @param id The unique identifier.
      * @returns an object instance or null if it cannot be found.
      */
-    getObjectById<T>(id: string | undefined): T | null;
+    getObjectById<T>(id: Id<T>): T | null;
     /**
      * Send a custom message at your profile email.
      *
@@ -1951,8 +1951,17 @@ interface _Constructor<T> {
 }
 
 interface _ConstructorById<T> extends _Constructor<T> {
-    new (id: string): T;
-    (id: string): T;
+    new (id: Id<T>): T;
+    (id: Id<T>): T;
+}
+
+interface Id<T> extends String {
+    /**
+     * This exists only to introduce constraints on T so that differently
+     * paramterized Id types are not assignable to each other
+     * @deprecated
+     */
+    readonly __ignoreme?: T;
 }
 /**
  * `InterShardMemory` object provides an interface for communicating between shards.
@@ -2929,7 +2938,7 @@ interface Mineral<T extends MineralConstant = MineralConstant> extends RoomObjec
     /**
      * A unique object identifier. You can use `Game.getObjectById` method to retrieve an object instance by its `id`.
      */
-    id: string;
+    id: Id<this>;
     /**
      * The remaining time after which the deposit will be refilled.
      */
@@ -2948,7 +2957,7 @@ interface Nuke extends RoomObject {
     /**
      * A unique object identifier. You can use Game.getObjectById method to retrieve an object instance by its id.
      */
-    id: string;
+    id: Id<this>;
     /**
      * The name of the room where this nuke has been launched from.
      */
@@ -2959,9 +2968,7 @@ interface Nuke extends RoomObject {
     timeToLand: number;
 }
 
-interface NukeConstructor extends _Constructor<Nuke>, _ConstructorById<Nuke> {
-    new (id: string): Nuke;
-}
+interface NukeConstructor extends _Constructor<Nuke>, _ConstructorById<Nuke> {}
 
 declare const Nuke: NukeConstructor;
 /**
@@ -3147,7 +3154,7 @@ interface PowerCreep extends RoomObject {
     /**
      * A unique identifier. You can use `Game.getObjectById` method to retrieve an object instance by its id.
      */
-    id: string;
+    id: Id<this>;
     /**
      * The power creep's level.
      */
@@ -3438,16 +3445,14 @@ interface Resource<T extends ResourceConstant = ResourceConstant> extends RoomOb
     /**
      * A unique object identifier. You can use `Game.getObjectById` method to retrieve an object instance by its `id`.
      */
-    id: string;
+    id: Id<this>;
     /**
      * One of the `RESOURCE_*` constants.
      */
     resourceType: T;
 }
 
-interface ResourceConstructor extends _Constructor<Resource>, _ConstructorById<Resource> {
-    new (id: string): Resource;
-}
+interface ResourceConstructor extends _Constructor<Resource>, _ConstructorById<Resource> {}
 
 declare const Resource: ResourceConstructor;
 /**
@@ -4255,7 +4260,7 @@ interface Ruin extends RoomObject {
      * A unique object identificator.
      * You can use {@link Game.getObjectById} method to retrieve an object instance by its id.
      */
-    id: string;
+    id: Id<this>;
     /**
      * Time of destruction.
      */
@@ -4296,7 +4301,7 @@ interface Source extends RoomObject {
     /**
      * A unique object identifier. You can use Game.getObjectById method to retrieve an object instance by its id.
      */
-    id: string;
+    id: Id<this>;
     /**
      * If you can get an instance of Source, you can see it.
      * If you can see a Source, you can see the room it's in.
@@ -4564,7 +4569,7 @@ interface Structure<T extends StructureConstant = StructureConstant> extends Roo
     /**
      * A unique object identifier. You can use Game.getObjectById method to retrieve an object instance by its id.
      */
-    id: string;
+    id: Id<this>;
     /**
      * If you can get an instance of a Structure, you can see it.
      * If you can see the Structure, you can see the room it's in.
@@ -5288,7 +5293,7 @@ interface Tombstone extends RoomObject {
      * A unique object identificator.
      * You can use {@link Game.getObjectById} method to retrieve an object instance by its id.
      */
-    id: string;
+    id: Id<this>;
     /**
      * Time of death.
      */

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1563,6 +1563,10 @@ interface Game {
 }
 
 declare var Game: Game;
+interface _HasId {
+    id: Id<this>;
+}
+
 interface _HasRoomPosition {
     pos: RoomPosition;
 }

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -21,7 +21,7 @@ const anotherRoomName: Room = Game.rooms.W10S11;
 
 // Sample memory extensions
 interface CreepMemory {
-    sourceId: string;
+    sourceId: Id<Source>;
     lastHits: number;
 }
 
@@ -36,6 +36,38 @@ function keys<T>(o: T): Array<keyof T> {
 
 function resources(o: GenericStore): ResourceConstant[] {
     return Object.keys(o) as ResourceConstant[];
+}
+
+// Game object Id types
+{
+    const creepId: Id<Creep> = "1";
+    const creepOne: Creep | null = Game.getObjectById(creepId);
+    const creepTwo: Creep | null = Game.getObjectById<Creep>("2");
+    const creepThree: Creep = new Creep(creepId); // Works with typed ID
+    const creepFour: Creep = new Creep("plainoldstring"); // Works with plain old string
+
+    if (creepOne) {
+        creepOne.hits;
+        const recycle = Game.getObjectById(creepOne.id);
+    }
+
+    type StoreStructure = StructureContainer | StructureStorage | StructureLink;
+    const storeID: Id<StoreStructure> = "1234"; // String assignable to Id<T>
+    // const foo: string = storeID; // Id<T> not assignable to string
+    const storeObject = Game.getObjectById(storeID)!;
+
+    // Object recognized
+    switch (storeObject.structureType) {
+        case STRUCTURE_CONTAINER:
+            storeObject.structureType === "container";
+        case STRUCTURE_STORAGE:
+            storeObject.structureType === "storage";
+        default:
+            storeObject.structureType === "link";
+    }
+
+    // Default type is unknown
+    const untyped = Game.getObjectById("untyped");
 }
 
 // Game.creeps

--- a/src/construction-site.ts
+++ b/src/construction-site.ts
@@ -6,7 +6,7 @@ interface ConstructionSite<T extends BuildableStructureConstant = BuildableStruc
     /**
      * A unique object identifier. You can use `Game.getObjectById` method to retrieve an object instance by its `id`.
      */
-    id: string;
+    id: Id<this>;
     /**
      * Whether this is your own construction site.
      */

--- a/src/creep.ts
+++ b/src/creep.ts
@@ -35,7 +35,7 @@ interface Creep extends RoomObject {
     /**
      * A unique object identifier. You can use `Game.getObjectById` method to retrieve an object instance by its `id`.
      */
-    id: string;
+    id: Id<this>;
     /**
      * A shorthand to `Memory.creeps[creep.name]`. You can use it for quick access the creep’s specific memory data object.
      */

--- a/src/deposit.ts
+++ b/src/deposit.ts
@@ -8,7 +8,7 @@ interface Deposit extends RoomObject {
      * A unique object identificator.
      * You can use {@link Game.getObjectById} method to retrieve an object instance by its id.
      */
-    id: string;
+    id: Id<this>;
     /**
      * The amount of game ticks until the next harvest action is possible.
      */

--- a/src/game.ts
+++ b/src/game.ts
@@ -72,7 +72,7 @@ interface Game {
      * @param id The unique identifier.
      * @returns an object instance or null if it cannot be found.
      */
-    getObjectById<T>(id: string | undefined): T | null;
+    getObjectById<T>(id: Id<T>): T | null;
     /**
      * Send a custom message at your profile email.
      *

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,3 +1,7 @@
+interface _HasId {
+    id: Id<this>;
+}
+
 interface _HasRoomPosition {
     pos: RoomPosition;
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -386,6 +386,15 @@ interface _Constructor<T> {
 }
 
 interface _ConstructorById<T> extends _Constructor<T> {
-    new (id: string): T;
-    (id: string): T;
+    new (id: Id<T>): T;
+    (id: Id<T>): T;
+}
+
+interface Id<T> extends String {
+    /**
+     * This exists only to introduce constraints on T so that differently
+     * paramterized Id types are not assignable to each other
+     * @deprecated
+     */
+    readonly __ignoreme?: T;
 }

--- a/src/mineral.ts
+++ b/src/mineral.ts
@@ -22,7 +22,7 @@ interface Mineral<T extends MineralConstant = MineralConstant> extends RoomObjec
     /**
      * A unique object identifier. You can use `Game.getObjectById` method to retrieve an object instance by its `id`.
      */
-    id: string;
+    id: Id<this>;
     /**
      * The remaining time after which the deposit will be refilled.
      */

--- a/src/nuke.ts
+++ b/src/nuke.ts
@@ -7,7 +7,7 @@ interface Nuke extends RoomObject {
     /**
      * A unique object identifier. You can use Game.getObjectById method to retrieve an object instance by its id.
      */
-    id: string;
+    id: Id<this>;
     /**
      * The name of the room where this nuke has been launched from.
      */
@@ -18,8 +18,6 @@ interface Nuke extends RoomObject {
     timeToLand: number;
 }
 
-interface NukeConstructor extends _Constructor<Nuke>, _ConstructorById<Nuke> {
-    new (id: string): Nuke;
-}
+interface NukeConstructor extends _Constructor<Nuke>, _ConstructorById<Nuke> {}
 
 declare const Nuke: NukeConstructor;

--- a/src/power-creep.ts
+++ b/src/power-creep.ts
@@ -32,7 +32,7 @@ interface PowerCreep extends RoomObject {
     /**
      * A unique identifier. You can use `Game.getObjectById` method to retrieve an object instance by its id.
      */
-    id: string;
+    id: Id<this>;
     /**
      * The power creep's level.
      */

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -12,15 +12,13 @@ interface Resource<T extends ResourceConstant = ResourceConstant> extends RoomOb
     /**
      * A unique object identifier. You can use `Game.getObjectById` method to retrieve an object instance by its `id`.
      */
-    id: string;
+    id: Id<this>;
     /**
      * One of the `RESOURCE_*` constants.
      */
     resourceType: T;
 }
 
-interface ResourceConstructor extends _Constructor<Resource>, _ConstructorById<Resource> {
-    new (id: string): Resource;
-}
+interface ResourceConstructor extends _Constructor<Resource>, _ConstructorById<Resource> {}
 
 declare const Resource: ResourceConstructor;

--- a/src/ruin.ts
+++ b/src/ruin.ts
@@ -9,7 +9,7 @@ interface Ruin extends RoomObject {
      * A unique object identificator.
      * You can use {@link Game.getObjectById} method to retrieve an object instance by its id.
      */
-    id: string;
+    id: Id<this>;
     /**
      * Time of destruction.
      */

--- a/src/source.ts
+++ b/src/source.ts
@@ -17,7 +17,7 @@ interface Source extends RoomObject {
     /**
      * A unique object identifier. You can use Game.getObjectById method to retrieve an object instance by its id.
      */
-    id: string;
+    id: Id<this>;
     /**
      * If you can get an instance of Source, you can see it.
      * If you can see a Source, you can see the room it's in.

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -15,7 +15,7 @@ interface Structure<T extends StructureConstant = StructureConstant> extends Roo
     /**
      * A unique object identifier. You can use Game.getObjectById method to retrieve an object instance by its id.
      */
-    id: string;
+    id: Id<this>;
     /**
      * If you can get an instance of a Structure, you can see it.
      * If you can see the Structure, you can see the room it's in.

--- a/src/tombstone.ts
+++ b/src/tombstone.ts
@@ -9,7 +9,7 @@ interface Tombstone extends RoomObject {
      * A unique object identificator.
      * You can use {@link Game.getObjectById} method to retrieve an object instance by its id.
      */
-    id: string;
+    id: Id<this>;
     /**
      * Time of death.
      */


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

- Adds helper `interface Id<T> extends String`.
  - Strings are assignable to Id<T> but Id<T> is not implicitly assignable to string
- Types `id` property of game objects to be of type `Id<this>`
- Changes type of `Game.getObjectById<T>(id: Id<T>): T | null`
  - Breaking change: Default return type is `unknown` if `typeof id === 'string'`
- Adds helper `_HasId` interface for uses similar to existing `_HasRoomPosition`
- Adds section to breaking changes portion of README about changes to game object ids 

Fixes #92

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
