### PR TITLE
Add type inference for params in filter callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-- Add missing MARKET_FEE constant ([#213](https://github.com/screepers/typed-screeps/pull/213)
+- Add type inference for params in filter callbacks ([#221](https://github.com/screepers/typed-screeps/pull/221))
+- Add missing MARKET_FEE constant ([#213](https://github.com/screepers/typed-screeps/pull/213))
 - Add CommodityTypes type and CommidityEntry interface ([#212](https://github.com/screepers/typed-screeps/pull/212))
-- Update Game.structures type to OwnedStructure ([#211](https://github.com/screepers/typed-screeps/pull/211)
+- Update Game.structures type to OwnedStructure ([#211](https://github.com/screepers/typed-screeps/pull/211))
 - Update ConcreteStructure syntax to use map instead of conditional chain ([#209](https://github.com/screepers/typed-screeps/pull/209))
 
 ## [3.3.0] - 2022-04-18

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3910,7 +3910,10 @@ interface RoomPosition {
      * @param objects An array of RoomPositions or objects with a RoomPosition.
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      */
-    findClosestByRange<T extends _HasRoomPosition | RoomPosition>(objects: T[], opts?: { filter: any | string }): T | null;
+    findClosestByRange<T extends _HasRoomPosition | RoomPosition>(
+        objects: T[],
+        opts?: { filter?: ((object: T) => boolean) | FilterObject | string },
+    ): T | null;
     /**
      * Find all objects in the specified linear range.
      * @param type Any of the FIND_* constants.
@@ -3929,7 +3932,11 @@ interface RoomPosition {
      * @param range The range distance.
      * @param opts See Room.find.
      */
-    findInRange<T extends _HasRoomPosition | RoomPosition>(objects: T[], range: number, opts?: { filter?: any | string }): T[];
+    findInRange<T extends _HasRoomPosition | RoomPosition>(
+        objects: T[],
+        range: number,
+        opts?: { filter?: ((object: T) => boolean) | FilterObject | string },
+    ): T[];
     /**
      * Find an optimal path to the specified position using A* search algorithm.
      *

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2177,7 +2177,9 @@ type FIND_RUINS = 123;
 interface FilterOptions<T extends FindConstant, S extends FindTypes[T] = FindTypes[T]> {
     filter: FilterFunction<FindTypes[T], S> | FilterObject | string;
 }
-type FilterFunction<T, S extends T> = (object: T) => object is S;
+
+// We do not need to mark params as optional, because this is used for callback functions, whose params are always optional
+type FilterFunction<T, S extends T> = (object: T, index: number, collection: T[]) => object is S;
 interface FilterObject {
     [key: string]: any;
 }
@@ -3893,7 +3895,9 @@ interface RoomPosition {
      */
     findClosestByPath<T extends _HasRoomPosition | RoomPosition>(
         objects: T[],
-        opts?: FindPathOpts & { filter?: ((object: T) => boolean) | FilterObject | string; algorithm?: FindClosestByPathAlgorithm },
+        opts?: FindPathOpts & { filter?: ((object: T, index: number, collection: T[]) => boolean) | FilterObject | string } & {
+            algorithm?: FindClosestByPathAlgorithm;
+        },
     ): T | null;
     /**
      * Find the object with the shortest linear distance from the given position.
@@ -3912,7 +3916,7 @@ interface RoomPosition {
      */
     findClosestByRange<T extends _HasRoomPosition | RoomPosition>(
         objects: T[],
-        opts?: { filter?: ((object: T) => boolean) | FilterObject | string },
+        opts?: { filter?: ((object: T, index: number, collection: T[]) => boolean) | FilterObject | string },
     ): T | null;
     /**
      * Find all objects in the specified linear range.
@@ -3935,7 +3939,7 @@ interface RoomPosition {
     findInRange<T extends _HasRoomPosition | RoomPosition>(
         objects: T[],
         range: number,
-        opts?: { filter?: ((object: T) => boolean) | FilterObject | string },
+        opts?: { filter?: ((object: T, index: number, collection: T[]) => boolean) | FilterObject | string },
     ): T[];
     /**
      * Find an optimal path to the specified position using A* search algorithm.

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -677,6 +677,37 @@ function resources(o: GenericStore): ResourceConstant[] {
     });
 
     labs[0].boostCreep(creep);
+
+    // Should be able to automatically infer the type of params in the filter function
+    creep.pos.findClosestByPath(FIND_STRUCTURES, {
+        // s should be AnyStructure
+        filter: (s) => s.structureType === STRUCTURE_EXTENSION,
+    });
+
+    creep.pos.findClosestByPath([] as AnyStructure[], {
+        // s should be AnyStructure
+        filter: (s) => s.structureType === STRUCTURE_EXTENSION,
+    });
+
+    creep.pos.findClosestByRange(FIND_STRUCTURES, {
+        // s should be AnyStructure
+        filter: (s) => s.structureType === STRUCTURE_EXTENSION,
+    });
+
+    creep.pos.findClosestByRange([] as AnyStructure[], {
+        // s should be AnyStructure
+        filter: (s) => s.structureType === STRUCTURE_EXTENSION,
+    });
+
+    creep.pos.findInRange(FIND_STRUCTURES, 10, {
+        // s should be AnyStructure
+        filter: (s) => s.structureType === STRUCTURE_EXTENSION,
+    });
+
+    creep.pos.findInRange([] as AnyStructure[], 10, {
+        // s should be AnyStructure
+        filter: (s) => s.structureType === STRUCTURE_EXTENSION,
+    });
 }
 
 // LookAt Finds

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -610,6 +610,16 @@ function resources(o: GenericStore): ResourceConstant[] {
     tower.attack(powerCreep);
     tower.attack(spawns[0]);
     tower.heal(powerCreep);
+
+    // All the params in filter callback should be automatically inferred
+    room.find(FIND_STRUCTURES, {
+        filter: (s, idx, array) => {
+            s.structureType === STRUCTURE_EXTENSION;
+            idx = idx + 1;
+            array.indexOf(s);
+            return true;
+        },
+    });
 }
 
 // RoomPosition Finds
@@ -707,6 +717,25 @@ function resources(o: GenericStore): ResourceConstant[] {
     creep.pos.findInRange([] as AnyStructure[], 10, {
         // s should be AnyStructure
         filter: (s) => s.structureType === STRUCTURE_EXTENSION,
+    });
+
+    // All the params in filter callback should be automatically inferred
+    creep.pos.findClosestByPath(FIND_STRUCTURES, {
+        filter: (s, idx, array) => {
+            s.structureType;
+            idx = idx + 1;
+            array.indexOf(s);
+            return true;
+        },
+    });
+
+    creep.pos.findClosestByPath([] as AnyStructure[], {
+        filter: (s, idx, array) => {
+            s.structureType;
+            idx = idx + 1;
+            array.indexOf(s);
+            return true;
+        },
     });
 }
 

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -105,7 +105,7 @@ function resources(o: GenericStore): ResourceConstant[] {
             } else {
                 // Boost resource
                 const targetSource = Game.getObjectById("targetSourceID" as Id<Source>)!;
-                const sourceEffect = targetSource.effects.find(effect => effect.effect === PWR_REGEN_SOURCE && effect.level > 0);
+                const sourceEffect = targetSource.effects.find((effect) => effect.effect === PWR_REGEN_SOURCE && effect.level > 0);
                 if (!sourceEffect && powerCreep.powers[PWR_REGEN_SOURCE] && powerCreep.powers[PWR_REGEN_SOURCE].cooldown === 0) {
                     powerCreep.usePower(PWR_REGEN_SOURCE, targetSource);
                 }
@@ -237,7 +237,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 {
     const exits = Game.map.describeExits("W8N3");
     // tslint:disable-next-line:newline-per-chained-call
-    keys(exits).map(exitKey => {
+    keys(exits).map((exitKey) => {
         const nextRoom = exits[exitKey];
         const exitDir = +exitKey as ExitConstant;
         const exitPos = creep.pos.findClosestByRange(exitDir);
@@ -315,14 +315,14 @@ function resources(o: GenericStore): ResourceConstant[] {
     });
 
     if (route !== ERR_NO_PATH) {
-        route.forEach(info => {
+        route.forEach((info) => {
             allowedRooms[info.room] = true;
         });
     }
 
     // Invoke PathFinder, allowing access only to rooms from `findRoute`
     const ret = PathFinder.search(from, [to], {
-        roomCallback: roomName => {
+        roomCallback: (roomName) => {
             if (allowedRooms[roomName] === undefined) {
                 return false;
             } else {
@@ -405,7 +405,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 
     const targetRoom = "W1N1";
     Game.market.getAllOrders(
-        currentOrder =>
+        (currentOrder) =>
             currentOrder.resourceType === RESOURCE_GHODIUM &&
             currentOrder.type === ORDER_SELL &&
             Game.market.calcTransactionCost(1000, targetRoom, currentOrder.roomName!) < 500,
@@ -435,7 +435,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     const pfCreep = Game.creeps.John;
 
     // tslint:disable-next-line:newline-per-chained-call
-    const goals = pfCreep.room.find(FIND_SOURCES).map(source => {
+    const goals = pfCreep.room.find(FIND_SOURCES).map((source) => {
         // We can't actually walk on sources-- set `range` to 1
         // so we path next to it.
         return { pos: source.pos, range: 1 };
@@ -458,7 +458,7 @@ function resources(o: GenericStore): ResourceConstant[] {
             const costs = new PathFinder.CostMatrix();
 
             // tslint:disable-next-line:newline-per-chained-call
-            curRoom.find(FIND_STRUCTURES).forEach(struct => {
+            curRoom.find(FIND_STRUCTURES).forEach((struct) => {
                 if (struct.structureType === STRUCTURE_ROAD) {
                     // Favor roads over plain tiles
                     costs.set(struct.pos.x, struct.pos.y, 1);
@@ -473,7 +473,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 
             // Avoid creeps in the room
             // tslint:disable-next-line:newline-per-chained-call
-            curRoom.find(FIND_CREEPS).forEach(thisCreep => {
+            curRoom.find(FIND_CREEPS).forEach((thisCreep) => {
                 costs.set(thisCreep.pos.x, thisCreep.pos.y, 0xff);
             });
 
@@ -588,7 +588,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     creepsHere[0].getActiveBodyparts(ATTACK);
 
     const towers = room.find<StructureTower>(FIND_MY_STRUCTURES, {
-        filter: structure => {
+        filter: (structure) => {
             return structure.structureType === STRUCTURE_TOWER;
         },
     });
@@ -622,7 +622,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     }
 
     const tower = creep.pos.findClosestByPath<StructureTower>(FIND_HOSTILE_STRUCTURES, {
-        filter: structure => {
+        filter: (structure) => {
             return structure.structureType === STRUCTURE_TOWER;
         },
         algorithm: "astar",
@@ -635,7 +635,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     // Generic type predicate filter
     const isStructureType = <T extends StructureConstant, S extends ConcreteStructure<T>>(structureType: T) => {
         return (structure: AnyStructure): structure is S => {
-            return structure.structureType === structureType as string;
+            return structure.structureType === (structureType as string);
         };
     };
 
@@ -648,14 +648,17 @@ function resources(o: GenericStore): ResourceConstant[] {
         tower2.attack(powerCreep);
     }
 
-    const creepWithEnergy = creep.pos.findClosestByPath(creep.room.find(FIND_CREEPS), { filter: c => c.store.energy > 0 });
+    const creepWithEnergy = creep.pos.findClosestByPath(creep.room.find(FIND_CREEPS), { filter: (c) => c.store.energy > 0 });
 
-    const creepAbove = creep.pos.findClosestByPath(creep.room.find(FIND_CREEPS).map(c => c.pos), {
-        filter: p => p.getDirectionTo(creep) === TOP,
-    });
+    const creepAbove = creep.pos.findClosestByPath(
+        creep.room.find(FIND_CREEPS).map((c) => c.pos),
+        {
+            filter: (p) => p.getDirectionTo(creep) === TOP,
+        },
+    );
 
     const rampart = creep.pos.findClosestByRange<StructureRampart>(FIND_HOSTILE_STRUCTURES, {
-        filter: structure => {
+        filter: (structure) => {
             return structure.structureType === STRUCTURE_RAMPART;
         },
     });
@@ -668,7 +671,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     hostileCreeps[0].saying;
 
     const labs = creep.pos.findInRange<StructureLab>(FIND_MY_STRUCTURES, 4, {
-        filter: structure => {
+        filter: (structure) => {
             return structure.structureType === STRUCTURE_LAB;
         },
     });
@@ -686,7 +689,7 @@ function resources(o: GenericStore): ResourceConstant[] {
             const pos = new RoomPosition(+x, +y, room.name);
             const objects = row[x as unknown as number];
             if (objects.length > 0) {
-                objects.map(o => o.type);
+                objects.map((o) => o.type);
             }
         }
     }
@@ -742,7 +745,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     owned.notifyWhenAttacked(false);
 
     const structs = room.find(FIND_MY_STRUCTURES);
-    structs.forEach(struct => {
+    structs.forEach((struct) => {
         switch (struct.structureType) {
             case STRUCTURE_CONTROLLER:
                 const usernameOptional: string | undefined = struct.owner && struct.owner.username;
@@ -774,17 +777,17 @@ function resources(o: GenericStore): ResourceConstant[] {
 
     // test discriminated union using filter functions on find
     const from = Game.rooms.myRoom.find(FIND_STRUCTURES, {
-        filter: s => (s.structureType === STRUCTURE_CONTAINER || s.structureType === STRUCTURE_STORAGE) && s.store.energy > 0,
+        filter: (s) => (s.structureType === STRUCTURE_CONTAINER || s.structureType === STRUCTURE_STORAGE) && s.store.energy > 0,
     })[0];
     const to = from.pos.findClosestByPath(FIND_MY_STRUCTURES, {
-        filter: s => (s.structureType === STRUCTURE_SPAWN || s.structureType === STRUCTURE_EXTENSION) && s.energy < s.energyCapacity,
+        filter: (s) => (s.structureType === STRUCTURE_SPAWN || s.structureType === STRUCTURE_EXTENSION) && s.energy < s.energyCapacity,
     });
 
     Game.rooms.myRoom
         .find(FIND_MY_STRUCTURES, {
-            filter: s => s.structureType === STRUCTURE_RAMPART,
+            filter: (s) => s.structureType === STRUCTURE_RAMPART,
         })
-        .forEach(r => r.notifyWhenAttacked(false));
+        .forEach((r) => r.notifyWhenAttacked(false));
 }
 
 {
@@ -831,7 +834,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 // StructurePortal
 
 {
-    const portals = room.find<StructurePortal>(FIND_STRUCTURES, { filter: s => s.structureType === STRUCTURE_PORTAL });
+    const portals = room.find<StructurePortal>(FIND_STRUCTURES, { filter: (s) => s.structureType === STRUCTURE_PORTAL });
     portals.forEach((p: StructurePortal) => {
         const state = p.ticksToDecay === undefined ? "stable" : "unstable";
         if (p.destination instanceof RoomPosition) {
@@ -917,7 +920,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Creep.body
 function atackPower(creep: Creep) {
     return creep.body
-        .map(part => {
+        .map((part) => {
             if (part.type === ATTACK) {
                 const multiplier = part.boost ? BOOSTS[part.type][part.boost].attack : 1;
                 return multiplier * ATTACK_POWER;
@@ -1016,11 +1019,7 @@ function atackPower(creep: Creep) {
     const point3 = new RoomPosition(1, 1, "E8N8");
     const point4 = new RoomPosition(1, 1, "E1N8");
 
-    mapVis
-        .line(point1, point2)
-        .circle(point3, { fill: "#f2f2f2" })
-        .poly([point1, point2, point3, point4])
-        .rect(point3, 50, 50);
+    mapVis.line(point1, point2).circle(point3, { fill: "#f2f2f2" }).poly([point1, point2, point3, point4]).rect(point3, 50, 50);
 
     const size: number = mapVis.getSize();
 

--- a/src/literals.ts
+++ b/src/literals.ts
@@ -124,7 +124,9 @@ type FIND_RUINS = 123;
 interface FilterOptions<T extends FindConstant, S extends FindTypes[T] = FindTypes[T]> {
     filter: FilterFunction<FindTypes[T], S> | FilterObject | string;
 }
-type FilterFunction<T, S extends T> = (object: T) => object is S;
+
+// We do not need to mark params as optional, because this is used for callback functions, whose params are always optional
+type FilterFunction<T, S extends T> = (object: T, index: number, collection: T[]) => object is S;
 interface FilterObject {
     [key: string]: any;
 }

--- a/src/room-position.ts
+++ b/src/room-position.ts
@@ -92,7 +92,10 @@ interface RoomPosition {
      * @param objects An array of RoomPositions or objects with a RoomPosition.
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      */
-    findClosestByRange<T extends _HasRoomPosition | RoomPosition>(objects: T[], opts?: { filter: any | string }): T | null;
+    findClosestByRange<T extends _HasRoomPosition | RoomPosition>(
+        objects: T[],
+        opts?: { filter?: ((object: T) => boolean) | FilterObject | string },
+    ): T | null;
     /**
      * Find all objects in the specified linear range.
      * @param type Any of the FIND_* constants.
@@ -111,7 +114,11 @@ interface RoomPosition {
      * @param range The range distance.
      * @param opts See Room.find.
      */
-    findInRange<T extends _HasRoomPosition | RoomPosition>(objects: T[], range: number, opts?: { filter?: any | string }): T[];
+    findInRange<T extends _HasRoomPosition | RoomPosition>(
+        objects: T[],
+        range: number,
+        opts?: { filter?: ((object: T) => boolean) | FilterObject | string },
+    ): T[];
     /**
      * Find an optimal path to the specified position using A* search algorithm.
      *

--- a/src/room-position.ts
+++ b/src/room-position.ts
@@ -75,7 +75,9 @@ interface RoomPosition {
      */
     findClosestByPath<T extends _HasRoomPosition | RoomPosition>(
         objects: T[],
-        opts?: FindPathOpts & { filter?: ((object: T) => boolean) | FilterObject | string; algorithm?: FindClosestByPathAlgorithm },
+        opts?: FindPathOpts & { filter?: ((object: T, index: number, collection: T[]) => boolean) | FilterObject | string } & {
+            algorithm?: FindClosestByPathAlgorithm;
+        },
     ): T | null;
     /**
      * Find the object with the shortest linear distance from the given position.
@@ -94,7 +96,7 @@ interface RoomPosition {
      */
     findClosestByRange<T extends _HasRoomPosition | RoomPosition>(
         objects: T[],
-        opts?: { filter?: ((object: T) => boolean) | FilterObject | string },
+        opts?: { filter?: ((object: T, index: number, collection: T[]) => boolean) | FilterObject | string },
     ): T | null;
     /**
      * Find all objects in the specified linear range.
@@ -117,7 +119,7 @@ interface RoomPosition {
     findInRange<T extends _HasRoomPosition | RoomPosition>(
         objects: T[],
         range: number,
-        opts?: { filter?: ((object: T) => boolean) | FilterObject | string },
+        opts?: { filter?: ((object: T, index: number, collection: T[]) => boolean) | FilterObject | string },
     ): T[];
     /**
      * Find an optimal path to the specified position using A* search algorithm.


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

See #219. 

`RoomPosition.findInRange` or `findclosestByRange` can not infer the type of params in filter callback function when the first arg is `targets[]` instead of a `FindConstant`.

We should fix this, because in typescript strict mode, implict `any` type for function params is forbidden.

---

Besides, `RoomPosition.findInRange` or `findclosestByRange` with first arg as `targets[]` also do not support filter callback's type predicate.  

I will fix it after this PR is merged.


### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
