### PR TITLE
Mark Spawning.directions as optional

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -4781,7 +4781,7 @@ interface Spawning {
      * An array with the spawn directions
      * @see http://docs.screeps.com/api/#StructureSpawn.Spawning.setDirections
      */
-    directions: DirectionConstant[];
+    directions: DirectionConstant[] | undefined;
 
     /**
      * The name of the creep

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -4781,7 +4781,7 @@ interface Spawning {
      * An array with the spawn directions
      * @see http://docs.screeps.com/api/#StructureSpawn.Spawning.setDirections
      */
-    directions: DirectionConstant[] | undefined;
+    directions?: DirectionConstant[];
 
     /**
      * The name of the creep

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -147,7 +147,7 @@ interface Spawning {
      * An array with the spawn directions
      * @see http://docs.screeps.com/api/#StructureSpawn.Spawning.setDirections
      */
-    directions: DirectionConstant[] | undefined;
+    directions?: DirectionConstant[];
 
     /**
      * The name of the creep

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -147,7 +147,7 @@ interface Spawning {
      * An array with the spawn directions
      * @see http://docs.screeps.com/api/#StructureSpawn.Spawning.setDirections
      */
-    directions: DirectionConstant[];
+    directions: DirectionConstant[] | undefined;
 
     /**
      * The name of the creep


### PR DESCRIPTION
This property is only defined if it was passed as spawn options, or it got set through `Spawn.spawning.setDirections`. Otherwise it'll be `undefined` and the creep will default to `[TOP]`.

Fixes #243.

### Checklists

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
