### PR TITLE
Fix typo in docstring

### DIFF
--- a/src/flag.ts
+++ b/src/flag.ts
@@ -17,7 +17,7 @@ interface Flag extends RoomObject {
      *
      * You can choose the name while creating a new flag, and it cannot be changed later.
      *
-     * This name is a hash key to access the spawn via the `Game.flags` object. The maximum name length is 60 characters.
+     * This name is a hash key to access the flag via the `Game.flags` object. The maximum name length is 60 characters.
      */
     name: string;
     /**


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

Just a simple typo fix in the Flag interface : `spawn` -> `flag` 🕵️

Also, thanks for the work on this types module! 👍
