### PR TITLE
Changed BodyPartDefinition so that boost type is inferred from part type

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,3 @@
-// Type definitions for Screeps 3.0.1
 // Project: https://github.com/screeps/screeps
 // Definitions by: Marko Sulamägi <https://github.com/MarkoSulamagi>
 //                 Nhan Ho <https://github.com/NhanHo>
@@ -1700,24 +1699,27 @@ interface HeapStatistics {
 }
 
 /**
- * An array describing the creep’s body. Each element contains the following properties:
+ * Describes one part of a creep’s body.
  */
-interface BodyPartDefinition {
-    /**
-     * One of the `RESOURCE_*` constants.
-     *
-     * If the body part is boosted, this property specifies the mineral type which is used for boosting.
-     */
-    boost?: MineralBoostConstant;
-    /**
-     * One of the body part types constants.
-     */
-    type: BodyPartConstant;
-    /**
-     * The remaining amount of hit points of this body part.
-     */
-    hits: number;
-}
+type BodyPartDefinition<T extends BodyPartConstant = BodyPartConstant> = T extends any
+    ? {
+          /**
+           * One of the `RESOURCE_*` constants.
+           *
+           * If the body part is boosted, this property specifies the mineral type which is used for boosting.
+           */
+          boost?: keyof typeof BOOSTS[T];
+          /**
+           * One of the body part types constants.
+           */
+          type: T;
+          /**
+           * The remaining amount of hit points of this body part.
+           */
+          hits: number;
+      }
+    : never;
+
 interface Owner {
     /**
      * The name of the owner user.

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -821,3 +821,16 @@ function resources(o: GenericStore): ResourceConstant[] {
 
     const enemyTerrain = new Room.Terrain("W2N5");
 }
+
+// Creep.body
+function atackPower(creep: Creep) {
+    return creep.body
+        .map(part => {
+            if (part.type === ATTACK) {
+                const multiplier = part.boost ? BOOSTS[part.type][part.boost].attack : 1;
+                return multiplier * ATTACK_POWER;
+            }
+            return 0;
+        })
+        .reduce((a, b) => a + b);
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -118,24 +118,27 @@ interface HeapStatistics {
 }
 
 /**
- * An array describing the creep’s body. Each element contains the following properties:
+ * Describes one part of a creep’s body.
  */
-interface BodyPartDefinition {
-    /**
-     * One of the `RESOURCE_*` constants.
-     *
-     * If the body part is boosted, this property specifies the mineral type which is used for boosting.
-     */
-    boost?: MineralBoostConstant;
-    /**
-     * One of the body part types constants.
-     */
-    type: BodyPartConstant;
-    /**
-     * The remaining amount of hit points of this body part.
-     */
-    hits: number;
-}
+type BodyPartDefinition<T extends BodyPartConstant = BodyPartConstant> = T extends any
+    ? {
+          /**
+           * One of the `RESOURCE_*` constants.
+           *
+           * If the body part is boosted, this property specifies the mineral type which is used for boosting.
+           */
+          boost?: keyof typeof BOOSTS[T];
+          /**
+           * One of the body part types constants.
+           */
+          type: T;
+          /**
+           * The remaining amount of hit points of this body part.
+           */
+          hits: number;
+      }
+    : never;
+
 interface Owner {
     /**
      * The name of the owner user.


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

Changed `BodyPartDefinition` so that boost type is inferred from part type. This way
```ts
if (part.type === ATTACK && part.boost)
```
narrows `part.boost` down to `'UH' | 'UH2O' | 'XUH2O'`

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [X] Test passed
- [X] Coding style (indentation, etc)
- [X] Edits have been made to `src/` files not `index.d.ts`
- [X] Run `npm run dtslint` to update `index.d.ts`
