### PR TITLE
Improve Memory support for role based creeps and the like

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Breaking changes
 
-- More flexible `Memory` ([#246](https://github.com/screepers/typed-screeps/pull/246))
+- Improve `Memory` support for role based creeps ([#246](https://github.com/screepers/typed-screeps/pull/246))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Breaking changes
+
+- More flexible `Memory` ([#246](https://github.com/screepers/typed-screeps/pull/246))
+
 ### Added
 
 - Add type inference for params in filter callbacks ([#221](https://github.com/screepers/typed-screeps/pull/221))

--- a/README.md
+++ b/README.md
@@ -22,30 +22,30 @@ This repo has more activity and is considerably more up-to-date.
 
 ### Breaking Changes:
 
-- `Memory` is typed by default. The added typings are:
+- `Memory` is typed by default, each record defaults to `unknown`. The added typings are:
 
   - `CreepMemory`
   - `FlagMemory`
   - `SpawnMemory`
   - `RoomMemory`
 
-  If you like the idea of typed memory, but aren't ready to just jump fully in, you only need to make sure you define an interface for the above four types. Then you can extend them at a later time.
+  If you like the idea of typed memory, but aren't ready to just jump fully in, you only need to make sure you define the `Memory` interface loosely. Then you can extend them at a later time.
 
   Example:
 
   ```TypeScript
-  interface CreepMemory { [name: string]: any };
-  interface FlagMemory { [name: string]: any };
-  interface SpawnMemory { [name: string]: any };
-  interface RoomMemory { [name: string]: any };
-  ```
+  interface Memory {
+    // TODO: Remove this once types are in place.
+    // Everything is allowed.
+    [key: string]: any;
 
-  If you don't want to add types to the global `Memory` object, you will need to add the following interface along with the four above.
-
-  Example:
-
-  ```Typescript
-  interface Memory { [key: string]: any };
+    // TODO: Replace with specific memory types.
+    // Narrow down for the record types.
+    creeps: Record<string, any>;
+    flags: Record<string, any>;
+    spawns: Record<string, any>;
+    rooms: Record<string, any>;
+  }
   ```
 
 - Any place in code that uses a constant (ex `STRUCTURE_EXTENSION` or `FIND_MY_SPAWNS` is now constrained to use literal types. Here is the list of the new types:

--- a/README.md
+++ b/README.md
@@ -31,9 +31,23 @@ This repo has more activity and is considerably more up-to-date.
 
   If you like the idea of typed memory, but aren't ready to just jump fully in, you only need to make sure you define the `Memory` interface loosely. Then you can extend them at a later time.
 
-  Example:
+  Example for [tutorial section 5](https://github.com/screeps/tutorial-scripts/tree/0fc8e9d2d6fe55415d39cf1a0118297480e275f3/section5) types
 
-  ```TypeScript
+  ```ts
+  interface BuilderMemory {
+    role: "builder";
+    building: boolean;
+  }
+  interface HarvesterMemory {
+    role: "harvester";
+  }
+  interface UpgraderMemory {
+    role: "upgrader";
+    upgrading: boolean;
+  }
+
+  type MyCreepMemory = BuilderMemory | HarvesterMemory | UpgraderMemory;
+
   interface Memory {
     // TODO: Remove this once types are in place.
     // Everything is allowed.
@@ -41,7 +55,7 @@ This repo has more activity and is considerably more up-to-date.
 
     // TODO: Replace with specific memory types.
     // Narrow down for the record types.
-    creeps: Record<string, any>;
+    creeps: Record<string, MyCreepMemory>;
     flags: Record<string, any>;
     spawns: Record<string, any>;
     rooms: Record<string, any>;
@@ -66,18 +80,18 @@ This repo has more activity and is considerably more up-to-date.
 
   To update your code, you just need to change any `string` types to match one of the above. For example, if your code had:
 
-  ```TypeScript
+  ```ts
   function getBody(): string[] {
-    return [ WORK, MOVE, CARRY ];
+    return [WORK, MOVE, CARRY];
   }
-
   ```
 
   Change it to:
 
-  ```TypeScript
-  function getBody(): BodyPartConstant[] {  // this line changed
-    return [ WORK, MOVE, CARRY ];
+  ```ts
+  function getBody(): BodyPartConstant[] {
+    // this line changed
+    return [WORK, MOVE, CARRY];
   }
   ```
 
@@ -88,34 +102,34 @@ This repo has more activity and is considerably more up-to-date.
 
   If you have code like this (un-type-asserted use of `Game.getObjectById`)
 
-  ```TypeScript
-  interface Memory{
+  ```ts
+  interface Memory {
     towerIds: string[];
   }
 
   Memory.towerIds.forEach((towerId) => {
     const tower = Game.getObjectById(towerId); // type of returned tower is 'unknown' instead of 'any'
     tower.attack(targetCreep); // Error Object is of type unknown ts(2571)
-  })
+  });
   ```
 
   Change it store typed Ids:
 
-  ```TypeScript
-  interface Memory{
+  ```ts
+  interface Memory {
     towerIds: Array<Id<StructureTower>>;
   }
 
   Memory.towerIds.forEach((towerId) => {
     const tower = Game.getObjectById(towerId); // type of returned tower is StructureTower
     tower.attack(targetCreep);
-  })
+  });
   ```
 
   If you're already manually asserting the type of the game object, you're not required to change anything immediately however this is deprecated and may be removed in the future.
 
-  ```TypeScript
-  const towerId: Id<StructureTower> = ""  as Id<StructureTower>;
+  ```ts
+  const towerId: Id<StructureTower> = "" as Id<StructureTower>;
   const tower1 = Game.getObjectById(towerId); // recommended use, returns StructureTower type
   const tower2 = Game.getObjectById<StructureTower>(""); // @deprecated returns StructureTower type
   const tower3 = Game.getObjectById("") as StructureTower; // @deprecated returns StructureTower type
@@ -123,17 +137,17 @@ This repo has more activity and is considerably more up-to-date.
 
   `Id<T>` types are assignable to `string` but the reverse is not allowed implicitly. To assign a `string` type to an `Id<T>` type, you must explicitly assert the type.
 
-  ```TypeScript
+  ```ts
   const typedId: Id<Creep> = "123" as Id<Creep>; // assertion required
   const untypedId1: string = typedId; // no assertion required
   ```
 
 - Game objects have typed id properties `id: Id<this>`. These typed ids can by passed to `Game.getObjectById()` to receive typed game objects matching the type of the Id. See above bullet for more details.
 
-  ```TypeScript
-  creep.id // has type Id<Creep>
-  copy = Game.getObjectById(creep.id) // returns type Creep
-  tower.id // has type Id<StructureTower>
+  ```ts
+  creep.id; // has type Id<Creep>
+  copy = Game.getObjectById(creep.id); // returns type Creep
+  tower.id; // has type Id<StructureTower>
   ```
 
 ### Additional (non-breaking) Features:

--- a/build/concat.js
+++ b/build/concat.js
@@ -1,16 +1,17 @@
 const fs = require("fs");
 const path = require("path");
 
-fs.readdir(path.join(__dirname, "..", "src"), function(err, files) {
-    files = files.map(function(value) {
+fs.readdir(path.join(__dirname, "..", "src"), function (err, files) {
+    files = files.map(function (value) {
         return path.join("src", value);
     });
 
-    Promise.all(files.map((name)=>fs.promises.readFile(name))).then(
-    (fileContents)=>{
-        fs.writeFileSync(path.join(__dirname, "..", "dist", "index.d.ts"),
-                         Buffer.concat(fileContents));
-    }, (reason)=>{
-        console.log(reason);
-    });
+    Promise.all(files.map((name) => fs.promises.readFile(name))).then(
+        (fileContents) => {
+            fs.writeFileSync(path.join(__dirname, "..", "dist", "index.d.ts"), Buffer.concat(fileContents));
+        },
+        (reason) => {
+            console.log(reason);
+        },
+    );
 });

--- a/build/prependDescription.js
+++ b/build/prependDescription.js
@@ -12,7 +12,7 @@ const version = `${major}.${minor}.${patch}`;
 var description = `// Type definitions for Screeps ${version}`;
 
 if (fs.existsSync(BUILT_FILE_PATH)) {
-    prepend(BUILT_FILE_PATH, description, function(err) {
+    prepend(BUILT_FILE_PATH, description, function (err) {
         if (err) console.error(err);
     });
 }

--- a/build/prependHeader.js
+++ b/build/prependHeader.js
@@ -6,7 +6,7 @@ const BUILT_FILE_PATH = path.resolve(__dirname, "../dist/index.d.ts");
 const HEADER_TEXT = path.resolve(__dirname, "header.txt");
 
 if (fs.existsSync(BUILT_FILE_PATH) && fs.existsSync(HEADER_TEXT)) {
-    prepend(BUILT_FILE_PATH, fs.readFileSync(HEADER_TEXT), function(err) {
+    prepend(BUILT_FILE_PATH, fs.readFileSync(HEADER_TEXT), function (err) {
         if (err) console.error(err);
     });
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3207,19 +3207,15 @@ interface PriceHistory {
     avgPrice: number;
     stddevPrice: number;
 }
-interface Memory {
-    creeps: { [name: string]: CreepMemory };
-    powerCreeps: { [name: string]: PowerCreepMemory };
-    flags: { [name: string]: FlagMemory };
-    rooms: { [name: string]: RoomMemory };
-    spawns: { [name: string]: SpawnMemory };
-}
+interface Memory {}
 
-interface CreepMemory {}
-interface FlagMemory {}
-interface PowerCreepMemory {}
-interface RoomMemory {}
-interface SpawnMemory {}
+type MemoryType<K extends string> = Memory extends { [k in K]: Record<string, infer M> } ? M : unknown;
+
+type CreepMemory = MemoryType<"creeps">;
+type FlagMemory = MemoryType<"flags">;
+type PowerCreepMemory = MemoryType<"powerCreeps">;
+type RoomMemory = MemoryType<"rooms">;
+type SpawnMemory = MemoryType<"spawns">;
 
 declare const Memory: Memory;
 /**

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Screeps 3.3.3
+// Type definitions for Screeps 4.0.0
 // Project: https://github.com/screeps/screeps
 // Definitions by: Nhan Ho <https://github.com/NhanHo>
 //                 Bryan <https://github.com/bryanbecker>

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -21,13 +21,7 @@ const anotherRoomName: Room = Game.rooms.W10S11;
 
 // Sample memory extensions
 interface Memory {
-    creeps: Record<
-        string,
-        {
-            sourceId: Id<Source>;
-            lastHits: number;
-        }
-    >;
+    creeps: Record<string, { sourceId: Id<Source>; lastHits: number } & ({ type: "foo"; foo: number } | { type: "bar"; bar: number })>;
     flags: Record<string, unknown>;
     spawns: Record<string, unknown>;
     rooms: Record<string, unknown>;
@@ -147,6 +141,8 @@ function resources(o: GenericStore): ResourceConstant[] {
             memory: {
                 sourceId: "" as Id<Source>,
                 lastHits: 0,
+                type: "foo",
+                foo: 1000,
             },
         });
 

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -25,19 +25,15 @@ interface MinerMemory {
     sourceId: Id<Source>;
 }
 
-interface BuilderMemory {
-    targetId?: Id<ConstructionSite>;
-}
-
-interface HaulerMemory {
-    targetId?: Id<AnyStructure>;
+interface UpgraderMemory {
+    upgrading: boolean;
 }
 
 interface CommonCreepMemory {
     lastHits: number;
 }
 
-type MyCreepMemory = CommonCreepMemory & (Brand<"miner", MinerMemory> | Brand<"builder", BuilderMemory> | Brand<"hauler", HaulerMemory>);
+type MyCreepMemory = CommonCreepMemory & (Brand<"miner", MinerMemory> | Brand<"upgrader", UpgraderMemory>);
 
 // Sample memory extensions
 interface Memory {
@@ -165,11 +161,10 @@ function resources(o: GenericStore): ResourceConstant[] {
             },
         });
         Game.spawns[i].spawnCreep(body, "error", {
+            // @ts-expect-error
             memory: {
                 lastHits: 0,
-                // @ts-expect-error
-                role: "hauler",
-                sourceId: "" as Id<Source>,
+                role: "upgrader",
             },
         });
 

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -19,7 +19,7 @@ const body: BodyPartConstant[] = [WORK, WORK, CARRY, MOVE];
 // Sample inputs for Game.map.findRoute testing
 const anotherRoomName: Room = Game.rooms.W10S11;
 
-type Brand<T extends string, O extends object & Partial<Record<"role", never>>> = { role: T } & O;
+type AttachRole<T extends string, O extends object & Partial<Record<"role", never>>> = { role: T } & O;
 
 interface MinerMemory {
     sourceId: Id<Source>;
@@ -33,7 +33,7 @@ interface CommonCreepMemory {
     lastHits: number;
 }
 
-type MyCreepMemory = CommonCreepMemory & (Brand<"miner", MinerMemory> | Brand<"upgrader", UpgraderMemory>);
+type MyCreepMemory = CommonCreepMemory & (AttachRole<"miner", MinerMemory> | AttachRole<"upgrader", UpgraderMemory>);
 
 // Sample memory extensions
 interface Memory {

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -20,9 +20,17 @@ const body: BodyPartConstant[] = [WORK, WORK, CARRY, MOVE];
 const anotherRoomName: Room = Game.rooms.W10S11;
 
 // Sample memory extensions
-interface CreepMemory {
-    sourceId: Id<Source>;
-    lastHits: number;
+interface Memory {
+    creeps: Record<
+        string,
+        {
+            sourceId: Id<Source>;
+            lastHits: number;
+        }
+    >;
+    flags: Record<string, unknown>;
+    spawns: Record<string, unknown>;
+    rooms: Record<string, unknown>;
 }
 
 // Typescript always uses 'string' as the type of a key inside 'for in' loops.
@@ -135,7 +143,12 @@ function resources(o: GenericStore): ResourceConstant[] {
 
 {
     for (const i of Object.keys(Game.spawns)) {
-        Game.spawns[i].createCreep(body);
+        Game.spawns[i].spawnCreep(body, "test", {
+            memory: {
+                sourceId: "" as Id<Source>,
+                lastHits: 0,
+            },
+        });
 
         // Test StructureSpawn.Spawning
         const creep: Spawning | null = Game.spawns[i].spawning;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-screeps",
-  "version": "3.3.3",
+  "version": "4.0.0",
   "description": "Strong TypeScript declarations for the game Screeps.",
   "repository": "screepers/typed-screeps",
   "types": "./dist/index.d.ts",

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,15 +1,11 @@
-interface Memory {
-    creeps: { [name: string]: CreepMemory };
-    powerCreeps: { [name: string]: PowerCreepMemory };
-    flags: { [name: string]: FlagMemory };
-    rooms: { [name: string]: RoomMemory };
-    spawns: { [name: string]: SpawnMemory };
-}
+interface Memory {}
 
-interface CreepMemory {}
-interface FlagMemory {}
-interface PowerCreepMemory {}
-interface RoomMemory {}
-interface SpawnMemory {}
+type MemoryType<K extends string> = Memory extends { [k in K]: Record<string, infer M> } ? M : unknown;
+
+type CreepMemory = MemoryType<"creeps">;
+type FlagMemory = MemoryType<"flags">;
+type PowerCreepMemory = MemoryType<"powerCreeps">;
+type RoomMemory = MemoryType<"rooms">;
+type SpawnMemory = MemoryType<"spawns">;
 
 declare const Memory: Memory;


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->
### Problem

It is currently impossible to have memory types that make use of union types with type guards to narrow properties.
Assume we have the following types for our various roles.
```ts
interface MinerMemory {
  sourceId: Id<Source>;
}
interface BuilderMemory {
    targetId?: Id<ConstructionSite>;
}
interface HaulerMemory {
    targetId?: Id<AnyStructure>;
}
```

There is currently two ways to type this:
```ts
// The method using optional properties
interface CreepMemory {
  sourceId?: Id<Source>;
  targetId?: Id<ConstructionSite> | Id<AnyStructure>;
}
// Or using a nested property
type AttachRole<T extends string, O extends object & Partial<Record<"role", never>>> = { role: T } & O;
interface CreepMemory {
  actualMemory:
    | AttachRole<'miner', MinerMemory>
    | AttachRole<'builder', BuilderMemory>
    | AttachRole<'hauler', HaulerMemory>;
}
```

The first method has the obvious issue of requiring unnecessary checks for undefined, or unsafe use of the non-null assertion operator, the type also get's rather large, and you may end up reusing a property for the a lot of different purposes with various types.
The second method adds an extra unnecessary level of nesting, but does allow you to safely access memory based on the `role` property that `AttachRole` adds.

### The solution
This PR adds a solution that allows us to fully control the memory type.
```ts
type MyCreepMemory =
  | Brand<'miner', MinerMemory>
  | Brand<'builder', BuilderMemory>
  | Brand<'hauler', HaulerMemory>;

interface Memory {
  creeps: Record<string, MyCreepMemory>;
}

const creep = Game.creeps[name];
if (creep.memory.role === 'hauler') {
  // creep.memory is now of type HaulerMemory
}
```

There is a caveat. This solution prevents us from merging `CreepMemory` and the likes from multiple files.
In my opinion it shouldn't be done anyway, and isn't necessary - you should just import them and add them to the `*Memory` type above.

Other than that, we should have full support of what could be done before.

### Try it out
Use either of the below commands, depending on your package manager
```sh
npm install -D @types/screeps@jomik/typed-screeps#flexible-memory
```
```sh
yarn add -D @types/screeps@jomik/typed-screeps#flexible-memory
```

This should update your package.json to contain a reference to my branch:
```json
    "@types/screeps": "jomik/typed-screeps#flexible-memory",
```

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
