### PR TITLE
Decoupling `FilterOption` and `FindConstant` and Improve `FilterOption`

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2176,7 +2176,7 @@ type FIND_RUINS = 123;
 // Filter Options
 
 interface FilterOptions<T extends FindConstant, S extends FindTypes[T] = FindTypes[T]> {
-    filter: PredicateFilterFunction<FindTypes[T], S> | FilterFunction<FindTypes[T]> | FilterObject<FindTypes[T]> | string;
+    filter?: PredicateFilterFunction<FindTypes[T], S> | FilterFunction<FindTypes[T]> | FilterObject<FindTypes[T]> | string;
 }
 
 type PredicateFilterFunction<T, S extends T> = (object: T, index: number, collection: T[]) => object is S;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2175,8 +2175,8 @@ type FIND_RUINS = 123;
 
 // Filter Options
 
-interface FilterOptions<T extends FindConstant, S extends FindTypes[T] = FindTypes[T]> {
-    filter?: PredicateFilterFunction<FindTypes[T], S> | FilterFunction<FindTypes[T]> | FilterObject<FindTypes[T]> | string;
+interface FilterOptions<T, S extends T> {
+    filter?: PredicateFilterFunction<T, S> | FilterFunction<T> | FilterObject<T> | string;
 }
 
 type PredicateFilterFunction<T, S extends T> = (object: T, index: number, collection: T[]) => object is S;
@@ -2589,65 +2589,65 @@ type EventDestroyType = "creep" | StructureConstant;
 
 type EventItem =
     | {
-          event: EVENT_ATTACK;
-          objectId: string;
-          data: EventData[EVENT_ATTACK];
-      }
+        event: EVENT_ATTACK;
+        objectId: string;
+        data: EventData[EVENT_ATTACK];
+    }
     | {
-          event: EVENT_OBJECT_DESTROYED;
-          objectId: string;
-          data: EventData[EVENT_OBJECT_DESTROYED];
-      }
+        event: EVENT_OBJECT_DESTROYED;
+        objectId: string;
+        data: EventData[EVENT_OBJECT_DESTROYED];
+    }
     | {
-          event: EVENT_ATTACK_CONTROLLER;
-          objectId: string;
-          data: EventData[EVENT_ATTACK_CONTROLLER];
-      }
+        event: EVENT_ATTACK_CONTROLLER;
+        objectId: string;
+        data: EventData[EVENT_ATTACK_CONTROLLER];
+    }
     | {
-          event: EVENT_BUILD;
-          objectId: string;
-          data: EventData[EVENT_BUILD];
-      }
+        event: EVENT_BUILD;
+        objectId: string;
+        data: EventData[EVENT_BUILD];
+    }
     | {
-          event: EVENT_HARVEST;
-          objectId: string;
-          data: EventData[EVENT_HARVEST];
-      }
+        event: EVENT_HARVEST;
+        objectId: string;
+        data: EventData[EVENT_HARVEST];
+    }
     | {
-          event: EVENT_HEAL;
-          objectId: string;
-          data: EventData[EVENT_HEAL];
-      }
+        event: EVENT_HEAL;
+        objectId: string;
+        data: EventData[EVENT_HEAL];
+    }
     | {
-          event: EVENT_REPAIR;
-          objectId: string;
-          data: EventData[EVENT_REPAIR];
-      }
+        event: EVENT_REPAIR;
+        objectId: string;
+        data: EventData[EVENT_REPAIR];
+    }
     | {
-          event: EVENT_RESERVE_CONTROLLER;
-          objectId: string;
-          data: EventData[EVENT_RESERVE_CONTROLLER];
-      }
+        event: EVENT_RESERVE_CONTROLLER;
+        objectId: string;
+        data: EventData[EVENT_RESERVE_CONTROLLER];
+    }
     | {
-          event: EVENT_UPGRADE_CONTROLLER;
-          objectId: string;
-          data: EventData[EVENT_UPGRADE_CONTROLLER];
-      }
+        event: EVENT_UPGRADE_CONTROLLER;
+        objectId: string;
+        data: EventData[EVENT_UPGRADE_CONTROLLER];
+    }
     | {
-          event: EVENT_EXIT;
-          objectId: string;
-          data: EventData[EVENT_EXIT];
-      }
+        event: EVENT_EXIT;
+        objectId: string;
+        data: EventData[EVENT_EXIT];
+    }
     | {
-          event: EVENT_POWER;
-          objectId: string;
-          data: EventData[EVENT_POWER];
-      }
+        event: EVENT_POWER;
+        objectId: string;
+        data: EventData[EVENT_POWER];
+    }
     | {
-          event: EVENT_TRANSFER;
-          objectId: string;
-          data: EventData[EVENT_TRANSFER];
-      };
+        event: EVENT_TRANSFER;
+        objectId: string;
+        data: EventData[EVENT_TRANSFER];
+    };
 
 interface EventData {
     [EVENT_ATTACK]: {
@@ -3883,11 +3883,11 @@ interface RoomPosition {
      */
     findClosestByPath<K extends FindConstant, S extends FindTypes[K]>(
         type: K,
-        opts?: FindPathOpts & Partial<FilterOptions<K, S>> & { algorithm?: FindClosestByPathAlgorithm },
+        opts?: FindPathOpts & FilterOptions<FindTypes[K], S> & { algorithm?: FindClosestByPathAlgorithm },
     ): S | null;
     findClosestByPath<S extends AnyStructure>(
         type: FIND_STRUCTURES | FIND_MY_STRUCTURES | FIND_HOSTILE_STRUCTURES,
-        opts?: FindPathOpts & Partial<FilterOptions<FIND_STRUCTURES, S>> & { algorithm?: FindClosestByPathAlgorithm },
+        opts?: FindPathOpts & FilterOptions<FindTypes[FIND_STRUCTURES], S> & { algorithm?: FindClosestByPathAlgorithm },
     ): S | null;
     /**
      * Find the object with the shortest path from the given position. Uses A* search algorithm and Dijkstra's algorithm.
@@ -3895,42 +3895,40 @@ interface RoomPosition {
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      * @returns One of the supplied objects
      */
-    findClosestByPath<T extends _HasRoomPosition | RoomPosition>(
+    findClosestByPath<T extends _HasRoomPosition | RoomPosition, S extends T = T>(
         objects: T[],
-        opts?: FindPathOpts & { filter?: ((object: T, index: number, collection: T[]) => boolean) | FilterObject | string } & {
-            algorithm?: FindClosestByPathAlgorithm;
-        },
-    ): T | null;
+        opts?: FindPathOpts &
+            FilterOptions<T, S> & {
+                algorithm?: FindClosestByPathAlgorithm;
+            },
+    ): S | null;
     /**
      * Find the object with the shortest linear distance from the given position.
      * @param type Any of the FIND_* constants.
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      */
-    findClosestByRange<K extends FindConstant, S extends FindTypes[K]>(type: K, opts?: FilterOptions<K, S>): S | null;
+    findClosestByRange<K extends FindConstant, S extends FindTypes[K]>(type: K, opts?: FilterOptions<FindTypes[K], S>): S | null;
     findClosestByRange<S extends AnyStructure>(
         type: FIND_STRUCTURES | FIND_MY_STRUCTURES | FIND_HOSTILE_STRUCTURES,
-        opts?: FilterOptions<FIND_STRUCTURES, S>,
+        opts?: FilterOptions<FindTypes[FIND_STRUCTURES], S>,
     ): S | null;
     /**
      * Find the object with the shortest linear distance from the given position.
      * @param objects An array of RoomPositions or objects with a RoomPosition.
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      */
-    findClosestByRange<T extends _HasRoomPosition | RoomPosition>(
-        objects: T[],
-        opts?: { filter?: ((object: T, index: number, collection: T[]) => boolean) | FilterObject | string },
-    ): T | null;
+    findClosestByRange<T extends _HasRoomPosition | RoomPosition, S extends T = T>(objects: T[], opts?: FilterOptions<T, S>): S | null;
     /**
      * Find all objects in the specified linear range.
      * @param type Any of the FIND_* constants.
      * @param range The range distance.
      * @param opts See Room.find.
      */
-    findInRange<K extends FindConstant, S extends FindTypes[K]>(type: K, range: number, opts?: FilterOptions<K, S>): S[];
+    findInRange<K extends FindConstant, S extends FindTypes[K]>(type: K, range: number, opts?: FilterOptions<FindTypes[K], S>): S[];
     findInRange<S extends AnyStructure>(
         type: FIND_STRUCTURES | FIND_MY_STRUCTURES | FIND_HOSTILE_STRUCTURES,
         range: number,
-        opts?: FilterOptions<FIND_STRUCTURES, S>,
+        opts?: FilterOptions<FindTypes[FIND_STRUCTURES], S>,
     ): S[];
     /**
      * Find all objects in the specified linear range.
@@ -3938,11 +3936,7 @@ interface RoomPosition {
      * @param range The range distance.
      * @param opts See Room.find.
      */
-    findInRange<T extends _HasRoomPosition | RoomPosition>(
-        objects: T[],
-        range: number,
-        opts?: { filter?: ((object: T, index: number, collection: T[]) => boolean) | FilterObject | string },
-    ): T[];
+    findInRange<T extends _HasRoomPosition | RoomPosition, S extends T = T>(objects: T[], range: number, opts?: FilterOptions<T, S>): S[];
     /**
      * Find an optimal path to the specified position using A* search algorithm.
      *
@@ -4416,10 +4410,10 @@ interface Room {
      * @param opts An object with additional options
      * @returns An array with the objects found.
      */
-    find<K extends FindConstant, S extends FindTypes[K]>(type: K, opts?: FilterOptions<K, S>): S[];
+    find<K extends FindConstant, S extends FindTypes[K]>(type: K, opts?: FilterOptions<FindTypes[K], S>): S[];
     find<S extends AnyStructure>(
         type: FIND_STRUCTURES | FIND_MY_STRUCTURES | FIND_HOSTILE_STRUCTURES,
-        opts?: FilterOptions<FIND_STRUCTURES, S>,
+        opts?: FilterOptions<FindTypes[FIND_STRUCTURES], S>,
     ): S[];
     /**
      * Find the exit direction en route to another room.

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2176,14 +2176,13 @@ type FIND_RUINS = 123;
 // Filter Options
 
 interface FilterOptions<T extends FindConstant, S extends FindTypes[T] = FindTypes[T]> {
-    filter: FilterFunction<FindTypes[T], S> | FilterObject | string;
+    filter: FilterFunction<FindTypes[T], S> | FilterObject<FindTypes[T]> | string;
 }
 
-// We do not need to mark params as optional, because this is used for callback functions, whose params are always optional
 type FilterFunction<T, S extends T> = (object: T, index: number, collection: T[]) => object is S;
-interface FilterObject {
-    [key: string]: any;
-}
+type FilterObject<T> = DeepPartial<T>;
+
+type DeepPartial<T> = T extends object ? { [P in keyof T]?: DeepPartial<T[P]> } : T;
 
 // Body Part Constants
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2176,10 +2176,11 @@ type FIND_RUINS = 123;
 // Filter Options
 
 interface FilterOptions<T extends FindConstant, S extends FindTypes[T] = FindTypes[T]> {
-    filter: FilterFunction<FindTypes[T], S> | FilterObject<FindTypes[T]> | string;
+    filter: PredicateFilterFunction<FindTypes[T], S> | FilterFunction<FindTypes[T]> | FilterObject<FindTypes[T]> | string;
 }
 
-type FilterFunction<T, S extends T> = (object: T, index: number, collection: T[]) => object is S;
+type PredicateFilterFunction<T, S extends T> = (object: T, index: number, collection: T[]) => object is S;
+type FilterFunction<T> = (object: T, index: number, collection: T[]) => unknown;
 type FilterObject<T> = DeepPartial<T>;
 
 type DeepPartial<T> = T extends object ? { [P in keyof T]?: DeepPartial<T[P]> } : T;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2589,65 +2589,65 @@ type EventDestroyType = "creep" | StructureConstant;
 
 type EventItem =
     | {
-        event: EVENT_ATTACK;
-        objectId: string;
-        data: EventData[EVENT_ATTACK];
-    }
+          event: EVENT_ATTACK;
+          objectId: string;
+          data: EventData[EVENT_ATTACK];
+      }
     | {
-        event: EVENT_OBJECT_DESTROYED;
-        objectId: string;
-        data: EventData[EVENT_OBJECT_DESTROYED];
-    }
+          event: EVENT_OBJECT_DESTROYED;
+          objectId: string;
+          data: EventData[EVENT_OBJECT_DESTROYED];
+      }
     | {
-        event: EVENT_ATTACK_CONTROLLER;
-        objectId: string;
-        data: EventData[EVENT_ATTACK_CONTROLLER];
-    }
+          event: EVENT_ATTACK_CONTROLLER;
+          objectId: string;
+          data: EventData[EVENT_ATTACK_CONTROLLER];
+      }
     | {
-        event: EVENT_BUILD;
-        objectId: string;
-        data: EventData[EVENT_BUILD];
-    }
+          event: EVENT_BUILD;
+          objectId: string;
+          data: EventData[EVENT_BUILD];
+      }
     | {
-        event: EVENT_HARVEST;
-        objectId: string;
-        data: EventData[EVENT_HARVEST];
-    }
+          event: EVENT_HARVEST;
+          objectId: string;
+          data: EventData[EVENT_HARVEST];
+      }
     | {
-        event: EVENT_HEAL;
-        objectId: string;
-        data: EventData[EVENT_HEAL];
-    }
+          event: EVENT_HEAL;
+          objectId: string;
+          data: EventData[EVENT_HEAL];
+      }
     | {
-        event: EVENT_REPAIR;
-        objectId: string;
-        data: EventData[EVENT_REPAIR];
-    }
+          event: EVENT_REPAIR;
+          objectId: string;
+          data: EventData[EVENT_REPAIR];
+      }
     | {
-        event: EVENT_RESERVE_CONTROLLER;
-        objectId: string;
-        data: EventData[EVENT_RESERVE_CONTROLLER];
-    }
+          event: EVENT_RESERVE_CONTROLLER;
+          objectId: string;
+          data: EventData[EVENT_RESERVE_CONTROLLER];
+      }
     | {
-        event: EVENT_UPGRADE_CONTROLLER;
-        objectId: string;
-        data: EventData[EVENT_UPGRADE_CONTROLLER];
-    }
+          event: EVENT_UPGRADE_CONTROLLER;
+          objectId: string;
+          data: EventData[EVENT_UPGRADE_CONTROLLER];
+      }
     | {
-        event: EVENT_EXIT;
-        objectId: string;
-        data: EventData[EVENT_EXIT];
-    }
+          event: EVENT_EXIT;
+          objectId: string;
+          data: EventData[EVENT_EXIT];
+      }
     | {
-        event: EVENT_POWER;
-        objectId: string;
-        data: EventData[EVENT_POWER];
-    }
+          event: EVENT_POWER;
+          objectId: string;
+          data: EventData[EVENT_POWER];
+      }
     | {
-        event: EVENT_TRANSFER;
-        objectId: string;
-        data: EventData[EVENT_TRANSFER];
-    };
+          event: EVENT_TRANSFER;
+          objectId: string;
+          data: EventData[EVENT_TRANSFER];
+      };
 
 interface EventData {
     [EVENT_ATTACK]: {

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -622,9 +622,9 @@ function resources(o: GenericStore): ResourceConstant[] {
     // All the params in filter callback should be automatically inferred
     room.find(FIND_STRUCTURES, {
         filter: (s, idx, array) => {
-            s.structureType === STRUCTURE_EXTENSION;
-            idx = idx + 1;
-            array.indexOf(s);
+            s; // $ExpectType AnyStructure
+            idx; // $ExpectType number
+            array; // $ExpectType AnyStructure[]
             return true;
         },
     });
@@ -640,6 +640,8 @@ function resources(o: GenericStore): ResourceConstant[] {
     }
 
     const tower = creep.pos.findClosestByPath<StructureTower>(FIND_HOSTILE_STRUCTURES, {
+        // ? s should be AnyOwnedStructure in the future
+        // $ExpectType (structure: AnyStructure) => boolean
         filter: (structure) => {
             return structure.structureType === STRUCTURE_TOWER;
         },
@@ -671,11 +673,14 @@ function resources(o: GenericStore): ResourceConstant[] {
     const creepAbove = creep.pos.findClosestByPath(
         creep.room.find(FIND_CREEPS).map((c) => c.pos),
         {
+            // $ExpectType (p: RoomPosition) => boolean
             filter: (p) => p.getDirectionTo(creep) === TOP,
         },
     );
 
     const rampart = creep.pos.findClosestByRange<StructureRampart>(FIND_HOSTILE_STRUCTURES, {
+        // ? s should be AnyOwnedStructure in the future
+        // $ExpectType (structure: AnyStructure) => boolean
         filter: (structure) => {
             return structure.structureType === STRUCTURE_RAMPART;
         },
@@ -689,6 +694,8 @@ function resources(o: GenericStore): ResourceConstant[] {
     hostileCreeps[0].saying;
 
     const labs = creep.pos.findInRange<StructureLab>(FIND_MY_STRUCTURES, 4, {
+        // ? s should be AnyOwnedStructure in the future
+        // $ExpectType (structure: AnyStructure) => boolean
         filter: (structure) => {
             return structure.structureType === STRUCTURE_LAB;
         },
@@ -698,50 +705,50 @@ function resources(o: GenericStore): ResourceConstant[] {
 
     // Should be able to automatically infer the type of params in the filter function
     creep.pos.findClosestByPath(FIND_STRUCTURES, {
-        // s should be AnyStructure
+        // $ExpectType (s: AnyStructure) => boolean
         filter: (s) => s.structureType === STRUCTURE_EXTENSION,
     });
 
     creep.pos.findClosestByPath([] as AnyStructure[], {
-        // s should be AnyStructure
+        // $ExpectType (s: AnyStructure) => boolean
         filter: (s) => s.structureType === STRUCTURE_EXTENSION,
     });
 
     creep.pos.findClosestByRange(FIND_STRUCTURES, {
-        // s should be AnyStructure
+        // $ExpectType (s: AnyStructure) => boolean
         filter: (s) => s.structureType === STRUCTURE_EXTENSION,
     });
 
     creep.pos.findClosestByRange([] as AnyStructure[], {
-        // s should be AnyStructure
+        // $ExpectType (s: AnyStructure) => boolean
         filter: (s) => s.structureType === STRUCTURE_EXTENSION,
     });
 
     creep.pos.findInRange(FIND_STRUCTURES, 10, {
-        // s should be AnyStructure
+        // $ExpectType (s: AnyStructure) => boolean
         filter: (s) => s.structureType === STRUCTURE_EXTENSION,
     });
 
     creep.pos.findInRange([] as AnyStructure[], 10, {
-        // s should be AnyStructure
+        // $ExpectType (s: AnyStructure) => boolean
         filter: (s) => s.structureType === STRUCTURE_EXTENSION,
     });
 
     // All the params in filter callback should be automatically inferred
     creep.pos.findClosestByPath(FIND_STRUCTURES, {
         filter: (s, idx, array) => {
-            s.structureType;
-            idx = idx + 1;
-            array.indexOf(s);
+            s; // $ExpectType AnyStructure
+            idx; // $ExpectType number
+            array; // $ExpectType AnyStructure[]
             return true;
         },
     });
 
     creep.pos.findClosestByPath([] as AnyStructure[], {
         filter: (s, idx, array) => {
-            s.structureType;
-            idx = idx + 1;
-            array.indexOf(s);
+            s; // $ExpectType AnyStructure
+            idx; // $ExpectType number
+            array; // $ExpectType AnyStructure[]
             return true;
         },
     });
@@ -749,18 +756,21 @@ function resources(o: GenericStore): ResourceConstant[] {
     // `findInRange, findClosestByRange, findClosestByPath` should be able to accept filter callback's type predicate
     // when using FIND_* constants
     {
+        // $ExpectType StructureTower[]
         const towers = creep.pos.findInRange(FIND_STRUCTURES, 2, {
             filter: isStructureType(STRUCTURE_TOWER),
         });
         towers[0].attack(creep);
     }
     {
+        // $ExpectType StructureTower | null
         const tower = creep.pos.findClosestByPath(FIND_STRUCTURES, {
             filter: isStructureType(STRUCTURE_TOWER),
         });
         tower?.attack(creep);
     }
     {
+        // $ExpectType StructureTower | null
         const tower = creep.pos.findClosestByRange(FIND_STRUCTURES, {
             filter: isStructureType(STRUCTURE_TOWER),
         });
@@ -768,18 +778,21 @@ function resources(o: GenericStore): ResourceConstant[] {
     }
     // when pass in an array of room objects
     {
+        // $ExpectType StructureTower[]
         const towers = creep.pos.findInRange([] as AnyStructure[], 2, {
             filter: isStructureType(STRUCTURE_TOWER),
         });
         towers[0].attack(creep);
     }
     {
+        // $ExpectType StructureTower | null
         const tower = creep.pos.findClosestByPath([] as AnyStructure[], {
             filter: isStructureType(STRUCTURE_TOWER),
         });
         tower?.attack(creep);
     }
     {
+        // $ExpectType StructureTower | null
         const tower = creep.pos.findClosestByRange([] as AnyStructure[], {
             filter: isStructureType(STRUCTURE_TOWER),
         });
@@ -884,9 +897,12 @@ function resources(o: GenericStore): ResourceConstant[] {
     }
 
     // test discriminated union using filter functions on find
+
+    // $ExpectType AnyStructure
     const from = Game.rooms.myRoom.find(FIND_STRUCTURES, {
         filter: (s) => (s.structureType === STRUCTURE_CONTAINER || s.structureType === STRUCTURE_STORAGE) && s.store.energy > 0,
     })[0];
+    // $ExpectType AnyOwnedStructure | null
     const to = from.pos.findClosestByPath(FIND_MY_STRUCTURES, {
         filter: (s) => (s.structureType === STRUCTURE_SPAWN || s.structureType === STRUCTURE_EXTENSION) && s.energy < s.energyCapacity,
     });

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -798,6 +798,90 @@ function resources(o: GenericStore): ResourceConstant[] {
         });
         tower?.attack(creep);
     }
+
+    // Lodash's object style filter predicate
+    // Currently do not support narrowing.
+    {
+        // $ExpectType AnyStructure[]
+        const towers = room.find(FIND_STRUCTURES, {
+            filter: { structureType: STRUCTURE_TOWER },
+        });
+    }
+    {
+        // $ExpectType AnyStructure[]
+        const towers = creep.pos.findInRange(FIND_STRUCTURES, 2, {
+            filter: { structureType: STRUCTURE_TOWER },
+        });
+
+        // $ExpectType AnyStructure[]
+        const towers2 = creep.pos.findInRange([] as AnyStructure[], 2, {
+            filter: { structureType: STRUCTURE_TOWER },
+        });
+    }
+    {
+        // $ExpectType AnyStructure | null
+        const tower = creep.pos.findClosestByPath(FIND_STRUCTURES, {
+            filter: { structureType: STRUCTURE_TOWER },
+        });
+
+        // $ExpectType AnyStructure | null
+        const towers2 = creep.pos.findClosestByPath([] as AnyStructure[], {
+            filter: { structureType: STRUCTURE_TOWER },
+        });
+    }
+    {
+        // $ExpectType AnyStructure | null
+        const tower = creep.pos.findClosestByRange(FIND_STRUCTURES, {
+            filter: { structureType: STRUCTURE_TOWER },
+        });
+
+        // $ExpectType AnyStructure | null
+        const towers2 = creep.pos.findClosestByRange([] as AnyStructure[], {
+            filter: { structureType: STRUCTURE_TOWER },
+        });
+    }
+
+    // should throw error if the property is not exist in the object
+    {
+        // @ts-expect-error
+        creep.pos.findInRange(FIND_STRUCTURES, 2, {
+            filter: { foo: "bar" },
+        });
+    }
+    // should throw error if type of values are not match
+    {
+        // @ts-expect-error
+        creep.pos.findInRange(FIND_STRUCTURES, 2, {
+            filter: { structureType: "foobar" },
+        });
+
+        // @ts-expect-error
+        creep.pos.findInRange(FIND_STRUCTURES, 2, {
+            filter: { structureType: 123 },
+        });
+    }
+
+    // should support deep property
+    {
+        // $ExpectType AnyOwnedStructure | null
+        const tower1 = creep.pos.findClosestByPath(FIND_MY_STRUCTURES, {
+            filter: { owner: { username: "foo" } },
+        });
+
+        // @ts-expect-error
+        const tower2 = creep.pos.findClosestByPath(FIND_MY_STRUCTURES, {
+            filter: { owner: { yourname: "Mitsuha" } },
+        });
+    }
+
+    // Lodash's path string style filter predicate
+    // Currently do not support narrowing, and maybe never will.
+    {
+        // $ExpectType AnyStructure[]
+        const towers = creep.pos.findInRange(FIND_STRUCTURES, 2, {
+            filter: "my",
+        });
+    }
 }
 
 // LookAt Finds

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -745,6 +745,46 @@ function resources(o: GenericStore): ResourceConstant[] {
             return true;
         },
     });
+
+    // `findInRange, findClosestByRange, findClosestByPath` should be able to accept filter callback's type predicate
+    // when using FIND_* constants
+    {
+        const towers = creep.pos.findInRange(FIND_STRUCTURES, 2, {
+            filter: isStructureType(STRUCTURE_TOWER),
+        });
+        towers[0].attack(creep);
+    }
+    {
+        const tower = creep.pos.findClosestByPath(FIND_STRUCTURES, {
+            filter: isStructureType(STRUCTURE_TOWER),
+        });
+        tower?.attack(creep);
+    }
+    {
+        const tower = creep.pos.findClosestByRange(FIND_STRUCTURES, {
+            filter: isStructureType(STRUCTURE_TOWER),
+        });
+        tower?.attack(creep);
+    }
+    // when pass in an array of room objects
+    {
+        const towers = creep.pos.findInRange([] as AnyStructure[], 2, {
+            filter: isStructureType(STRUCTURE_TOWER),
+        });
+        towers[0].attack(creep);
+    }
+    {
+        const tower = creep.pos.findClosestByPath([] as AnyStructure[], {
+            filter: isStructureType(STRUCTURE_TOWER),
+        });
+        tower?.attack(creep);
+    }
+    {
+        const tower = creep.pos.findClosestByRange([] as AnyStructure[], {
+            filter: isStructureType(STRUCTURE_TOWER),
+        });
+        tower?.attack(creep);
+    }
 }
 
 // LookAt Finds

--- a/src/literals.ts
+++ b/src/literals.ts
@@ -121,8 +121,8 @@ type FIND_RUINS = 123;
 
 // Filter Options
 
-interface FilterOptions<T extends FindConstant, S extends FindTypes[T] = FindTypes[T]> {
-    filter?: PredicateFilterFunction<FindTypes[T], S> | FilterFunction<FindTypes[T]> | FilterObject<FindTypes[T]> | string;
+interface FilterOptions<T, S extends T> {
+    filter?: PredicateFilterFunction<T, S> | FilterFunction<T> | FilterObject<T> | string;
 }
 
 type PredicateFilterFunction<T, S extends T> = (object: T, index: number, collection: T[]) => object is S;

--- a/src/literals.ts
+++ b/src/literals.ts
@@ -122,14 +122,13 @@ type FIND_RUINS = 123;
 // Filter Options
 
 interface FilterOptions<T extends FindConstant, S extends FindTypes[T] = FindTypes[T]> {
-    filter: FilterFunction<FindTypes[T], S> | FilterObject | string;
+    filter: FilterFunction<FindTypes[T], S> | FilterObject<FindTypes[T]> | string;
 }
 
-// We do not need to mark params as optional, because this is used for callback functions, whose params are always optional
 type FilterFunction<T, S extends T> = (object: T, index: number, collection: T[]) => object is S;
-interface FilterObject {
-    [key: string]: any;
-}
+type FilterObject<T> = DeepPartial<T>;
+
+type DeepPartial<T> = T extends object ? { [P in keyof T]?: DeepPartial<T[P]> } : T;
 
 // Body Part Constants
 

--- a/src/literals.ts
+++ b/src/literals.ts
@@ -122,7 +122,7 @@ type FIND_RUINS = 123;
 // Filter Options
 
 interface FilterOptions<T extends FindConstant, S extends FindTypes[T] = FindTypes[T]> {
-    filter: PredicateFilterFunction<FindTypes[T], S> | FilterFunction<FindTypes[T]> | FilterObject<FindTypes[T]> | string;
+    filter?: PredicateFilterFunction<FindTypes[T], S> | FilterFunction<FindTypes[T]> | FilterObject<FindTypes[T]> | string;
 }
 
 type PredicateFilterFunction<T, S extends T> = (object: T, index: number, collection: T[]) => object is S;

--- a/src/literals.ts
+++ b/src/literals.ts
@@ -122,10 +122,11 @@ type FIND_RUINS = 123;
 // Filter Options
 
 interface FilterOptions<T extends FindConstant, S extends FindTypes[T] = FindTypes[T]> {
-    filter: FilterFunction<FindTypes[T], S> | FilterObject<FindTypes[T]> | string;
+    filter: PredicateFilterFunction<FindTypes[T], S> | FilterFunction<FindTypes[T]> | FilterObject<FindTypes[T]> | string;
 }
 
-type FilterFunction<T, S extends T> = (object: T, index: number, collection: T[]) => object is S;
+type PredicateFilterFunction<T, S extends T> = (object: T, index: number, collection: T[]) => object is S;
+type FilterFunction<T> = (object: T, index: number, collection: T[]) => unknown;
 type FilterObject<T> = DeepPartial<T>;
 
 type DeepPartial<T> = T extends object ? { [P in keyof T]?: DeepPartial<T[P]> } : T;

--- a/src/room-position.ts
+++ b/src/room-position.ts
@@ -61,11 +61,11 @@ interface RoomPosition {
      */
     findClosestByPath<K extends FindConstant, S extends FindTypes[K]>(
         type: K,
-        opts?: FindPathOpts & Partial<FilterOptions<K, S>> & { algorithm?: FindClosestByPathAlgorithm },
+        opts?: FindPathOpts & FilterOptions<FindTypes[K], S> & { algorithm?: FindClosestByPathAlgorithm },
     ): S | null;
     findClosestByPath<S extends AnyStructure>(
         type: FIND_STRUCTURES | FIND_MY_STRUCTURES | FIND_HOSTILE_STRUCTURES,
-        opts?: FindPathOpts & Partial<FilterOptions<FIND_STRUCTURES, S>> & { algorithm?: FindClosestByPathAlgorithm },
+        opts?: FindPathOpts & FilterOptions<FindTypes[FIND_STRUCTURES], S> & { algorithm?: FindClosestByPathAlgorithm },
     ): S | null;
     /**
      * Find the object with the shortest path from the given position. Uses A* search algorithm and Dijkstra's algorithm.
@@ -73,42 +73,40 @@ interface RoomPosition {
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      * @returns One of the supplied objects
      */
-    findClosestByPath<T extends _HasRoomPosition | RoomPosition>(
+    findClosestByPath<T extends _HasRoomPosition | RoomPosition, S extends T = T>(
         objects: T[],
-        opts?: FindPathOpts & { filter?: ((object: T, index: number, collection: T[]) => boolean) | FilterObject | string } & {
-            algorithm?: FindClosestByPathAlgorithm;
-        },
-    ): T | null;
+        opts?: FindPathOpts &
+            FilterOptions<T, S> & {
+                algorithm?: FindClosestByPathAlgorithm;
+            },
+    ): S | null;
     /**
      * Find the object with the shortest linear distance from the given position.
      * @param type Any of the FIND_* constants.
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      */
-    findClosestByRange<K extends FindConstant, S extends FindTypes[K]>(type: K, opts?: FilterOptions<K, S>): S | null;
+    findClosestByRange<K extends FindConstant, S extends FindTypes[K]>(type: K, opts?: FilterOptions<FindTypes[K], S>): S | null;
     findClosestByRange<S extends AnyStructure>(
         type: FIND_STRUCTURES | FIND_MY_STRUCTURES | FIND_HOSTILE_STRUCTURES,
-        opts?: FilterOptions<FIND_STRUCTURES, S>,
+        opts?: FilterOptions<FindTypes[FIND_STRUCTURES], S>,
     ): S | null;
     /**
      * Find the object with the shortest linear distance from the given position.
      * @param objects An array of RoomPositions or objects with a RoomPosition.
      * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
      */
-    findClosestByRange<T extends _HasRoomPosition | RoomPosition>(
-        objects: T[],
-        opts?: { filter?: ((object: T, index: number, collection: T[]) => boolean) | FilterObject | string },
-    ): T | null;
+    findClosestByRange<T extends _HasRoomPosition | RoomPosition, S extends T = T>(objects: T[], opts?: FilterOptions<T, S>): S | null;
     /**
      * Find all objects in the specified linear range.
      * @param type Any of the FIND_* constants.
      * @param range The range distance.
      * @param opts See Room.find.
      */
-    findInRange<K extends FindConstant, S extends FindTypes[K]>(type: K, range: number, opts?: FilterOptions<K, S>): S[];
+    findInRange<K extends FindConstant, S extends FindTypes[K]>(type: K, range: number, opts?: FilterOptions<FindTypes[K], S>): S[];
     findInRange<S extends AnyStructure>(
         type: FIND_STRUCTURES | FIND_MY_STRUCTURES | FIND_HOSTILE_STRUCTURES,
         range: number,
-        opts?: FilterOptions<FIND_STRUCTURES, S>,
+        opts?: FilterOptions<FindTypes[FIND_STRUCTURES], S>,
     ): S[];
     /**
      * Find all objects in the specified linear range.
@@ -116,11 +114,7 @@ interface RoomPosition {
      * @param range The range distance.
      * @param opts See Room.find.
      */
-    findInRange<T extends _HasRoomPosition | RoomPosition>(
-        objects: T[],
-        range: number,
-        opts?: { filter?: ((object: T, index: number, collection: T[]) => boolean) | FilterObject | string },
-    ): T[];
+    findInRange<T extends _HasRoomPosition | RoomPosition, S extends T = T>(objects: T[], range: number, opts?: FilterOptions<T, S>): S[];
     /**
      * Find an optimal path to the specified position using A* search algorithm.
      *

--- a/src/room.ts
+++ b/src/room.ts
@@ -146,10 +146,10 @@ interface Room {
      * @param opts An object with additional options
      * @returns An array with the objects found.
      */
-    find<K extends FindConstant, S extends FindTypes[K]>(type: K, opts?: FilterOptions<K, S>): S[];
+    find<K extends FindConstant, S extends FindTypes[K]>(type: K, opts?: FilterOptions<FindTypes[K], S>): S[];
     find<S extends AnyStructure>(
         type: FIND_STRUCTURES | FIND_MY_STRUCTURES | FIND_HOSTILE_STRUCTURES,
-        opts?: FilterOptions<FIND_STRUCTURES, S>,
+        opts?: FilterOptions<FindTypes[FIND_STRUCTURES], S>,
     ): S[];
     /**
      * Find the exit direction en route to another room.


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

https://github.com/screepers/typed-screeps/issues/235

Simply decoupling `FilterOption` and `FindConstant`, and improve `FilterOption`.

This PR does not brings any breaking change logically.

Currently the return type of `FilterFunction` is still `unknown`. It would be a breaking change to change it to `boolean`. Anyway I am in favor of doing that. Let's do it in another PR later.


### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
