### PR TITLE
fix: brings `getObjectById(id: string)` back

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1571,6 +1571,15 @@ interface Game {
     getObjectById<T extends _HasId>(id: Id<T>): T | null;
 
     /**
+     * Get an object with the specified unique ID. It may be a game object of any type. Only objects from the rooms which are visible to you can be accessed.
+     * @param id The unique identifier.
+     * @returns an object instance or null if it cannot be found.
+     * @deprecated Use Id<T>, instead of strings, to increase type safety
+     */
+    // tslint:disable-next-line:unified-signatures
+    getObjectById<T extends _HasId>(id: string): T | null;
+
+    /**
      * Send a custom message at your profile email.
      *
      * This way, you can set up notifications to yourself on any occasion within the game.

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3386,8 +3386,8 @@ interface PathFinderOpts {
 }
 
 interface CostMatrixConstructor extends _Constructor<CostMatrix> {
-    new(): CostMatrix;
-    
+    new (): CostMatrix;
+
     /**
      * Static method which deserializes a new CostMatrix using the return value of serialize.
      * @param val Whatever serialize returned

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -483,11 +483,11 @@ function resources(o: GenericStore): ResourceConstant[] {
 
     const pos = ret.path[0];
     pfCreep.move(pfCreep.pos.getDirectionTo(pos));
-    
+
     // CostMatrix Creation
-    const costs = new PathFinder.CostMatrix;
+    const costs = new PathFinder.CostMatrix();
     costs.set(20, 20, 42);
-    
+
     // Serialization
     const toStoreInMemory = costs.serialize();
     const costsFromMemory = PathFinder.CostMatrix.deserialize([]);
@@ -1100,5 +1100,5 @@ function atackPower(creep: Creep) {
 {
     const roomId = "" as Id<Room>; // $ExpectError
     const creep = Game.getObjectById("" as Id<Creep>);
-    const foo = Game.getObjectById<StructureTower>("" as Id<Creep>); // $ExpectError
+    const foo = Game.getObjectById<StructureTower>("" as Id<Creep>); // excepted to be deprecated in the next major release
 }

--- a/src/game.ts
+++ b/src/game.ts
@@ -76,6 +76,15 @@ interface Game {
     getObjectById<T extends _HasId>(id: Id<T>): T | null;
 
     /**
+     * Get an object with the specified unique ID. It may be a game object of any type. Only objects from the rooms which are visible to you can be accessed.
+     * @param id The unique identifier.
+     * @returns an object instance or null if it cannot be found.
+     * @deprecated Use Id<T>, instead of strings, to increase type safety
+     */
+    // tslint:disable-next-line:unified-signatures
+    getObjectById<T extends _HasId>(id: string): T | null;
+
+    /**
      * Send a custom message at your profile email.
      *
      * This way, you can set up notifications to yourself on any occasion within the game.

--- a/src/path-finder.ts
+++ b/src/path-finder.ts
@@ -111,8 +111,8 @@ interface PathFinderOpts {
 }
 
 interface CostMatrixConstructor extends _Constructor<CostMatrix> {
-    new(): CostMatrix;
-    
+    new (): CostMatrix;
+
     /**
      * Static method which deserializes a new CostMatrix using the return value of serialize.
      * @param val Whatever serialize returned


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

#223 

Bring `getObjectById(id: string)` back to follow Semantic Versioning.

I have tested this on some popular screeps reposities which using @type/screeps version less than `3.3.0` . No error occurres after replacing their @type/screeps with the currently built version.

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
