### PR TITLE
PTR Updates 2019-12-21

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Screeps 3.0.1
+// Type definitions for Screeps 3.1.0-beta
 // Project: https://github.com/screeps/screeps
 // Definitions by: Marko Sulamägi <https://github.com/MarkoSulamagi>
 //                 Nhan Ho <https://github.com/NhanHo>

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2722,6 +2722,18 @@ interface RouteOptions {
     routeCallback: (roomName: string, fromRoomName: string) => any;
 }
 
+interface RoomSatusPermanent {
+    status: "normal" | "closed";
+    timestamp: null;
+}
+
+interface RoomStatusTemporary {
+    status: "novice" | "respawn";
+    timestamp: number;
+}
+
+type RoomStatus = RoomSatusPermanent | RoomStatusTemporary;
+
 /**
  * A global object representing world map. Use it to navigate between rooms. The object is accessible via Game.map property.
  */
@@ -2774,11 +2786,13 @@ interface GameMap {
      * @param x X position in the room.
      * @param y Y position in the room.
      * @param roomName The room name.
+     * @deprecated use `Game.map.getRoomTerrain` instead
      */
     getTerrainAt(x: number, y: number, roomName: string): Terrain;
     /**
      * Get terrain type at the specified room position. This method works for any room in the world even if you have no access to it.
      * @param pos The position object.
+     * @deprecated use `Game.map.getRoomTerrain` instead
      */
     getTerrainAt(pos: RoomPosition): Terrain;
     /**
@@ -2795,8 +2809,16 @@ interface GameMap {
      * Check if the room is available to move into.
      * @param roomName The room name.
      * @returns A boolean value.
+     * @deprecated Use `Game.map.getRoomStatus` instead
      */
     isRoomAvailable(roomName: string): boolean;
+
+    /**
+     * Get the room status to determine if it's available, or in a reserved area.
+     * @param roomName The room name.
+     * @returns An object with the following properties {status: "normal" | "closed" | "novice" | "respawn", timestamp: number}
+     */
+    getRoomStatus(roomName: string): RoomStatus;
 }
 
 // No static is available
@@ -4041,7 +4063,7 @@ interface Room {
     /**
      * The name of the room.
      */
-    name: string;
+    readonly name: string;
     /**
      * The Storage structure of this room, if present, otherwise undefined.
      */
@@ -5110,6 +5132,12 @@ interface StructureLab extends OwnedStructure<STRUCTURE_LAB> {
      * @param creep The target creep.
      */
     unboostCreep(creep: Creep): ScreepsReturnCode;
+    /**
+     * Breaks mineral compounds back into reagents. The same output labs can be used by many source labs.
+     * @param lab1 The first result lab.
+     * @param lab2 The second result lab.
+     */
+    reverseReaction(lab1: StructureLab, lab2: StructureLab): ScreepsReturnCode;
     /**
      * Produce mineral compounds using reagents from two another labs. Each lab has to be within 2 squares range. The same input labs can be used by many output labs
      * @param lab1 The first source lab.

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -4600,7 +4600,11 @@ interface SpawnOptions {
 
 interface SpawningConstructor extends _Constructor<Spawning>, _ConstructorById<Spawning> {}
 interface StoreBase<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE extends boolean> {
-    /** Returns capacity of this store for the specified resource, or total capacity if resource is undefined. */
+    /**
+     * Returns capacity of this store for the specified resource. For a general purpose store, it returns total capacity if `resource` is undefined.
+     * @param resource The type of the resource.
+     * @returns Returns capacity number, or `null` in case of an invalid `resource` for this store type.
+     */
     getCapacity<R extends ResourceConstant | undefined>(
         resource?: R,
     ): UNLIMITED_STORE extends true
@@ -4608,12 +4612,22 @@ interface StoreBase<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE
         : (undefined extends R
               ? (ResourceConstant extends POSSIBLE_RESOURCES ? number : null)
               : (R extends POSSIBLE_RESOURCES ? number : null));
-    /** Returns the capacity used by the specified resource, or total used capacity for general purpose stores if resource is undefined. */
+    /**
+     * Returns the capacity used by the specified resource, or total used capacity for general purpose stores if `resource` is undefined.
+     * @param resource The type of the resource.
+     * @returns Returns used capacity number, or `null` in case of a not valid `resource` for this store type.
+     */
     getUsedCapacity<R extends ResourceConstant | undefined>(
         resource?: R,
-    ): undefined extends R ? (ResourceConstant extends POSSIBLE_RESOURCES ? number : null) : (R extends POSSIBLE_RESOURCES ? number : 0);
-    /** A shorthand for getCapacity(resource) - getUsedCapacity(resource). */
-    getFreeCapacity(resource?: ResourceConstant): number;
+    ): undefined extends R ? (ResourceConstant extends POSSIBLE_RESOURCES ? number : null) : (R extends POSSIBLE_RESOURCES ? number : null);
+    /**
+     * Returns free capacity for the store. For a limited store, it returns the capacity available for the specified resource if `resource` is defined and valid for this store.
+     * @param resource The type of the resource.
+     * @returns Returns available capacity number, or `null` in case of an invalid `resource` for this store type.
+     */
+    getFreeCapacity<R extends ResourceConstant | undefined>(
+        resource?: R,
+    ): undefined extends R ? (ResourceConstant extends POSSIBLE_RESOURCES ? number : null) : (R extends POSSIBLE_RESOURCES ? number : null);
 }
 
 type Store<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE extends boolean> = StoreBase<POSSIBLE_RESOURCES, UNLIMITED_STORE> &
@@ -4621,12 +4635,24 @@ type Store<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE extends 
     { [P in Exclude<ResourceConstant, POSSIBLE_RESOURCES>]: 0 };
 
 interface GenericStoreBase {
-    /** Returns capacity of this store for the specified resource, or total capacity if resource is undefined. */
+    /**
+     * Returns capacity of this store for the specified resource. For a general purpose store, it returns total capacity if `resource` is undefined.
+     * @param resource The type of the resource.
+     * @returns Returns capacity number, or `null` in case of an invalid `resource` for this store type.
+     */
     getCapacity(resource?: ResourceConstant): number | null;
-    /** Returns the capacity used by the specified resource, or total used capacity for general purpose stores if resource is undefined. */
+    /**
+     * Returns the capacity used by the specified resource, or total used capacity for general purpose stores if `resource` is undefined.
+     * @param resource The type of the resource.
+     * @returns Returns used capacity number, or `null` in case of a not valid `resource` for this store type.
+     */
     getUsedCapacity(resource?: ResourceConstant): number | null;
-    /** A shorthand for getCapacity(resource) - getUsedCapacity(resource). */
-    getFreeCapacity(resource?: ResourceConstant): number;
+    /**
+     * Returns free capacity for the store. For a limited store, it returns the capacity available for the specified resource if `resource` is defined and valid for this store.
+     * @param resource The type of the resource.
+     * @returns Returns available capacity number, or `null` in case of an invalid `resource` for this store type.
+     */
+    getFreeCapacity(resource?: ResourceConstant): number | null;
 }
 
 type GenericStore = GenericStoreBase & { [P in ResourceConstant]: number };

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -337,10 +337,11 @@ function resources(o: GenericStore): ResourceConstant[] {
     Game.map.getTerrainAt(new RoomPosition(25, 20, "W10N10"));
 }
 
-// Game.map.isRoomAvailable(roomName)
+// Game.map.getRoomStatus(roomName)
 
 {
-    if (Game.map.isRoomAvailable(room.name)) {
+    const roomStatus = Game.map.getRoomStatus(room.name);
+    if (roomStatus.status === "normal") {
         creep.moveTo(room.getPositionAt(25, 25)!);
     }
 }
@@ -775,6 +776,8 @@ function resources(o: GenericStore): ResourceConstant[] {
         if (lab1.mineralAmount >= LAB_REACTION_AMOUNT && lab2.mineralAmount >= LAB_REACTION_AMOUNT && lab0.mineralType === null) {
             lab0.runReaction(lab1, lab2);
         }
+        // nevermind, reverse that
+        lab0.reverseReaction(lab1, lab2);
     }
 }
 

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -659,12 +659,17 @@ function resources(o: GenericStore): ResourceConstant[] {
     const e1: number = extension.store.getUsedCapacity(RESOURCE_ENERGY);
     const e2: number = extension.store[RESOURCE_ENERGY];
 
-    const g1: 0 = extension.store.getUsedCapacity(RESOURCE_GHODIUM);
-    const g2: 0 = extension.store.getUsedCapacity(RESOURCE_GHODIUM);
+    // Invalid resource type for extension
+    const eg1: null = extension.store.getUsedCapacity(RESOURCE_GHODIUM);
+    const eg2: null = extension.store.getFreeCapacity(RESOURCE_GHODIUM);
+    const eg3: null = extension.store.getCapacity(RESOURCE_GHODIUM);
+    const eg4: 0 = extension.store.G;
 
     const storage = new StructureStorage("" as Id<StructureStorage>);
 
-    const g3: number = storage.store.getUsedCapacity(RESOURCE_GHODIUM);
+    const sg1: number = storage.store.getUsedCapacity(RESOURCE_GHODIUM);
+    const sg2: number = storage.store.getFreeCapacity(RESOURCE_GHODIUM);
+    const sg3: number = storage.store.getCapacity(RESOURCE_GHODIUM);
 }
 
 // Advanced Structure types

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-screeps",
-  "version": "3.0.1",
+  "version": "3.1.0-beta.1",
   "description": "Strong TypeScript declarations for the game Screeps.",
   "repository": "screepers/typed-screeps",
   "types": "./dist/index.d.ts",

--- a/src/map.ts
+++ b/src/map.ts
@@ -5,6 +5,18 @@ interface RouteOptions {
     routeCallback: (roomName: string, fromRoomName: string) => any;
 }
 
+interface RoomSatusPermanent {
+    status: "normal" | "closed";
+    timestamp: null;
+}
+
+interface RoomStatusTemporary {
+    status: "novice" | "respawn";
+    timestamp: number;
+}
+
+type RoomStatus = RoomSatusPermanent | RoomStatusTemporary;
+
 /**
  * A global object representing world map. Use it to navigate between rooms. The object is accessible via Game.map property.
  */
@@ -57,11 +69,13 @@ interface GameMap {
      * @param x X position in the room.
      * @param y Y position in the room.
      * @param roomName The room name.
+     * @deprecated use `Game.map.getRoomTerrain` instead
      */
     getTerrainAt(x: number, y: number, roomName: string): Terrain;
     /**
      * Get terrain type at the specified room position. This method works for any room in the world even if you have no access to it.
      * @param pos The position object.
+     * @deprecated use `Game.map.getRoomTerrain` instead
      */
     getTerrainAt(pos: RoomPosition): Terrain;
     /**
@@ -78,8 +92,16 @@ interface GameMap {
      * Check if the room is available to move into.
      * @param roomName The room name.
      * @returns A boolean value.
+     * @deprecated Use `Game.map.getRoomStatus` instead
      */
     isRoomAvailable(roomName: string): boolean;
+
+    /**
+     * Get the room status to determine if it's available, or in a reserved area.
+     * @param roomName The room name.
+     * @returns An object with the following properties {status: "normal" | "closed" | "novice" | "respawn", timestamp: number}
+     */
+    getRoomStatus(roomName: string): RoomStatus;
 }
 
 // No static is available

--- a/src/room.ts
+++ b/src/room.ts
@@ -35,7 +35,7 @@ interface Room {
     /**
      * The name of the room.
      */
-    name: string;
+    readonly name: string;
     /**
      * The Storage structure of this room, if present, otherwise undefined.
      */

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,9 @@
 interface StoreBase<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE extends boolean> {
-    /** Returns capacity of this store for the specified resource, or total capacity if resource is undefined. */
+    /**
+     * Returns capacity of this store for the specified resource. For a general purpose store, it returns total capacity if `resource` is undefined.
+     * @param resource The type of the resource.
+     * @returns Returns capacity number, or `null` in case of an invalid `resource` for this store type.
+     */
     getCapacity<R extends ResourceConstant | undefined>(
         resource?: R,
     ): UNLIMITED_STORE extends true
@@ -7,12 +11,22 @@ interface StoreBase<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE
         : (undefined extends R
               ? (ResourceConstant extends POSSIBLE_RESOURCES ? number : null)
               : (R extends POSSIBLE_RESOURCES ? number : null));
-    /** Returns the capacity used by the specified resource, or total used capacity for general purpose stores if resource is undefined. */
+    /**
+     * Returns the capacity used by the specified resource, or total used capacity for general purpose stores if `resource` is undefined.
+     * @param resource The type of the resource.
+     * @returns Returns used capacity number, or `null` in case of a not valid `resource` for this store type.
+     */
     getUsedCapacity<R extends ResourceConstant | undefined>(
         resource?: R,
-    ): undefined extends R ? (ResourceConstant extends POSSIBLE_RESOURCES ? number : null) : (R extends POSSIBLE_RESOURCES ? number : 0);
-    /** A shorthand for getCapacity(resource) - getUsedCapacity(resource). */
-    getFreeCapacity(resource?: ResourceConstant): number;
+    ): undefined extends R ? (ResourceConstant extends POSSIBLE_RESOURCES ? number : null) : (R extends POSSIBLE_RESOURCES ? number : null);
+    /**
+     * Returns free capacity for the store. For a limited store, it returns the capacity available for the specified resource if `resource` is defined and valid for this store.
+     * @param resource The type of the resource.
+     * @returns Returns available capacity number, or `null` in case of an invalid `resource` for this store type.
+     */
+    getFreeCapacity<R extends ResourceConstant | undefined>(
+        resource?: R,
+    ): undefined extends R ? (ResourceConstant extends POSSIBLE_RESOURCES ? number : null) : (R extends POSSIBLE_RESOURCES ? number : null);
 }
 
 type Store<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE extends boolean> = StoreBase<POSSIBLE_RESOURCES, UNLIMITED_STORE> &
@@ -20,12 +34,24 @@ type Store<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE extends 
     { [P in Exclude<ResourceConstant, POSSIBLE_RESOURCES>]: 0 };
 
 interface GenericStoreBase {
-    /** Returns capacity of this store for the specified resource, or total capacity if resource is undefined. */
+    /**
+     * Returns capacity of this store for the specified resource. For a general purpose store, it returns total capacity if `resource` is undefined.
+     * @param resource The type of the resource.
+     * @returns Returns capacity number, or `null` in case of an invalid `resource` for this store type.
+     */
     getCapacity(resource?: ResourceConstant): number | null;
-    /** Returns the capacity used by the specified resource, or total used capacity for general purpose stores if resource is undefined. */
+    /**
+     * Returns the capacity used by the specified resource, or total used capacity for general purpose stores if `resource` is undefined.
+     * @param resource The type of the resource.
+     * @returns Returns used capacity number, or `null` in case of a not valid `resource` for this store type.
+     */
     getUsedCapacity(resource?: ResourceConstant): number | null;
-    /** A shorthand for getCapacity(resource) - getUsedCapacity(resource). */
-    getFreeCapacity(resource?: ResourceConstant): number;
+    /**
+     * Returns free capacity for the store. For a limited store, it returns the capacity available for the specified resource if `resource` is defined and valid for this store.
+     * @param resource The type of the resource.
+     * @returns Returns available capacity number, or `null` in case of an invalid `resource` for this store type.
+     */
+    getFreeCapacity(resource?: ResourceConstant): number | null;
 }
 
 type GenericStore = GenericStoreBase & { [P in ResourceConstant]: number };

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -501,6 +501,12 @@ interface StructureLab extends OwnedStructure<STRUCTURE_LAB> {
      */
     unboostCreep(creep: Creep): ScreepsReturnCode;
     /**
+     * Breaks mineral compounds back into reagents. The same output labs can be used by many source labs.
+     * @param lab1 The first result lab.
+     * @param lab2 The second result lab.
+     */
+    reverseReaction(lab1: StructureLab, lab2: StructureLab): ScreepsReturnCode;
+    /**
      * Produce mineral compounds using reagents from two another labs. Each lab has to be within 2 squares range. The same input labs can be used by many output labs
      * @param lab1 The first source lab.
      * @param lab2 The second source lab.


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

**NB:** The target for this PR is a new `ptr` branch, not `master`. Changes will not be merged to `master` until officially implemented in base game world.

### Brief Description

Adds `Game.map.getRoomStauts(roomName)`
Adds `StructureLab.reverseReaction(lab1,lab2)`
Changes `Room.name` to be readonly
Deprecates `Game.map.isRoomAvailable`, see `Game.map.getRoomStatus`
Changes return types and documentation of `StoreDefinition` capacity functions. For limited stores, `null` is returned for invalid resource types consistently, instead of zero in certain cases.
Update version to 3.1.0-beta.1

Addresses #153

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
