### PR TITLE
fix: Room.getEventLog() may return string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update `Game.structures` type to `OwnedStructure` ([#211](https://github.com/screepers/typed-screeps/pull/211))
 - Refactor: Decoupling `FilterOption` and `FindConstant` and improve `FilterOption` ([#238](https://github.com/screepers/typed-screeps/pull/238))
 - Fix: Mark `Spawning.directions` as optional ([#244](https://github.com/screepers/typed-screeps/pull/244))
+- Fix: `Room.getEventLog()` may return string ([#245](https://github.com/screepers/typed-screeps/pull/245))
 
 ### Removed
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -4286,7 +4286,11 @@ interface Room {
     /**
      * Returns an array of events happened on the previous tick in this room.
      */
-    getEventLog(raw?: boolean): EventItem[];
+    getEventLog(raw?: false): EventItem[];
+    /**
+     * Returns an raw JSON string of events happened on the previous tick in this room.
+     */
+    getEventLog(raw: true): string;
     /**
      * A shorthand to `Memory.rooms[room.name]`. You can use it for quick access the room’s specific memory data object.
      */

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -1085,7 +1085,10 @@ function resources(o: GenericStore): ResourceConstant[] {
 
 {
     room.getEventLog();
-    room.getEventLog(true);
+    const eventStr = room.getEventLog(true);
+    if (eventStr.includes(`build:4`)) {
+        // Build occured on last tick.
+    }
 
     const events = room.getEventLog();
 

--- a/src/room.ts
+++ b/src/room.ts
@@ -23,7 +23,11 @@ interface Room {
     /**
      * Returns an array of events happened on the previous tick in this room.
      */
-    getEventLog(raw?: boolean): EventItem[];
+    getEventLog(raw?: false): EventItem[];
+    /**
+     * Returns an raw JSON string of events happened on the previous tick in this room.
+     */
+    getEventLog(raw: true): string;
     /**
      * A shorthand to `Memory.rooms[room.name]`. You can use it for quick access the room’s specific memory data object.
      */


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

`Room.getEventLog(true)` will return a string.
The current type definitions dictate that `Room.getEventLog()` will always return `EventLog[]`. This is not the case.
This PR should correct this oversight.

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
