### PR TITLE
unlimited stores have no notion of free capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update `Game.structures` type to `OwnedStructure` ([#211](https://github.com/screepers/typed-screeps/pull/211))
 - Refactor: Decoupling `FilterOption` and `FindConstant` and improve `FilterOption` ([#238](https://github.com/screepers/typed-screeps/pull/238))
 - Fix: Mark `Spawning.directions` as optional ([#244](https://github.com/screepers/typed-screeps/pull/244))
+- Fix: Unlimited stores have no notion of free capacity ([#208](https://github.com/screepers/typed-screeps/pull/208))
 
 ### Removed
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -4869,7 +4869,15 @@ interface StoreBase<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE
      */
     getFreeCapacity<R extends ResourceConstant | undefined = undefined>(
         resource?: R,
-    ): R extends undefined ? (ResourceConstant extends POSSIBLE_RESOURCES ? number : null) : R extends POSSIBLE_RESOURCES ? number : null;
+    ): UNLIMITED_STORE extends true
+        ? null
+        : R extends undefined
+        ? ResourceConstant extends POSSIBLE_RESOURCES
+            ? number
+            : null
+        : R extends POSSIBLE_RESOURCES
+        ? number
+        : null;
 }
 
 type Store<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE extends boolean> = StoreBase<

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -1300,6 +1300,62 @@ function atackPower(creep: Creep) {
             const shouldNotBeNull2 = tombstoneStore[resourceType]; // $ExpectType number
         }
     }
+
+    // test return type of `get*Capacity()` with no resourceType specified
+    {
+        // should be null for structures that only accept certain resource types
+        {
+            const spawnStore = new StructureSpawn("" as Id<StructureSpawn>).store;
+
+            const shouldBeNull1 = spawnStore.getCapacity(); // $ExpectType null
+            const shouldBeNull2 = spawnStore.getFreeCapacity(); // $ExpectType null
+            const shouldBeNull3 = spawnStore.getUsedCapacity(); // $ExpectType null
+        }
+        {
+            const nukeStore = new StructureNuker("" as Id<StructureNuker>).store;
+
+            const shouldBeNull1 = nukeStore.getCapacity(); // $ExpectType null
+            const shouldBeNull2 = nukeStore.getFreeCapacity(); // $ExpectType null
+            const shouldBeNull3 = nukeStore.getUsedCapacity(); // $ExpectType null
+        }
+        {
+            const labStore = new StructureLab("" as Id<StructureLab>).store;
+
+            const shouldBeNull1 = labStore.getCapacity(); // $ExpectType null
+            const shouldBeNull2 = labStore.getFreeCapacity(); // $ExpectType null
+            const shouldBeNull3 = labStore.getUsedCapacity(); // $ExpectType null
+        }
+
+        // should be number for structures that accept all resource types
+        {
+            const containerStore = new StructureContainer("" as Id<StructureContainer>).store;
+
+            const shouldBeNumber1 = containerStore.getCapacity(); // $ExpectType number
+            const shouldBeNumber2 = containerStore.getFreeCapacity(); // $ExpectType number
+            const shouldBeNumber3 = containerStore.getUsedCapacity(); // $ExpectType number
+        }
+        {
+            const storageStore = new StructureStorage("" as Id<StructureStorage>).store;
+
+            const shouldBeNumber1 = storageStore.getCapacity(); // $ExpectType number
+            const shouldBeNumber2 = storageStore.getFreeCapacity(); // $ExpectType number
+            const shouldBeNumber3 = storageStore.getUsedCapacity(); // $ExpectType number
+        }
+        {
+            const terminalStore = new StructureTerminal("" as Id<StructureTerminal>).store;
+
+            const shouldBeNumber1 = terminalStore.getCapacity(); // $ExpectType number
+            const shouldBeNumber2 = terminalStore.getFreeCapacity(); // $ExpectType number
+            const shouldBeNumber3 = terminalStore.getUsedCapacity(); // $ExpectType number
+        }
+        {
+            const factoryStore = new StructureFactory("" as Id<StructureFactory>).store;
+
+            const shouldBeNumber1 = factoryStore.getCapacity(); // $ExpectType number
+            const shouldBeNumber2 = factoryStore.getFreeCapacity(); // $ExpectType number
+            const shouldBeNumber3 = factoryStore.getUsedCapacity(); // $ExpectType number
+        }
+    }
 }
 
 // Id

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -1236,6 +1236,72 @@ function atackPower(creep: Creep) {
     mapVis.import(visData);
 }
 
+// Store
+{
+    // Store definitions of structures are well typed with their capable resources
+    {
+        const energyOnlyStores = [
+            new StructureSpawn("" as Id<StructureSpawn>).store,
+            new StructureExtension("" as Id<StructureExtension>).store,
+            new StructureTower("" as Id<StructureTower>).store,
+            new StructureLink("" as Id<StructureLink>).store,
+        ];
+
+        for (const store of energyOnlyStores) {
+            // should be number for capabale resources
+            const shouldBeNumber = store.getCapacity(RESOURCE_ENERGY); // $ExpectType number
+            const shouldBeNumber2 = store.getFreeCapacity(RESOURCE_ENERGY); // $ExpectType number
+            const shouldBeNumber3 = store.getUsedCapacity(RESOURCE_ENERGY); // $ExpectType number
+
+            // should be null for non-capabale resources
+            const shouldBeNull1 = store.getCapacity(RESOURCE_HYDROGEN); // $ExpectType null
+            const shouldBeNull2 = store.getFreeCapacity(RESOURCE_HYDROGEN); // $ExpectType null
+            const shouldBeNull3 = store.getUsedCapacity(RESOURCE_HYDROGEN); // $ExpectType null
+
+            const shouldBeZero = store[RESOURCE_HYDROGEN]; // $ExpectType 0
+        }
+
+        const nukerStore = new StructureNuker("" as Id<StructureNuker>).store;
+
+        // should be number for capabale resources
+        const shouldBeNumber = nukerStore.getCapacity(RESOURCE_ENERGY); // $ExpectType number
+        const shouldBeNumber2 = nukerStore.getFreeCapacity(RESOURCE_ENERGY); // $ExpectType number
+        const shouldBeNumber3 = nukerStore.getUsedCapacity(RESOURCE_ENERGY); // $ExpectType number
+
+        const shouldBeNumber4 = nukerStore.getCapacity(RESOURCE_GHODIUM); // $ExpectType number
+        const shouldBeNumber5 = nukerStore.getFreeCapacity(RESOURCE_GHODIUM); // $ExpectType number
+        const shouldBeNumber6 = nukerStore.getUsedCapacity(RESOURCE_GHODIUM); // $ExpectType number
+
+        // should be null for non-capabale resources
+        const shouldBeNull1 = nukerStore.getCapacity(RESOURCE_HYDROGEN); // $ExpectType null
+        const shouldBeNull2 = nukerStore.getFreeCapacity(RESOURCE_HYDROGEN); // $ExpectType null
+        const shouldBeNull3 = nukerStore.getUsedCapacity(RESOURCE_HYDROGEN); // $ExpectType null
+    }
+
+    // Unlimited store have no notion of capacity and free capacity
+    {
+        const ruinStore = new Ruin("" as Id<Ruin>).store;
+
+        for (const resourceType of RESOURCES_ALL) {
+            const shouldBeNull1 = ruinStore.getCapacity(resourceType); // $ExpectType null
+            const shouldBeNull2 = ruinStore.getFreeCapacity(resourceType); // $ExpectType null
+
+            const shouldNotBeNull = ruinStore.getUsedCapacity(resourceType); // $ExpectType number
+            const shouldNotBeNull2 = ruinStore[resourceType]; // $ExpectType number
+        }
+
+        const tombstoneStore = new Tombstone("" as Id<Tombstone>).store;
+
+        for (const resourceType of RESOURCES_ALL) {
+            const shouldBeNull1 = tombstoneStore.getCapacity(resourceType); // $ExpectType null
+            const shouldBeNull2 = tombstoneStore.getFreeCapacity(resourceType); // $ExpectType null
+
+            const shouldNotBeNull = tombstoneStore.getUsedCapacity(resourceType); // $ExpectType number
+            const shouldNotBeNull2 = tombstoneStore[resourceType]; // $ExpectType number
+        }
+    }
+}
+
 // Id
 {
     /// @ts-expect-error

--- a/src/store.ts
+++ b/src/store.ts
@@ -30,7 +30,15 @@ interface StoreBase<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE
      */
     getFreeCapacity<R extends ResourceConstant | undefined = undefined>(
         resource?: R,
-    ): R extends undefined ? (ResourceConstant extends POSSIBLE_RESOURCES ? number : null) : R extends POSSIBLE_RESOURCES ? number : null;
+    ): UNLIMITED_STORE extends true
+        ? null
+        : R extends undefined
+        ? ResourceConstant extends POSSIBLE_RESOURCES
+            ? number
+            : null
+        : R extends POSSIBLE_RESOURCES
+        ? number
+        : null;
 }
 
 type Store<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE extends boolean> = StoreBase<


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

Refine the type of `getFreeCapacity` so that unlimited stores will definitely return null.

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [ x ] Test passed
- [ x ] Coding style (indentation, etc)
- [ x ] Edits have been made to `src/` files not `index.d.ts`
- [ x ] Run `npm run dtslint` to update `index.d.ts`
