### PR TITLE
Fix version number and include patch on build

### DIFF
--- a/build/prependDescription.js
+++ b/build/prependDescription.js
@@ -1,18 +1,18 @@
 const fs = require("fs");
 const path = require("path");
 const prepend = require("prepend");
-const pkg = require('../package.json');
+const pkg = require("../package.json");
 
 const BUILT_FILE_PATH = path.resolve(__dirname, "../dist/index.d.ts");
 
-const [major, minor, patch] = pkg.version.split('.');
+const [major, minor, patch] = pkg.version.split(".");
 
-const version = `${major}.${minor}`;
+const version = `${major}.${minor}.${patch}`;
 
 var description = `// Type definitions for Screeps ${version}`;
 
 if (fs.existsSync(BUILT_FILE_PATH)) {
-    prepend(BUILT_FILE_PATH, description, function (err) {
+    prepend(BUILT_FILE_PATH, description, function(err) {
         if (err) console.error(err);
     });
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Screeps 3.0
+// Type definitions for Screeps 3.0.1
 // Project: https://github.com/screeps/screeps
 // Definitions by: Marko Sulamägi <https://github.com/MarkoSulamagi>
 //                 Nhan Ho <https://github.com/NhanHo>


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

- Updates the build script to include the patch number automatically in the version number
- Correct version number to be 3.0.1 in DT header (already correct in package.json)

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
