### PR TITLE
Fix tower.attack(), should allow structures to be attacked

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -5058,7 +5058,7 @@ interface StructureTower extends OwnedStructure<STRUCTURE_TOWER> {
     store: Store<RESOURCE_ENERGY, false>;
 
     /**
-     * Remotely attack any creep in the room. Consumes 10 energy units per tick. Attack power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
+     * Remotely attack any creep or structure in the room. Consumes 10 energy units per tick. Attack power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
      * @param target The target creep.
      */
     attack(target: AnyCreep | Structure): ScreepsReturnCode;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -5061,7 +5061,7 @@ interface StructureTower extends OwnedStructure<STRUCTURE_TOWER> {
      * Remotely attack any creep in the room. Consumes 10 energy units per tick. Attack power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
      * @param target The target creep.
      */
-    attack(target: AnyCreep): ScreepsReturnCode;
+    attack(target: AnyCreep | Structure): ScreepsReturnCode;
     /**
      * Remotely heal any creep in the room. Consumes 10 energy units per tick. Heal power depends on the distance to the target: from 400 hits at range 10 to 200 hits at range 40.
      * @param target The target creep.

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -569,6 +569,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     towers[0].attack(creeps[0]);
     towers[0].attack(creeps[0] as AnyCreep);
     towers[0].attack(powerCreep);
+    towers[0].attack(spawns[0]);
     towers[0].heal(powerCreep);
 }
 

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -395,7 +395,7 @@ interface StructureTower extends OwnedStructure<STRUCTURE_TOWER> {
     store: Store<RESOURCE_ENERGY, false>;
 
     /**
-     * Remotely attack any creep in the room. Consumes 10 energy units per tick. Attack power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
+     * Remotely attack any creep or structure in the room. Consumes 10 energy units per tick. Attack power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
      * @param target The target creep.
      */
     attack(target: AnyCreep | Structure): ScreepsReturnCode;

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -398,7 +398,7 @@ interface StructureTower extends OwnedStructure<STRUCTURE_TOWER> {
      * Remotely attack any creep in the room. Consumes 10 energy units per tick. Attack power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
      * @param target The target creep.
      */
-    attack(target: AnyCreep): ScreepsReturnCode;
+    attack(target: AnyCreep | Structure): ScreepsReturnCode;
     /**
      * Remotely heal any creep in the room. Consumes 10 energy units per tick. Heal power depends on the distance to the target: from 400 hits at range 10 to 200 hits at range 40.
      * @param target The target creep.


### PR DESCRIPTION
### Brief Description

The official documentation for `tower.attack()` says:

> Remotely attack any creep, power creep or structure in the room.

### Checklists

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
