### PR TITLE
Fix tower.attack() to allow attacking structures

### DIFF
--- a/src/structure.ts
+++ b/src/structure.ts
@@ -395,10 +395,10 @@ interface StructureTower extends OwnedStructure<STRUCTURE_TOWER> {
     store: Store<RESOURCE_ENERGY, false>;
 
     /**
-     * Remotely attack any creep in the room. Consumes 10 energy units per tick. Attack power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
+     * Remotely attack any creep or structure in the room. Consumes 10 energy units per tick. Attack power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
      * @param target The target creep.
      */
-    attack(target: AnyCreep): ScreepsReturnCode;
+    attack(target: AnyCreep | Structure): ScreepsReturnCode;
     /**
      * Remotely heal any creep in the room. Consumes 10 energy units per tick. Heal power depends on the distance to the target: from 400 hits at range 10 to 200 hits at range 40.
      * @param target The target creep.


### PR DESCRIPTION
The official documentation for `tower.attack()` says:

> Remotely attack any creep, power creep or structure in the room.

<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

{Please write here}

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [ ] Test passed
- [ ] Coding style (indentation, etc)
- [ ] Edits have been made to `src/` files not `index.d.ts`
- [ ] Run `npm run dtslint` to update `index.d.ts`
