### PR TITLE
Make ticksToRegeneration optional in Minerals

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3238,9 +3238,9 @@ interface Mineral<T extends MineralConstant = MineralConstant> extends RoomObjec
      */
     id: Id<this>;
     /**
-     * The remaining time after which the deposit will be refilled.
+     * The remaining time after which the deposit will be refilled if is recharging, otherwise undefined.
      */
-    ticksToRegeneration: number;
+    ticksToRegeneration?: number;
 }
 
 interface MineralConstructor extends _Constructor<Mineral>, _ConstructorById<Mineral> {}

--- a/src/mineral.ts
+++ b/src/mineral.ts
@@ -24,9 +24,9 @@ interface Mineral<T extends MineralConstant = MineralConstant> extends RoomObjec
      */
     id: Id<this>;
     /**
-     * The remaining time after which the deposit will be refilled.
+     * The remaining time after which the deposit will be refilled if is recharging, otherwise undefined.
      */
-    ticksToRegeneration: number;
+    ticksToRegeneration?: number;
 }
 
 interface MineralConstructor extends _Constructor<Mineral>, _ConstructorById<Mineral> {}


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

Found that `ticksToRegeneration` on a Mineral is actually `undefined` when its amount is not 0
![image](https://user-images.githubusercontent.com/5989971/138452090-b101b79b-d487-41af-add9-77f40b845ba4.png)
![image](https://user-images.githubusercontent.com/5989971/138452188-4f72989a-77e8-4289-883a-32dcbb526e14.png)

Prints from my rooms on shard3.
https://screeps.com/a/#!/room/shard3/E12N51
https://screeps.com/a/#!/room/shard3/E13N51

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
