### PR TITLE
Changed `LOOK_STRUCTURES` return type

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,3 @@
-// Type definitions for Screeps 3.3.0
 // Project: https://github.com/screeps/screeps
 // Definitions by: Marko Sulamägi <https://github.com/MarkoSulamagi>
 //                 Nhan Ho <https://github.com/NhanHo>
@@ -1790,7 +1789,7 @@ interface AllLookAtTypes {
     nuke: Nuke;
     resource: Resource;
     source: Source;
-    structure: Structure;
+    structure: AnyStructure;
     terrain: Terrain;
     tombstone: Tombstone;
     powerCreep: PowerCreep;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -204,7 +204,7 @@ interface AllLookAtTypes {
     nuke: Nuke;
     resource: Resource;
     source: Source;
-    structure: Structure;
+    structure: AnyStructure;
     terrain: Terrain;
     tombstone: Tombstone;
     powerCreep: PowerCreep;


### PR DESCRIPTION
Was `AllLookAtTypes.structure: Structure`, Now `AllLookAtTypes.structure: AnyStructure`.

<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

- Changed interface `AllLookAtTypes` property `structure` from type `Structure` to type `AnyStructure`. Purpose is to better match `FindTypes` return types.

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
