### PR TITLE
Implement Tag based Id typing (soft)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ This repo has more activity and is considerably more up-to-date.
   ```
 
 - Some original functions were incorrectly typed to not include `null` as a possible return. You may need to update your code to reflect this update (ex. `findClosestByPath` or `findClosestByRange`)
-- `Game.getObjectById()` now returns typed objects if given a typed Id (ex. `Id<StructureTower>`) according to the type of the Id.
+- `Game.getObjectById()` now returns typed objects according to the type of the Id (ex. `Id<StructureTower>` returns `StructureTower` type).
 
-  If given a `string` typed id, the type of the returned game object is `unknown` forcing manual type assertion. Previously this returned `any` typed objects which could accidently be left untyped;
+  Use of `string` typed Id, is deprecated and may be removed in the future. When using string Ids, the type of the returned game object is `unknown` which requires manual type assertion. Previously this function returned `any` typed objects which could accidently be left untyped;
 
   If you have code like this (un-type-asserted use of `Game.getObjectById`)
 
@@ -101,7 +101,7 @@ This repo has more activity and is considerably more up-to-date.
   })
   ```
 
-  Change it to:
+  Change it store typed Ids:
 
   ```TypeScript
   interface Memory{
@@ -114,14 +114,13 @@ This repo has more activity and is considerably more up-to-date.
   })
   ```
 
-  If you're already manually asserting the type of the game object, you're not required to change anything.
+  If you're already manually asserting the type of the game object, you're not required to change anything immediately however this is deprecated and may be removed in the future.
 
   ```TypeScript
-  const tower1 = Game.getObjectById<StructureTower>(""); // previously possible, returns StructureTower type
-  const tower2 = Game.getObjectById("") as StructureTower; // previously possible, returns StructureTower type
   const towerId: Id<StructureTower> = ""  as Id<StructureTower>;
-  const tower3 = Game.getObjectById(towerId); // new option, returns StructureTower type
-  const tower4 = Game.getObjectById(tower1!.id); // new option, returns StructureTower type
+  const tower1 = Game.getObjectById(towerId); // recommended use, returns StructureTower type
+  const tower2 = Game.getObjectById<StructureTower>(""); // @deprecated returns StructureTower type
+  const tower3 = Game.getObjectById("") as StructureTower; // @deprecated returns StructureTower type
   ```
 
   `Id<T>` types are assignable to `string` but the reverse is not allowed implicitly. To assign a `string` type to an `Id<T>` type, you must explicitly assert the type.
@@ -135,7 +134,7 @@ This repo has more activity and is considerably more up-to-date.
 
   ```TypeScript
   creep.id // has type Id<Creep>
-  copy = Game.getObjectById(creep.id) // has type Creep
+  copy = Game.getObjectById(creep.id) // returns type Creep
   tower.id // has type Id<StructureTower>
   ```
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This repo has more activity and is considerably more up-to-date.
   ```
 
 - Some original functions were incorrectly typed to not include `null` as a possible return. You may need to update your code to reflect this update (ex. `findClosestByPath` or `findClosestByRange`)
-- `Game.getObjectById()` now returns typed objects if given a typed Id (ex. `Id<StructureTower>`) would return a typed object according to the type of the Id.
+- `Game.getObjectById()` now returns typed objects if given a typed Id (ex. `Id<StructureTower>`) according to the type of the Id.
 
   If given a `string` typed id, the type of the returned game object is `unknown` forcing manual type assertion. Previously this returned `any` typed objects which could accidently be left untyped;
 
@@ -117,19 +117,18 @@ This repo has more activity and is considerably more up-to-date.
   If you're already manually asserting the type of the game object, you're not required to change anything.
 
   ```TypeScript
-  tower = Game.getObjectById<StructureTower>("") // previously possible, returns StructureTower type
-  tower = Game.getObjectById("") as StructureTower // previously possible, returns StructureTower type
-  const towerId: Id<StructureTower> = "";
-  tower = Game.getObjectById(towerId); // new option, returns StructureTower type
-  tower = Game.getObjectById(tower.id); // new option, returns StructureTower type
+  const tower1 = Game.getObjectById<StructureTower>(""); // previously possible, returns StructureTower type
+  const tower2 = Game.getObjectById("") as StructureTower; // previously possible, returns StructureTower type
+  const towerId: Id<StructureTower> = ""  as Id<StructureTower>;
+  const tower3 = Game.getObjectById(towerId); // new option, returns StructureTower type
+  const tower4 = Game.getObjectById(tower1!.id); // new option, returns StructureTower type
   ```
 
-  Strings are assignable to `Id<T>` types but the reverse is not allowed implicitly. To assign an `Id<T>` type to a `string` type, you must explicitly assert the type.
+  `Id<T>` types are assignable to `string` but the reverse is not allowed implicitly. To assign a `string` type to an `Id<T>` type, you must explicitly assert the type.
 
   ```TypeScript
-  const typedId: Id<Creep> = "123"; // valid
-  const untypedId: string = typedId; // Type 'Id<Creep>' is not assignable to type 'string'.ts(2322)
-  const untypedId: string = typedId as string; // valid
+  const typedId: Id<Creep> = "123" as Id<Creep>; // assertion required
+  const untypedId1: string = typedId; // no assertion required
   ```
 
 - Game objects have typed id properties `id: Id<this>`. These typed ids can by passed to `Game.getObjectById()` to receive typed game objects matching the type of the Id. See above bullet for more details.

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1553,7 +1553,7 @@ interface Game {
      * @param id The unique identifier.
      * @returns an object instance or null if it cannot be found.
      */
-    getObjectById<T>(id: Id<T>): T | null;
+    getObjectById<T>(id: Id<T> | string): T | null;
     /**
      * Send a custom message at your profile email.
      *
@@ -1972,14 +1972,15 @@ interface _ConstructorById<T> extends _Constructor<T> {
     (id: Id<T>): T;
 }
 
-interface Id<T> extends String {
-    /**
-     * This exists only to introduce constraints on T so that differently
-     * paramterized Id types are not assignable to each other
-     * @deprecated
-     */
-    readonly __ignoreme?: T;
+// tslint:disable-next-line: no-namespace
+declare namespace Tag {
+    const OpaqueTagSymbol: unique symbol;
+    // tslint:disable-next-line: strict-export-declare-modifiers
+    export class OpaqueTag<T> {
+        private [OpaqueTagSymbol]: T;
+    }
 }
+type Id<T> = string & Tag.OpaqueTag<T>;
 /**
  * `InterShardMemory` object provides an interface for communicating between shards.
  * Your script is executed separatedly on each shard, and their `Memory` objects are isolated from each other.

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1553,7 +1553,17 @@ interface Game {
      * @param id The unique identifier.
      * @returns an object instance or null if it cannot be found.
      */
-    getObjectById<T>(id: Id<T> | string): T | null;
+    getObjectById<T>(id: Id<T>): T | null;
+
+    /**
+     * Get an object with the specified unique ID. It may be a game object of any type. Only objects from the rooms which are visible to you can be accessed.
+     * @param id The unique identifier.
+     * @returns an object instance or null if it cannot be found.
+     * @deprecated Use Id<T>, instead of strings, to increase type safety
+     */
+    // tslint:disable-next-line:unified-signatures
+    getObjectById<T>(id: string): T | null;
+
     /**
      * Send a custom message at your profile email.
      *

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -40,11 +40,10 @@ function resources(o: GenericStore): ResourceConstant[] {
 
 // Game object Id types
 {
-    const creepId: Id<Creep> = "1";
+    const creepId: Id<Creep> = "1" as Id<Creep>;
     const creepOne: Creep | null = Game.getObjectById(creepId);
     const creepTwo: Creep | null = Game.getObjectById<Creep>("2");
     const creepThree: Creep = new Creep(creepId); // Works with typed ID
-    const creepFour: Creep = new Creep("plainoldstring"); // Works with plain old string
 
     if (creepOne) {
         creepOne.hits;
@@ -52,8 +51,8 @@ function resources(o: GenericStore): ResourceConstant[] {
     }
 
     type StoreStructure = StructureContainer | StructureStorage | StructureLink;
-    const storeID: Id<StoreStructure> = "1234"; // String assignable to Id<T>
-    // const foo: string = storeID; // Id<T> not assignable to string
+    const storeID: Id<StoreStructure> = "1234" as Id<StoreStructure>; // Strict assertion required
+    const stringID: string = storeID; // Id<T> assignable implicitly to string
     const storeObject = Game.getObjectById(storeID)!;
 
     // Object recognized
@@ -66,7 +65,7 @@ function resources(o: GenericStore): ResourceConstant[] {
             storeObject.structureType === "link";
     }
 
-    // Default type is unknown
+    // Default type is unknown if untyped Id provided
     const untyped = Game.getObjectById("untyped");
 }
 
@@ -151,8 +150,8 @@ function resources(o: GenericStore): ResourceConstant[] {
             const setDirectionStatus: OK | ERR_NOT_OWNER | ERR_INVALID_ARGS = creep.setDirections([TOP, BOTTOM, LEFT, RIGHT]);
         }
 
-        creep = new StructureSpawn.Spawning("");
-        creep = StructureSpawn.Spawning("");
+        creep = new StructureSpawn.Spawning("" as Id<Spawning>);
+        creep = StructureSpawn.Spawning("" as Id<Spawning>);
     }
 }
 
@@ -654,7 +653,7 @@ function resources(o: GenericStore): ResourceConstant[] {
         creep.drop(resourceType, amount);
     }
 
-    const extension = new StructureExtension("");
+    const extension = new StructureExtension("" as Id<StructureExtension>);
 
     const e1: number = extension.store.getUsedCapacity(RESOURCE_ENERGY);
     const e2: number = extension.store[RESOURCE_ENERGY];
@@ -662,7 +661,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     const g1: 0 = extension.store.getUsedCapacity(RESOURCE_GHODIUM);
     const g2: 0 = extension.store.getUsedCapacity(RESOURCE_GHODIUM);
 
-    const storage = new StructureStorage("");
+    const storage = new StructureStorage("" as Id<StructureStorage>);
 
     const g3: number = storage.store.getUsedCapacity(RESOURCE_GHODIUM);
 }

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -42,7 +42,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 {
     const creepId: Id<Creep> = "1" as Id<Creep>;
     const creepOne: Creep | null = Game.getObjectById(creepId);
-    const creepTwo: Creep | null = Game.getObjectById<Creep>("2");
+    const creepTwo: Creep | null = Game.getObjectById<Creep>("2"); // deprecated
     const creepThree: Creep = new Creep(creepId); // Works with typed ID
 
     if (creepOne) {

--- a/src/game.ts
+++ b/src/game.ts
@@ -72,7 +72,17 @@ interface Game {
      * @param id The unique identifier.
      * @returns an object instance or null if it cannot be found.
      */
-    getObjectById<T>(id: Id<T> | string): T | null;
+    getObjectById<T>(id: Id<T>): T | null;
+
+    /**
+     * Get an object with the specified unique ID. It may be a game object of any type. Only objects from the rooms which are visible to you can be accessed.
+     * @param id The unique identifier.
+     * @returns an object instance or null if it cannot be found.
+     * @deprecated Use Id<T>, instead of strings, to increase type safety
+     */
+    // tslint:disable-next-line:unified-signatures
+    getObjectById<T>(id: string): T | null;
+
     /**
      * Send a custom message at your profile email.
      *

--- a/src/game.ts
+++ b/src/game.ts
@@ -72,7 +72,7 @@ interface Game {
      * @param id The unique identifier.
      * @returns an object instance or null if it cannot be found.
      */
-    getObjectById<T>(id: Id<T>): T | null;
+    getObjectById<T>(id: Id<T> | string): T | null;
     /**
      * Send a custom message at your profile email.
      *

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -402,11 +402,12 @@ interface _ConstructorById<T> extends _Constructor<T> {
     (id: Id<T>): T;
 }
 
-interface Id<T> extends String {
-    /**
-     * This exists only to introduce constraints on T so that differently
-     * paramterized Id types are not assignable to each other
-     * @deprecated
-     */
-    readonly __ignoreme?: T;
+// tslint:disable-next-line: no-namespace
+declare namespace Tag {
+    const OpaqueTagSymbol: unique symbol;
+    // tslint:disable-next-line: strict-export-declare-modifiers
+    export class OpaqueTag<T> {
+        private [OpaqueTagSymbol]: T;
+    }
 }
+type Id<T> = string & Tag.OpaqueTag<T>;


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

- Change `Id<T>` to use `Tag` based implementation.
  - Allows implicit casting of `Id<T>` to `string`.
  - Requires explicit casting of `string` to `Id<T>`.
  - These are opposite of existing implementation.
- `Game.getObjectById()` returns `unknown` type if `string` id provided
without alternative method for designating type of returned object (ex.
`Game.getObjectById<Creep>(stringId)`)
- Use of `Game.getObjectById(id: string)` is deprecated
- Update README with breaking changes

Related to #92 and #93 
Alternative to #145 

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
