### PR TITLE
Dtslint assert types

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1588,7 +1588,7 @@ interface Game {
      * @param groupInterval If set to 0 (default), the notification will be scheduled immediately.
      * Otherwise, it will be grouped with other notifications and mailed out later using the specified time in minutes.
      */
-    notify(message: string, groupInterval?: number): undefined;
+    notify(message: string, groupInterval?: number): void;
 }
 
 declare var Game: Game;
@@ -2762,7 +2762,7 @@ type EFFECT_COLLAPSE_TIMER = 1002;
  * The options that can be accepted by `findRoute()` and friends.
  */
 interface RouteOptions {
-    routeCallback: (roomName: string, fromRoomName: string) => any;
+    routeCallback: (roomName: string, fromRoomName: string) => number;
 }
 
 interface RoomStatusPermanent {

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1567,7 +1567,7 @@ interface Game {
      * @param id The unique identifier.
      * @returns an object instance or null if it cannot be found.
      */
-    getObjectById<T>(id: Id<T>): T | null;
+    getObjectById<T extends Id<any>>(id: T): fromId<T> | null;
 
     /**
      * Get an object with the specified unique ID. It may be a game object of any type. Only objects from the rooms which are visible to you can be accessed.
@@ -2027,6 +2027,7 @@ declare namespace Tag {
     }
 }
 type Id<T> = string & Tag.OpaqueTag<T>;
+type fromId<T> = T extends Id<infer R> ? R : never;
 /**
  * `InterShardMemory` object provides an interface for communicating between shards.
  * Your script is executed separatedly on each shard, and their `Memory` objects are isolated from each other.

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -287,8 +287,8 @@ function resources(o: GenericStore): ResourceConstant[] {
 }
 
 {
+    // $ExpectType -2 | { exit: ExitConstant; room: string; }[]
     const route = Game.map.findRoute(creep.room, anotherRoomName, {
-        // $ExpectType -2 | { exit: ExitConstant; room: string; }[]
         routeCallback(roomName, fromRoomName) {
             if (roomName === "W10S10") {
                 // avoid this room
@@ -306,8 +306,8 @@ function resources(o: GenericStore): ResourceConstant[] {
     // Use `findRoute` to calculate a high-level plan for this path,
     // prioritizing highways and owned rooms
     const allowedRooms = { [from.roomName]: true };
+    // $ExpectType -2 | { exit: ExitConstant; room: string; }[]
     const route = Game.map.findRoute(from.roomName, to.roomName, {
-        // $ExpectType -2 | { exit: ExitConstant; room: string; }[]
         routeCallback(roomName) {
             const parsed = /^[WE]([0-9]+)[NS]([0-9]+)$/.exec(roomName);
             if (parsed !== null) {
@@ -331,8 +331,8 @@ function resources(o: GenericStore): ResourceConstant[] {
     }
 
     // Invoke PathFinder, allowing access only to rooms from `findRoute`
+    // $ExpectType PathFinderPath
     const ret = PathFinder.search(from, [to], {
-        // $ExpectType PathFinderPath
         roomCallback: roomName => {
             if (allowedRooms[roomName] === undefined) {
                 return false;
@@ -415,8 +415,8 @@ function resources(o: GenericStore): ResourceConstant[] {
     Game.market.getAllOrders({ type: ORDER_SELL, resourceType: RESOURCE_GHODIUM }); // $ExpectType Order[]
 
     const targetRoom = "W1N1";
+    // $ExpectType Order[]
     Game.market.getAllOrders(
-        // $ExpectType Order[]
         currentOrder =>
             currentOrder.resourceType === RESOURCE_GHODIUM &&
             currentOrder.type === ORDER_SELL &&
@@ -452,8 +452,8 @@ function resources(o: GenericStore): ResourceConstant[] {
         return { pos: source.pos, range: 1 };
     });
 
+    // $ExpectType PathFinderPath
     const ret = PathFinder.search(pfCreep.pos, goals, {
-        // $ExpectType PathFinderPath
         // We need to set the defaults costs higher so that we
         // can set the road cost lower in `roomCallback`
         plainCost: 2,
@@ -586,8 +586,8 @@ function resources(o: GenericStore): ResourceConstant[] {
     const sites = room.find(FIND_CONSTRUCTION_SITES); // $ExpectType ConstructionSite<BuildableStructureConstant>[]
     sites[0].remove();
 
+    // $ExpectType ConstructionSite<"extension">[]
     const extensionsites = room.find(FIND_CONSTRUCTION_SITES, {
-        // $ExpectType ConstructionSite<"extension">[]
         filter: (site): site is ConstructionSite<STRUCTURE_EXTENSION> => {
             return site.structureType === STRUCTURE_EXTENSION;
         },
@@ -601,8 +601,8 @@ function resources(o: GenericStore): ResourceConstant[] {
     const creepsHere = room.lookForAt(LOOK_CREEPS, 10, 10); // $ExpectType Creep[]
     creepsHere[0].getActiveBodyparts(ATTACK);
 
+    // $ExpectType StructureTower[]
     const towers = room.find<StructureTower>(FIND_MY_STRUCTURES, {
-        // $ExpectType StructureTower[]
         filter: structure => {
             return structure.structureType === STRUCTURE_TOWER;
         },
@@ -617,8 +617,8 @@ function resources(o: GenericStore): ResourceConstant[] {
         return structure.structureType === STRUCTURE_TOWER;
     };
 
+    // $ExpectType StructureTower
     const tower = room.find(FIND_MY_STRUCTURES, {
-        // $ExpectType StructureTower
         filter: isTower,
     })[0];
     tower.attack(creeps[0]);
@@ -637,8 +637,8 @@ function resources(o: GenericStore): ResourceConstant[] {
         creep.say(hostileCreep.name);
     }
 
+    // $ExpectType StructureTower | null
     const tower = creep.pos.findClosestByPath<StructureTower>(FIND_HOSTILE_STRUCTURES, {
-        // $ExpectType StructureTower | null
         filter: structure => {
             return structure.structureType === STRUCTURE_TOWER;
         },
@@ -656,8 +656,8 @@ function resources(o: GenericStore): ResourceConstant[] {
         };
     };
 
+    // $ExpectType StructureTower | null
     const tower2 = creep.pos.findClosestByPath(FIND_HOSTILE_STRUCTURES, {
-        // $ExpectType StructureTower | null
         filter: isStructureType(STRUCTURE_TOWER),
         algorithm: "astar",
     });
@@ -672,8 +672,8 @@ function resources(o: GenericStore): ResourceConstant[] {
         filter: p => p.getDirectionTo(creep) === TOP,
     });
 
+    // $ExpectType StructureRampart | null
     const rampart = creep.pos.findClosestByRange<StructureRampart>(FIND_HOSTILE_STRUCTURES, {
-        // $ExpectType StructureRampart | null
         filter: structure => {
             return structure.structureType === STRUCTURE_RAMPART;
         },
@@ -686,8 +686,8 @@ function resources(o: GenericStore): ResourceConstant[] {
     const hostileCreeps = creep.pos.findInRange(FIND_HOSTILE_CREEPS, 10); // $ExpectType Creep[]
     hostileCreeps[0].saying;
 
+    // $ExpectType StructureLab[]
     const labs = creep.pos.findInRange<StructureLab>(FIND_MY_STRUCTURES, 4, {
-        // $ExpectType StructureLab[]
         filter: structure => {
             return structure.structureType === STRUCTURE_LAB;
         },

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -41,13 +41,14 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Game object Id types
 {
     const creepId: Id<Creep> = "1" as Id<Creep>;
-    const creepOne: Creep | null = Game.getObjectById(creepId);
-    const creepTwo: Creep | null = Game.getObjectById<Creep>("2"); // deprecated
-    const creepThree: Creep = new Creep(creepId); // Works with typed ID
+    const creepOne: Creep | null = Game.getObjectById(creepId); // $ExpectType Creep | null
+    const creepTwo: Creep | null = Game.getObjectById<Creep>("2"); // deprecated $ExpectType Creep | null
+    // Works with typed ID
+    const creepThree: Creep = new Creep(creepId); // $ExpectType Creep
 
     if (creepOne) {
-        creepOne.hits;
-        const recycle = Game.getObjectById(creepOne.id);
+        creepOne.hits; // $ExpectType number
+        const recycle = Game.getObjectById(creepOne.id); // $ExpectType Creep | null
     }
 
     type StoreStructure = StructureContainer | StructureStorage | StructureLink;
@@ -55,8 +56,8 @@ function resources(o: GenericStore): ResourceConstant[] {
     const storeIdUnion: StoreStructure["id"] = "1234" as StoreStructure["id"];
     const stringID: string = storeUnionID; // Id<T> assignable implicitly to string
     const stringID2: string = storeIdUnion; // Id<T> assignable implicitly to string
-    const storeObject = Game.getObjectById(storeUnionID)!;
-    const storeObject2 = Game.getObjectById(storeIdUnion)!;
+    const storeObject = Game.getObjectById(storeUnionID)!; // $ExpectType StoreStructure
+    const storeObject2 = Game.getObjectById(storeIdUnion)!; // $ExpectType StructureContainer | StructureStorage | StructureLink
 
     // Object recognized
     switch (storeObject.structureType) {
@@ -69,7 +70,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     }
 
     // Default type is unknown if untyped Id provided
-    const untyped = Game.getObjectById("untyped");
+    const untyped = Game.getObjectById("untyped"); // $ExpectType unknown
 }
 
 // Game.creeps
@@ -92,7 +93,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     PowerCreep.create("steve", POWER_CLASS.OPERATOR) === OK;
 
     for (const i in Game.powerCreeps) {
-        const powerCreep = Game.powerCreeps[i];
+        const powerCreep = Game.powerCreeps[i]; // $ExpectType PowerCreep
 
         if (powerCreep.ticksToLive === undefined) {
             // Not spawned in world; spawn creep
@@ -109,7 +110,7 @@ function resources(o: GenericStore): ResourceConstant[] {
             } else {
                 // Boost resource
                 const targetSource = Game.getObjectById("targetSourceID") as Source;
-                const sourceEffect = targetSource.effects.find(effect => effect.effect === PWR_REGEN_SOURCE && effect.level > 0);
+                const sourceEffect = targetSource.effects.find(effect => effect.effect === PWR_REGEN_SOURCE && effect.level > 0); // $ExpectType RoomObjectEffect | undefined
                 if (!sourceEffect && powerCreep.powers[PWR_REGEN_SOURCE] && powerCreep.powers[PWR_REGEN_SOURCE].cooldown === 0) {
                     powerCreep.usePower(PWR_REGEN_SOURCE, targetSource);
                 }
@@ -128,7 +129,7 @@ function resources(o: GenericStore): ResourceConstant[] {
         powerCreep.upgrade(PWR_GENERATE_OPS);
     }
 
-    const myPowaCreeps = Game.rooms.sim.find(FIND_MY_POWER_CREEPS);
+    const myPowaCreeps = Game.rooms.sim.find(FIND_MY_POWER_CREEPS); // $ExpectType PowerCreep[]
 
     // Constant type checking
     POWER_INFO[PWR_GENERATE_OPS].className === POWER_CLASS.OPERATOR;
@@ -142,24 +143,24 @@ function resources(o: GenericStore): ResourceConstant[] {
         Game.spawns[i].createCreep(body);
 
         // Test StructureSpawn.Spawning
-        let creep: Spawning | null = Game.spawns[i].spawning;
+        let creep = Game.spawns[i].spawning; // $ExpectType Spawning | null
         if (creep) {
-            const name: string = creep.name;
-            const needTime: number = creep.needTime;
-            const remainingTime: number = creep.remainingTime;
-            const creepSpawn: StructureSpawn = creep.spawn;
+            const name: string = creep.name; // $ExpectType string
+            const needTime: number = creep.needTime; // $ExpectType number
+            const remainingTime: number = creep.remainingTime; // $ExpectType number
+            const creepSpawn: StructureSpawn = creep.spawn; // $ExpectType StructureSpawn
 
             const cancelStatus: OK | ERR_NOT_OWNER = creep.cancel();
             const setDirectionStatus: OK | ERR_NOT_OWNER | ERR_INVALID_ARGS = creep.setDirections([TOP, BOTTOM, LEFT, RIGHT]);
         }
 
-        creep = new StructureSpawn.Spawning("" as Id<Spawning>);
-        creep = StructureSpawn.Spawning("" as Id<Spawning>);
+        creep = new StructureSpawn.Spawning("" as Id<Spawning>); // $ExpectType Spawning
+        creep = StructureSpawn.Spawning("" as Id<Spawning>); // $ExpectType Spawning
 
         const invaderCore = new StructureInvaderCore("" as Id<StructureInvaderCore>);
-        const invader = invaderCore.spawning;
+        const invader = invaderCore.spawning; // $ExpectType Spawning | null
         if (invader) {
-            const name = invader.name;
+            const name = invader.name; // $ExpectType string
         }
     }
 }
@@ -167,7 +168,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Game.time
 
 {
-    let time = Game.time;
+    let time = Game.time; // $ExpectType number
     time += 1;
 }
 
@@ -181,11 +182,11 @@ function resources(o: GenericStore): ResourceConstant[] {
 
 {
     for (const name in Game.creeps) {
-        const startCpu = Game.cpu.getUsed();
+        const startCpu = Game.cpu.getUsed(); // $ExpectType number
 
         // creep logic goes here
 
-        const elapsed = Game.cpu.getUsed() - startCpu;
+        const elapsed = Game.cpu.getUsed() - startCpu; // $ExpectType number
     }
 }
 
@@ -198,7 +199,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Game.cpu.halt()
 {
     if (Game.cpu.hasOwnProperty("halt")) {
-        Game.cpu.halt!();
+        Game.cpu.halt!(); // $ExpectType never
     }
 }
 
@@ -217,17 +218,17 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Game.getObjectById(id)
 
 {
-    creep.memory.sourceId = creep.pos.findClosestByRange(FIND_SOURCES)!.id;
-    const source = Game.getObjectById<Source>(creep.memory.sourceId);
+    creep.memory.sourceId = creep.pos.findClosestByRange(FIND_SOURCES)!.id; // $ExpectType Id<Source>
+    const source = Game.getObjectById(creep.memory.sourceId); // $ExpectType Source | null
 }
 
 // Game.notify(message, [groupInterval])
 
 {
     if (creep.hits < creep.memory.lastHits) {
-        Game.notify(`Creep ${creep} has been attacked at ${creep.pos}!`);
+        Game.notify(`Creep ${creep} has been attacked at ${creep.pos}!`); // $ExpectType void
     }
-    creep.memory.lastHits = creep.hits;
+    creep.memory.lastHits = creep.hits; // $ExpectType number
 }
 
 {
@@ -242,12 +243,12 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Game.map.describeExits()
 
 {
-    const exits = Game.map.describeExits("W8N3");
+    const exits: ExitsInformation = Game.map.describeExits("W8N3"); // $ExpectType ExitsInformation
     // tslint:disable-next-line:newline-per-chained-call
     keys(exits).map(exitKey => {
-        const nextRoom = exits[exitKey];
+        const nextRoom = exits[exitKey]; // $ExpectType string | undefined
         const exitDir = +exitKey as ExitConstant;
-        const exitPos = creep.pos.findClosestByRange(exitDir);
+        const exitPos = creep.pos.findClosestByRange(exitDir); // $ExpectType RoomPosition | null
         return { nextRoom, exitPos };
     });
 }
@@ -258,7 +259,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     if (creep.room !== anotherRoomName) {
         const exitDir = Game.map.findExit(creep.room, anotherRoomName);
         if (exitDir !== ERR_NO_PATH && exitDir !== ERR_INVALID_ARGS) {
-            const exit = creep.pos.findClosestByRange(exitDir);
+            const exit = creep.pos.findClosestByRange(exitDir); // $ExpectType RoomPosition | null
             if (exit !== null) {
                 creep.moveTo(exit);
             }
@@ -275,10 +276,10 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Game.map.findRoute()
 
 {
-    const route = Game.map.findRoute(creep.room, anotherRoomName);
+    const route = Game.map.findRoute(creep.room, anotherRoomName); // $ExpectType -2 | { exit: ExitConstant; room: string; }[]
 
     if (route !== ERR_NO_PATH && route.length > 0) {
-        const exit = creep.pos.findClosestByRange(route[0].exit);
+        const exit = creep.pos.findClosestByRange(route[0].exit); // $ExpectType RoomPosition | null
         if (exit !== null) {
             creep.moveTo(exit);
         }
@@ -287,6 +288,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 
 {
     const route = Game.map.findRoute(creep.room, anotherRoomName, {
+        // $ExpectType -2 | { exit: ExitConstant; room: string; }[]
         routeCallback(roomName, fromRoomName) {
             if (roomName === "W10S10") {
                 // avoid this room
@@ -305,6 +307,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     // prioritizing highways and owned rooms
     const allowedRooms = { [from.roomName]: true };
     const route = Game.map.findRoute(from.roomName, to.roomName, {
+        // $ExpectType -2 | { exit: ExitConstant; room: string; }[]
         routeCallback(roomName) {
             const parsed = /^[WE]([0-9]+)[NS]([0-9]+)$/.exec(roomName);
             if (parsed !== null) {
@@ -329,6 +332,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 
     // Invoke PathFinder, allowing access only to rooms from `findRoute`
     const ret = PathFinder.search(from, [to], {
+        // $ExpectType PathFinderPath
         roomCallback: roomName => {
             if (allowedRooms[roomName] === undefined) {
                 return false;
@@ -342,7 +346,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Game.map.getRoomLinearDistance(roomName1, roomName2, [continuous])
 
 {
-    Game.map.getRoomLinearDistance("W1N1", "W4N2"); // 3
+    Game.map.getRoomLinearDistance("W1N1", "W4N2"); // 3 $ExpectType number
     Game.map.getRoomLinearDistance("E65S55", "W65S55", false); // 131
     Game.map.getRoomLinearDistance("E65S55", "W65S55", true); // 11
 }
@@ -351,17 +355,17 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Game.map.getTerrainAt(pos)
 
 {
-    Game.map.getTerrainAt(25, 20, "W10N10");
+    Game.map.getTerrainAt(25, 20, "W10N10"); // $ExpectType Terrain
 }
 
 {
-    Game.map.getTerrainAt(new RoomPosition(25, 20, "W10N10"));
+    Game.map.getTerrainAt(new RoomPosition(25, 20, "W10N10")); // $ExpectType Terrain
 }
 
 // Game.map.getRoomStatus(roomName)
 
 {
-    const roomStatus = Game.map.getRoomStatus(room.name);
+    const roomStatus = Game.map.getRoomStatus(room.name); // $ExpectType RoomStatus
     if (roomStatus.status === "normal") {
         creep.moveTo(room.getPositionAt(25, 25)!);
     }
@@ -371,47 +375,48 @@ function resources(o: GenericStore): ResourceConstant[] {
 
 {
     // Game.market.calcTransactionCost(amount, roomName1, roomName2)
-    const cost = Game.market.calcTransactionCost(1000, "W0N0", "W10N5");
+    const cost = Game.market.calcTransactionCost(1000, "W0N0", "W10N5"); // $ExpectType number
 
     // Game.market.cancelOrder(orderId)
     for (const id in Game.market.orders) {
-        Game.market.cancelOrder(id);
+        Game.market.cancelOrder(id); // $ExpectType ScreepsReturnCode
     }
 
     // Game.market.changeOrderPrice(orderId, newPrice)
-    Game.market.changeOrderPrice("57bec1bf77f4d17c4c011960", 9.95);
+    Game.market.changeOrderPrice("57bec1bf77f4d17c4c011960", 9.95); // $ExpectType ScreepsReturnCode
 
     // Game.market.createOrder({type, resourceType, price, totalAmount, [roomName]})
-    Game.market.createOrder({ type: ORDER_SELL, resourceType: RESOURCE_GHODIUM, price: 9.95, totalAmount: 10000, roomName: "W1N1" });
-    Game.market.createOrder({ type: ORDER_SELL, resourceType: RESOURCE_GHODIUM, price: 9.95, totalAmount: 10000 });
+    Game.market.createOrder({ type: ORDER_SELL, resourceType: RESOURCE_GHODIUM, price: 9.95, totalAmount: 10000, roomName: "W1N1" }); // $ExpectType ScreepsReturnCode
+    Game.market.createOrder({ type: ORDER_SELL, resourceType: RESOURCE_GHODIUM, price: 9.95, totalAmount: 10000 }); // $ExpectType ScreepsReturnCode
 
     // Game.market.deal(orderId, amount, [yourRoomName])
-    Game.market.deal("57cd2b12cda69a004ae223a3", 1000, "W1N1");
+    Game.market.deal("57cd2b12cda69a004ae223a3", 1000, "W1N1"); // $ExpectType ScreepsReturnCode
 
     const amountToBuy = 2000;
     const maxTransferEnergyCost = 500;
-    const orders = Game.market.getAllOrders({ type: ORDER_SELL, resourceType: RESOURCE_GHODIUM });
+    const orders = Game.market.getAllOrders({ type: ORDER_SELL, resourceType: RESOURCE_GHODIUM }); // $ExpectType Order[]
 
     for (const i of orders) {
         if (i.roomName) {
-            const transferEnergyCost = Game.market.calcTransactionCost(amountToBuy, "W1N1", i.roomName);
+            const transferEnergyCost = Game.market.calcTransactionCost(amountToBuy, "W1N1", i.roomName); // $ExpectType number
 
             if (transferEnergyCost < maxTransferEnergyCost) {
-                Game.market.deal(i.id, amountToBuy, "W1N1");
+                Game.market.deal(i.id, amountToBuy, "W1N1"); // $ExpectType ScreepsReturnCode
                 break;
             }
         }
     }
 
     // Game.market.extendOrder(orderId, addAmount)
-    Game.market.extendOrder("57bec1bf77f4d17c4c011960", 10000);
+    Game.market.extendOrder("57bec1bf77f4d17c4c011960", 10000); // $ExpectType ScreepsReturnCode
 
     // Game.market.getAllOrders([filter])
-    Game.market.getAllOrders();
-    Game.market.getAllOrders({ type: ORDER_SELL, resourceType: RESOURCE_GHODIUM });
+    Game.market.getAllOrders(); // $ExpectType Order[]
+    Game.market.getAllOrders({ type: ORDER_SELL, resourceType: RESOURCE_GHODIUM }); // $ExpectType Order[]
 
     const targetRoom = "W1N1";
     Game.market.getAllOrders(
+        // $ExpectType Order[]
         currentOrder =>
             currentOrder.resourceType === RESOURCE_GHODIUM &&
             currentOrder.type === ORDER_SELL &&
@@ -419,27 +424,26 @@ function resources(o: GenericStore): ResourceConstant[] {
     );
 
     // Game.market.getOrderById(id)
-    const order = Game.market.getOrderById("55c34a6b5be41a0a6e80c123");
+    const order = Game.market.getOrderById("55c34a6b5be41a0a6e80c123"); // $ExpectType Order | null
 
     // Subscription tokens
-    Game.market.getAllOrders({ type: ORDER_SELL, resourceType: SUBSCRIPTION_TOKEN });
-    Game.market.createOrder({ type: ORDER_BUY, resourceType: SUBSCRIPTION_TOKEN, totalAmount: 10000000, price: 1 });
-
-    const priceHistory = Game.market.getHistory(RESOURCE_FIXTURES);
+    Game.market.getAllOrders({ type: ORDER_SELL, resourceType: SUBSCRIPTION_TOKEN }); // $ExpectType Order[]
+    Game.market.createOrder({ type: ORDER_BUY, resourceType: SUBSCRIPTION_TOKEN, totalAmount: 10000000, price: 1 }); // $ExpectType ScreepsReturnCode
+    const priceHistory = Game.market.getHistory(RESOURCE_FIXTURES); // $ExpectType PriceHistory[]
 
     const avgPrice: number = priceHistory[0].avgPrice;
     const stddevPrice: number = priceHistory[0].stddevPrice;
     const volume: number = priceHistory[0].volume;
 
     // Game.market.getHistory([resourceType])
-    const energyHistory = Game.market.getHistory(RESOURCE_ENERGY);
-    const pixelHistory = Game.market.getHistory(PIXEL);
+    const energyHistory = Game.market.getHistory(RESOURCE_ENERGY); // $ExpectType PriceHistory[]
+    const pixelHistory = Game.market.getHistory(PIXEL); // $ExpectType PriceHistory[]
 }
 
 // PathFinder
 
 {
-    const pfCreep = Game.creeps.John;
+    const pfCreep = Game.creeps.John; // $ExpectType Creep
 
     // tslint:disable-next-line:newline-per-chained-call
     const goals = pfCreep.room.find(FIND_SOURCES).map(source => {
@@ -449,13 +453,15 @@ function resources(o: GenericStore): ResourceConstant[] {
     });
 
     const ret = PathFinder.search(pfCreep.pos, goals, {
+        // $ExpectType PathFinderPath
         // We need to set the defaults costs higher so that we
         // can set the road cost lower in `roomCallback`
         plainCost: 2,
         swampCost: 10,
 
         roomCallback(roomName) {
-            const curRoom = Game.rooms[roomName];
+            const curRoom = Game.rooms[roomName]; // $ExpectType Room
+
             // In this example `room` will always exist, but since
             // PathFinder supports searches which span multiple rooms
             // you should be careful!
@@ -488,7 +494,7 @@ function resources(o: GenericStore): ResourceConstant[] {
         },
     });
 
-    const pos = ret.path[0];
+    const pos = ret.path[0]; // $ExpectType RoomPosition
     pfCreep.move(pfCreep.pos.getDirectionTo(pos));
 }
 
@@ -562,25 +568,26 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Find Overloads
 
 {
-    const creeps = room.find(FIND_HOSTILE_CREEPS);
+    const creeps = room.find(FIND_HOSTILE_CREEPS); // $ExpectType Creep[]
     creeps[0].say(creeps[1].name);
 
-    const flags = room.find(FIND_FLAGS);
+    const flags = room.find(FIND_FLAGS); // $ExpectType Flag[]
     flags[0].remove();
 
-    const spawns = room.find(FIND_HOSTILE_SPAWNS);
+    const spawns = room.find(FIND_HOSTILE_SPAWNS); // $ExpectType StructureSpawn[]
     spawns[0].spawning;
 
-    const sources = room.find(FIND_SOURCES);
+    const sources = room.find(FIND_SOURCES); // $ExpectType Source[]
     sources[0].ticksToRegeneration;
 
-    const resources = room.find(FIND_DROPPED_RESOURCES);
+    const resources = room.find(FIND_DROPPED_RESOURCES); // $ExpectType Resource<ResourceConstant>[]
     resources[0].resourceType;
 
-    const sites = room.find(FIND_CONSTRUCTION_SITES);
+    const sites = room.find(FIND_CONSTRUCTION_SITES); // $ExpectType ConstructionSite<BuildableStructureConstant>[]
     sites[0].remove();
 
     const extensionsites = room.find(FIND_CONSTRUCTION_SITES, {
+        // $ExpectType ConstructionSite<"extension">[]
         filter: (site): site is ConstructionSite<STRUCTURE_EXTENSION> => {
             return site.structureType === STRUCTURE_EXTENSION;
         },
@@ -589,12 +596,13 @@ function resources(o: GenericStore): ResourceConstant[] {
     extensionsites[0].structureType === STRUCTURE_EXTENSION;
 
     // Should have type (_HasRoomPosition | RoomPosition)[]
-    const exits = room.find(FIND_EXIT);
+    const exits = room.find(FIND_EXIT); // $ExpectType RoomPosition[]
 
-    const creepsHere = room.lookForAt(LOOK_CREEPS, 10, 10);
+    const creepsHere = room.lookForAt(LOOK_CREEPS, 10, 10); // $ExpectType Creep[]
     creepsHere[0].getActiveBodyparts(ATTACK);
 
     const towers = room.find<StructureTower>(FIND_MY_STRUCTURES, {
+        // $ExpectType StructureTower[]
         filter: structure => {
             return structure.structureType === STRUCTURE_TOWER;
         },
@@ -610,6 +618,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     };
 
     const tower = room.find(FIND_MY_STRUCTURES, {
+        // $ExpectType StructureTower
         filter: isTower,
     })[0];
     tower.attack(creeps[0]);
@@ -623,12 +632,13 @@ function resources(o: GenericStore): ResourceConstant[] {
 
 {
     // Should have type Creep
-    const hostileCreep = creep.pos.findClosestByRange(FIND_HOSTILE_CREEPS);
+    const hostileCreep = creep.pos.findClosestByRange(FIND_HOSTILE_CREEPS); // $ExpectType Creep | null
     if (hostileCreep !== null) {
         creep.say(hostileCreep.name);
     }
 
     const tower = creep.pos.findClosestByPath<StructureTower>(FIND_HOSTILE_STRUCTURES, {
+        // $ExpectType StructureTower | null
         filter: structure => {
             return structure.structureType === STRUCTURE_TOWER;
         },
@@ -647,6 +657,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     };
 
     const tower2 = creep.pos.findClosestByPath(FIND_HOSTILE_STRUCTURES, {
+        // $ExpectType StructureTower | null
         filter: isStructureType(STRUCTURE_TOWER),
         algorithm: "astar",
     });
@@ -655,13 +666,14 @@ function resources(o: GenericStore): ResourceConstant[] {
         tower2.attack(powerCreep);
     }
 
-    const creepWithEnergy = creep.pos.findClosestByPath(creep.room.find(FIND_CREEPS), { filter: c => c.store.energy > 0 });
+    const creepWithEnergy = creep.pos.findClosestByPath(creep.room.find(FIND_CREEPS), { filter: c => c.store.energy > 0 }); // $ExpectType Creep | null
 
     const creepAbove = creep.pos.findClosestByPath(creep.room.find(FIND_CREEPS).map(c => c.pos), {
         filter: p => p.getDirectionTo(creep) === TOP,
     });
 
     const rampart = creep.pos.findClosestByRange<StructureRampart>(FIND_HOSTILE_STRUCTURES, {
+        // $ExpectType StructureRampart | null
         filter: structure => {
             return structure.structureType === STRUCTURE_RAMPART;
         },
@@ -671,10 +683,11 @@ function resources(o: GenericStore): ResourceConstant[] {
     }
 
     // Should have type Creep[]
-    const hostileCreeps = creep.pos.findInRange(FIND_HOSTILE_CREEPS, 10);
+    const hostileCreeps = creep.pos.findInRange(FIND_HOSTILE_CREEPS, 10); // $ExpectType Creep[]
     hostileCreeps[0].saying;
 
     const labs = creep.pos.findInRange<StructureLab>(FIND_MY_STRUCTURES, 4, {
+        // $ExpectType StructureLab[]
         filter: structure => {
             return structure.structureType === STRUCTURE_LAB;
         },
@@ -686,7 +699,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 // LookAt Finds
 
 {
-    const matrix = room.lookAtArea(10, 10, 20, 20, false);
+    const matrix = room.lookAtArea(10, 10, 20, 20, false); // $ExpectType LookAtResultMatrix<LookConstant>
     for (const y in matrix) {
         const row = matrix[y];
         for (const x in row) {
@@ -698,18 +711,18 @@ function resources(o: GenericStore): ResourceConstant[] {
         }
     }
 
-    const nukes = room.lookForAt(LOOK_NUKES, creep.pos);
+    const nukes = room.lookForAt(LOOK_NUKES, creep.pos); // $ExpectType Nuke[]
 
     nukes[0].launchRoomName;
 
-    const flags = room.lookForAtArea(LOOK_FLAGS, 10, 10, 20, 20);
+    const flags = room.lookForAtArea(LOOK_FLAGS, 10, 10, 20, 20); // $ExpectType LookForAtAreaResultMatrix<Flag, "flag">
 
     const x = flags[10];
     const y = x[11];
     const entry = y[0];
     entry.flag.remove();
 
-    const creeps = room.lookForAtArea(LOOK_CREEPS, 10, 10, 20, 20, true);
+    const creeps = room.lookForAtArea(LOOK_CREEPS, 10, 10, 20, 20, true); // $ExpectType LookForAtAreaResultArray<Creep, "creep">
 
     creeps[0].x;
     creeps[0].y;
@@ -726,29 +739,29 @@ function resources(o: GenericStore): ResourceConstant[] {
 
     const extension = new StructureExtension("" as Id<StructureExtension>);
 
-    const e1: number = extension.store.getUsedCapacity(RESOURCE_ENERGY);
-    const e2: number = extension.store[RESOURCE_ENERGY];
+    const e1: number = extension.store.getUsedCapacity(RESOURCE_ENERGY); // $ExpectType number
+    const e2: number = extension.store[RESOURCE_ENERGY]; // $ExpectType number
 
     // Invalid resource type for extension
-    const eg1: null = extension.store.getUsedCapacity(RESOURCE_GHODIUM);
-    const eg2: null = extension.store.getFreeCapacity(RESOURCE_GHODIUM);
-    const eg3: null = extension.store.getCapacity(RESOURCE_GHODIUM);
-    const eg4: 0 = extension.store.G;
+    const eg1: null = extension.store.getUsedCapacity(RESOURCE_GHODIUM); // $ExpectType null
+    const eg2: null = extension.store.getFreeCapacity(RESOURCE_GHODIUM); // $ExpectType null
+    const eg3: null = extension.store.getCapacity(RESOURCE_GHODIUM); // $ExpectType null
+    const eg4: 0 = extension.store.G; // $ExpectType 0
 
     const storage = new StructureStorage("" as Id<StructureStorage>);
 
-    const sg1: number = storage.store.getUsedCapacity(RESOURCE_GHODIUM);
-    const sg2: number = storage.store.getFreeCapacity(RESOURCE_GHODIUM);
-    const sg3: number = storage.store.getCapacity(RESOURCE_GHODIUM);
+    const sg1: number = storage.store.getUsedCapacity(RESOURCE_GHODIUM); // $ExpectType number
+    const sg2: number = storage.store.getFreeCapacity(RESOURCE_GHODIUM); // $ExpectType number
+    const sg3: number = storage.store.getCapacity(RESOURCE_GHODIUM); // $ExpectType number
 }
 
 // Advanced Structure types
 {
-    const owned = Game.getObjectById<AnyOwnedStructure>("blah")!;
-    const owner = owned.owner && owned.owner.username;
+    const owned = Game.getObjectById<AnyOwnedStructure>("blah")!; // $ExpectType AnyOwnedStructure
+    const owner = owned.owner && owned.owner.username; // $ExpectType string | undefined
     owned.notifyWhenAttacked(false);
 
-    const structs = room.find(FIND_MY_STRUCTURES);
+    const structs = room.find(FIND_MY_STRUCTURES); // $ExpectType AnyOwnedStructure[]
     structs.forEach(struct => {
         switch (struct.structureType) {
             case STRUCTURE_CONTROLLER:
@@ -760,17 +773,19 @@ function resources(o: GenericStore): ResourceConstant[] {
         }
     });
 
-    const unowned = Game.getObjectById<AnyStructure>("blah2")!;
+    const unowned = Game.getObjectById<AnyStructure>("blah2")!; // $ExpectType AnyStructure
     const hp = unowned.hits / unowned.hitsMax;
 
     // test discriminated union
     switch (unowned.structureType) {
         case STRUCTURE_TOWER:
+            unowned; // $ExpectType StructureTower
             unowned.heal(Game.creeps.myCreep);
             break;
         case STRUCTURE_CONTAINER:
         case STRUCTURE_STORAGE:
         case STRUCTURE_TERMINAL:
+            unowned.store; // $ExpectType StoreDefinition
             const energyPercent = unowned.store.energy / unowned.storeCapacity;
             break;
         case STRUCTURE_WALL:
@@ -796,24 +811,25 @@ function resources(o: GenericStore): ResourceConstant[] {
 
 {
     // Test that you can use signatures
-    EXTENSION_ENERGY_CAPACITY[Game.rooms.myRoom.controller!.level];
+    EXTENSION_ENERGY_CAPACITY[Game.rooms.myRoom.controller!.level]; // $ExpectType number
 
-    REACTIONS[Object.keys(creep.carry)[0]];
+    REACTIONS[Object.keys(creep.carry)[0]]; // $ExpectType { [resource: string]: string; }
 
-    BOOSTS[creep.body[0].type];
+    BOOSTS[creep.body[0].type as string]; // $ExpectType { [boost: string]: { [action: string]: number; }; }
 }
 
 // Tombstones
 
 {
-    const tombstone = room.find(FIND_TOMBSTONES)[0];
+    const tombstone = room.find(FIND_TOMBSTONES)[0]; // $ExpectType Tombstone
 
+    tombstone.creep; // $ExpectType AnyCreep
     (tombstone.creep as PowerCreep).spawnCooldownTime;
     (tombstone.creep as Creep).my;
 
-    tombstone.store.energy;
+    tombstone.store; // $ExpectType StoreDefinitionUnlimited
 
-    tombstone.id;
+    tombstone.id; // $ExpectType Id<Tombstone>
 
     const creep = Game.creeps["dave"];
     creep.withdraw(tombstone, RESOURCE_ENERGY);
@@ -822,7 +838,10 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Ruin
 
 {
-    const ruin = room.find(FIND_RUINS)[0];
+    const ruin = room.find(FIND_RUINS)[0]; // $ExpectType Ruin
+
+    ruin.store; // $ExpectType StoreDefinitionUnlimited
+    ruin.structure; // $ExpectType AnyStructure
 
     creep.withdraw(ruin, RESOURCE_ENERGY);
     powerCreep.withdraw(ruin, RESOURCE_ENERGY);
@@ -838,7 +857,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 // StructurePortal
 
 {
-    const portals = room.find<StructurePortal>(FIND_STRUCTURES, { filter: s => s.structureType === STRUCTURE_PORTAL });
+    const portals = room.find<StructurePortal>(FIND_STRUCTURES, { filter: s => s.structureType === STRUCTURE_PORTAL }); // $ExpectType StructurePortal[]
     portals.forEach((p: StructurePortal) => {
         const state = p.ticksToDecay === undefined ? "stable" : "unstable";
         if (p.destination instanceof RoomPosition) {
@@ -852,14 +871,14 @@ function resources(o: GenericStore): ResourceConstant[] {
 // ConstructionSite
 
 {
-    room.createConstructionSite(10, 10, STRUCTURE_EXTENSION);
-    room.createConstructionSite(10, 11, STRUCTURE_SPAWN, "mySpawn");
+    room.createConstructionSite(10, 10, STRUCTURE_EXTENSION); // $ExpectType ScreepsReturnCode
+    room.createConstructionSite(10, 11, STRUCTURE_SPAWN, "mySpawn"); // $ExpectType ScreepsReturnCode
 
     const pos = new RoomPosition(10, 10, room.name);
-    room.createConstructionSite(pos, STRUCTURE_EXTENSION);
-    room.createConstructionSite(pos, STRUCTURE_SPAWN, "mySpawn");
-    pos.createConstructionSite(STRUCTURE_EXTENSION);
-    pos.createConstructionSite(STRUCTURE_SPAWN, "mySpawn");
+    room.createConstructionSite(pos, STRUCTURE_EXTENSION); // $ExpectType ScreepsReturnCode
+    room.createConstructionSite(pos, STRUCTURE_SPAWN, "mySpawn"); // $ExpectType ScreepsReturnCode
+    pos.createConstructionSite(STRUCTURE_EXTENSION); // $ExpectType ScreepsReturnCode
+    pos.createConstructionSite(STRUCTURE_SPAWN, "mySpawn"); // $ExpectType ScreepsReturnCode
 }
 
 // StructureLab
@@ -870,32 +889,32 @@ function resources(o: GenericStore): ResourceConstant[] {
     const lab2 = Game.getObjectById<StructureLab>("lab2");
     if (lab0 !== null && lab1 !== null && lab2 !== null) {
         if (lab1.mineralAmount >= LAB_REACTION_AMOUNT && lab2.mineralAmount >= LAB_REACTION_AMOUNT && lab0.mineralType === null) {
-            lab0.runReaction(lab1, lab2);
+            lab0.runReaction(lab1, lab2); // $ExpectType ScreepsReturnCode
         }
         // nevermind, reverse that
-        lab0.reverseReaction(lab1, lab2);
+        lab0.reverseReaction(lab1, lab2); // $ExpectType ScreepsReturnCode
     }
 }
 
 // Room event log
 
 {
-    room.getEventLog();
-    room.getEventLog(true);
+    room.getEventLog(); // $ExpectType EventItem[]
+    room.getEventLog(true); // $ExpectType EventItem[]
 
-    const events = room.getEventLog();
+    const events = room.getEventLog(); // $ExpectType EventItem[]
 
-    const event = events[0];
+    const event = events[0]; // $ExpectType EventItem
 
     switch (event.event) {
         case EVENT_ATTACK:
-            const attackType: EventAttackType = event.data.attackType;
+            const attackType: EventAttackType = event.data.attackType; // $ExpectType EventAttackType
             break;
         case EVENT_BUILD:
-            const energySpent: number = event.data.energySpent;
+            const energySpent: number = event.data.energySpent; // $ExpectTypenumber
             break;
         case EVENT_POWER:
-            const power = event.data.power;
+            const power = event.data.power; // $ExpectType PowerConstant
             break;
     }
 }
@@ -905,7 +924,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 {
     const room = Game.rooms[""];
 
-    const myTerrain = room.getTerrain();
+    const myTerrain = room.getTerrain(); // $ExpectType RoomTerrain
 
     const ret = myTerrain.get(5, 5);
     if (ret === 0) {
@@ -918,7 +937,7 @@ function resources(o: GenericStore): ResourceConstant[] {
         /*wall*/
     }
 
-    const enemyTerrain = new Room.Terrain("W2N5");
+    const enemyTerrain = new Room.Terrain("W2N5"); // $ExpectType RoomTerrain
 }
 
 // Creep.body
@@ -944,15 +963,15 @@ function atackPower(creep: Creep) {
     creep.transfer(factory, RESOURCE_LEMERGIUM_BAR, 16);
     creep.transfer(factory, RESOURCE_ENERGY, 8);
 
-    factory.produce(RESOURCE_PHLEGM);
+    factory.produce(RESOURCE_PHLEGM); // $ExpectType ScreepsReturnCode
 
-    factory.produce(RESOURCE_BATTERY);
-    factory.produce(RESOURCE_ENERGY);
+    factory.produce(RESOURCE_BATTERY); // $ExpectType ScreepsReturnCode
+    factory.produce(RESOURCE_ENERGY); // $ExpectType ScreepsReturnCode
 
-    factory.produce(RESOURCE_GHODIUM);
-    factory.produce(RESOURCE_GHODIUM_MELT);
+    factory.produce(RESOURCE_GHODIUM); // $ExpectType ScreepsReturnCode
+    factory.produce(RESOURCE_GHODIUM_MELT); // $ExpectType ScreepsReturnCode
 
-    creep.withdraw(factory, RESOURCE_PHLEGM);
+    creep.withdraw(factory, RESOURCE_PHLEGM); // $ExpectType ScreepsReturnCode
 
     // Energy and ghodium commodities
     COMMODITIES[RESOURCE_ENERGY];
@@ -1008,12 +1027,12 @@ function atackPower(creep: Creep) {
 
 // <strike>Horse armor!</strike>Pixels!
 {
-    const ret: OK | ERR_NOT_ENOUGH_RESOURCES | ERR_FULL = Game.cpu.generatePixel();
+    const ret: OK | ERR_NOT_ENOUGH_RESOURCES = Game.cpu.generatePixel(); // $ExpectType 0 | -6
 }
 
 // Game.map.visual
 {
-    const mapVis = Game.map.visual;
+    const mapVis = Game.map.visual; // $ExpectType MapVisual
     const point1 = new RoomPosition(1, 1, "E1N1");
     const point2 = new RoomPosition(1, 1, "E1N8");
     const point3 = new RoomPosition(1, 1, "E8N8");
@@ -1025,9 +1044,9 @@ function atackPower(creep: Creep) {
         .poly([point1, point2, point3, point4])
         .rect(point3, 50, 50);
 
-    const size: number = mapVis.getSize();
+    const size: number = mapVis.getSize(); // $ExpectType number
 
-    const visData = mapVis.export();
-    mapVis.clear();
-    mapVis.import(visData);
+    const visData = mapVis.export(); // $ExpectType string
+    mapVis.clear(); // $ExpectType MapVisual
+    mapVis.import(visData); // $ExpectType MapVisual
 }

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -51,9 +51,12 @@ function resources(o: GenericStore): ResourceConstant[] {
     }
 
     type StoreStructure = StructureContainer | StructureStorage | StructureLink;
-    const storeID: Id<StoreStructure> = "1234" as Id<StoreStructure>; // Strict assertion required
-    const stringID: string = storeID; // Id<T> assignable implicitly to string
-    const storeObject = Game.getObjectById(storeID)!;
+    const storeUnionID: Id<StoreStructure> = "1234" as Id<StoreStructure>; // Strict assertion required
+    const storeIdUnion: StoreStructure["id"] = "1234" as StoreStructure["id"];
+    const stringID: string = storeUnionID; // Id<T> assignable implicitly to string
+    const stringID2: string = storeIdUnion; // Id<T> assignable implicitly to string
+    const storeObject = Game.getObjectById(storeUnionID)!;
+    const storeObject2 = Game.getObjectById(storeIdUnion)!;
 
     // Object recognized
     switch (storeObject.structureType) {

--- a/src/game.ts
+++ b/src/game.ts
@@ -72,7 +72,7 @@ interface Game {
      * @param id The unique identifier.
      * @returns an object instance or null if it cannot be found.
      */
-    getObjectById<T>(id: Id<T>): T | null;
+    getObjectById<T extends Id<any>>(id: T): fromId<T> | null;
 
     /**
      * Get an object with the specified unique ID. It may be a game object of any type. Only objects from the rooms which are visible to you can be accessed.

--- a/src/game.ts
+++ b/src/game.ts
@@ -93,7 +93,7 @@ interface Game {
      * @param groupInterval If set to 0 (default), the notification will be scheduled immediately.
      * Otherwise, it will be grouped with other notifications and mailed out later using the specified time in minutes.
      */
-    notify(message: string, groupInterval?: number): undefined;
+    notify(message: string, groupInterval?: number): void;
 }
 
 declare var Game: Game;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -433,3 +433,4 @@ declare namespace Tag {
     }
 }
 type Id<T> = string & Tag.OpaqueTag<T>;
+type fromId<T> = T extends Id<infer R> ? R : never;

--- a/src/map.ts
+++ b/src/map.ts
@@ -2,7 +2,7 @@
  * The options that can be accepted by `findRoute()` and friends.
  */
 interface RouteOptions {
-    routeCallback: (roomName: string, fromRoomName: string) => any;
+    routeCallback: (roomName: string, fromRoomName: string) => number;
 }
 
 interface RoomStatusPermanent {


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

Added dtslint `$ExpectType` to most places in tests, this makes it easier/possible to split tests across multiple files and to accurately test is a type is what it is supposed to be.
Another benefit is that we can remove a lot of unnecessary "hacky" code from the tests that were previously used to make typescript complain 

There are some issues that need to be dealt with before this can be merged

![image](https://user-images.githubusercontent.com/21281226/129938097-4d0e3b05-52c7-49f9-841c-e016cb076706.png)
describeExits return type is evaluated as `Partial<Record<ExitKey, string>>` 
even though it is specified as `describeExits(roomName: string): ExitsInformation;`

![image](https://user-images.githubusercontent.com/21281226/129938325-cb77af8c-2470-4a72-9110-ad1e8af73abe.png)
dtslint is order sensitive and this one likes to shuffle around

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [ ] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
