### PR TITLE
Fixing function documentation. 10k per pixel

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -112,7 +112,7 @@ interface CPU {
      */
     halt?(): never;
     /**
-     * Generate 1 pixel resource unit for 5000 CPU from your bucket.
+     * Generate 1 pixel resource unit for 10000 CPU from your bucket.
      */
     generatePixel(): OK | ERR_NOT_ENOUGH_RESOURCES;
 


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

I just corrected the comment string for `Game.cpu.generatePixel()` which said it generates 1 pixel for every 5k CPU. It is actually 10k pixel as per the [docs](https://docs.screeps.com/api/#Game.cpu.generatePixel)

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [ ] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [ ] Run `npm run dtslint` to update `index.d.ts`
