### PR TITLE
Allow owner to be undefined on StructureController

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -4668,11 +4668,11 @@ interface OwnedStructure<T extends StructureConstant = StructureConstant> extend
     /**
      * Whether this is your own structure. Walls and roads don't have this property as they are considered neutral structures.
      */
-    my: boolean;
+    my: T extends STRUCTURE_CONTROLLER ? boolean | undefined : boolean;
     /**
      * An object with the structure’s owner info (if present) containing the following properties: username
      */
-    owner: Owner;
+    owner: T extends STRUCTURE_CONTROLLER ? Owner | undefined : Owner;
     /**
      * The link to the Room object. Is always present because owned structures give visibility.
      */

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -668,9 +668,21 @@ function resources(o: GenericStore): ResourceConstant[] {
 
 // Advanced Structure types
 {
-    const owned = Game.getObjectById<AnyOwnedStructure>("blah");
-    const owner = owned!.owner.username;
-    owned!.notifyWhenAttacked(false);
+    const owned = Game.getObjectById<AnyOwnedStructure>("blah")!;
+    const owner = owned.owner && owned.owner.username;
+    owned.notifyWhenAttacked(false);
+
+    const structs = room.find(FIND_MY_STRUCTURES);
+    structs.forEach(struct => {
+        switch (struct.structureType) {
+            case STRUCTURE_CONTROLLER:
+                const usernameOptional: string | undefined = struct.owner && struct.owner.username;
+                break;
+            default:
+                const usernameRequired: string = struct.owner.username;
+                break;
+        }
+    });
 
     const unowned = Game.getObjectById<AnyStructure>("blah2")!;
     const hp = unowned.hits / unowned.hitsMax;

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -54,11 +54,11 @@ interface OwnedStructure<T extends StructureConstant = StructureConstant> extend
     /**
      * Whether this is your own structure. Walls and roads don't have this property as they are considered neutral structures.
      */
-    my: boolean;
+    my: T extends STRUCTURE_CONTROLLER ? boolean | undefined : boolean;
     /**
      * An object with the structure’s owner info (if present) containing the following properties: username
      */
-    owner: Owner;
+    owner: T extends STRUCTURE_CONTROLLER ? Owner | undefined : Owner;
     /**
      * The link to the Room object. Is always present because owned structures give visibility.
      */


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

Redefines `owner` and `my` properties on `OwnedStructure` to allow for `undefined` values if structure type is `STRUCTURE_CONTROLLER`.

Impacts `AnyOwnedStructure` type (ex. return type from `room.find(FIND_HOSTILE_STRUCTURES)`). Users will need to account for `owner` and `my` to be possibly undefined if not narrowing the type of the returned structure.

Technically the game engine defines [this behavior ](https://github.com/screeps/engine/blob/master/src/game/structures.js#L135-L140) for all owned structures but only controller appear to actually exhibit this behavior.

Fixes #159

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
