### PR TITLE
Add InterShardResourceConstant, fix resources missing from MarketResourceConstant

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -741,7 +741,7 @@ declare const BOOSTS: {
     };
 };
 
-declare const INTERSHARD_RESOURCES: [SUBSCRIPTION_TOKEN, CPU_UNLOCK, PIXEL, ACCESS_KEY];
+declare const INTERSHARD_RESOURCES: InterShardResourceConstant[];
 
 declare const COMMODITIES: Record<
     CommodityConstant | MineralConstant | RESOURCE_GHODIUM | RESOURCE_ENERGY,
@@ -2430,7 +2430,8 @@ type CommodityConstant =
     | RESOURCE_EMANATION
     | RESOURCE_ESSENCE;
 
-type MarketResourceConstant = ResourceConstant | SUBSCRIPTION_TOKEN;
+type InterShardResourceConstant = SUBSCRIPTION_TOKEN | CPU_UNLOCK | PIXEL | ACCESS_KEY;
+type MarketResourceConstant = ResourceConstant | InterShardResourceConstant;
 
 type RESOURCE_ENERGY = "energy";
 type RESOURCE_POWER = "power";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -726,7 +726,7 @@ declare const BOOSTS: {
     };
 };
 
-declare const INTERSHARD_RESOURCES: [SUBSCRIPTION_TOKEN, CPU_UNLOCK, PIXEL, ACCESS_KEY];
+declare const INTERSHARD_RESOURCES: InterShardResourceConstant[];
 
 declare const COMMODITIES: Record<
     CommodityConstant | MineralConstant | RESOURCE_GHODIUM | RESOURCE_ENERGY,

--- a/src/literals.ts
+++ b/src/literals.ts
@@ -375,7 +375,8 @@ type CommodityConstant =
     | RESOURCE_EMANATION
     | RESOURCE_ESSENCE;
 
-type MarketResourceConstant = ResourceConstant | SUBSCRIPTION_TOKEN;
+type InterShardResourceConstant = SUBSCRIPTION_TOKEN | CPU_UNLOCK | PIXEL | ACCESS_KEY;
+type MarketResourceConstant = ResourceConstant | InterShardResourceConstant;
 
 type RESOURCE_ENERGY = "energy";
 type RESOURCE_POWER = "power";


### PR DESCRIPTION
### Brief Description

MarketResourceConstant was typed as `ResourceConstant | SUBSCRIPTION_TOKEN`. We now have `CPU_UNLOCK`, `PIXEL` and `ACCESS_KEY`, which were all missing.

I've created an InterShardResourceConstant type for these four resources and set MarketResourceConstant to `ResourceConstant | InterShardResourceConstant`.

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
