### PR TITLE
Game.map.describeExits returns null for non-existent rooms

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,3 +1,4 @@
+// Type definitions for Screeps 3.3.3
 // Project: https://github.com/screeps/screeps
 // Definitions by: Nhan Ho <https://github.com/NhanHo>
 //                 Bryan <https://github.com/bryanbecker>

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1746,7 +1746,7 @@ type BodyPartDefinition<T extends BodyPartConstant = BodyPartConstant> = T exten
            *
            * If the body part is boosted, this property specifies the mineral type which is used for boosting.
            */
-          boost?: keyof typeof BOOSTS[T];
+          boost?: keyof (typeof BOOSTS)[T];
           /**
            * One of the body part types constants.
            */
@@ -1790,6 +1790,15 @@ type StoreDefinitionUnlimited = Store<ResourceConstant, true>;
 //   energy: number;
 // }
 
+/**
+ * @example
+ * {
+ *   "1": "W8N4",       // TOP
+ *   "3": "W7N3",       // RIGHT
+ *   // "5": "W8N2",    // BOTTOM
+ *   "7": "W9N3"        // LEFT
+ * }
+ */
 type ExitsInformation = Partial<Record<ExitKey, string>>;
 
 interface AllLookAtTypes {

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,3 @@
-// Type definitions for Screeps 3.3.3
 // Project: https://github.com/screeps/screeps
 // Definitions by: Nhan Ho <https://github.com/NhanHo>
 //                 Bryan <https://github.com/bryanbecker>
@@ -2796,7 +2795,7 @@ interface GameMap {
      * @param roomName The room name.
      * @returns The exits information or null if the room not found.
      */
-    describeExits(roomName: string): ExitsInformation;
+    describeExits(roomName: string): ExitsInformation | null;
     /**
      * Find the exit direction from the given room en route to another room.
      * @param fromRoom Start room name or room object.

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -236,13 +236,15 @@ function resources(o: GenericStore): ResourceConstant[] {
 
 {
     const exits = Game.map.describeExits("W8N3");
-    // tslint:disable-next-line:newline-per-chained-call
-    keys(exits).map((exitKey) => {
-        const nextRoom = exits[exitKey];
-        const exitDir = +exitKey as ExitConstant;
-        const exitPos = creep.pos.findClosestByRange(exitDir);
-        return { nextRoom, exitPos };
-    });
+    if (exits) {
+        // tslint:disable-next-line:newline-per-chained-call
+        keys(exits).map((exitKey) => {
+            const nextRoom = exits[exitKey];
+            const exitDir = +exitKey as ExitConstant;
+            const exitPos = creep.pos.findClosestByRange(exitDir);
+            return { nextRoom, exitPos };
+        });
+    }
 }
 
 // Game.map.findExit()

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -147,7 +147,7 @@ type BodyPartDefinition<T extends BodyPartConstant = BodyPartConstant> = T exten
            *
            * If the body part is boosted, this property specifies the mineral type which is used for boosting.
            */
-          boost?: keyof typeof BOOSTS[T];
+          boost?: keyof (typeof BOOSTS)[T];
           /**
            * One of the body part types constants.
            */
@@ -191,6 +191,15 @@ type StoreDefinitionUnlimited = Store<ResourceConstant, true>;
 //   energy: number;
 // }
 
+/**
+ * @example
+ * {
+ *   "1": "W8N4",       // TOP
+ *   "3": "W7N3",       // RIGHT
+ *   // "5": "W8N2",    // BOTTOM
+ *   "7": "W9N3"        // LEFT
+ * }
+ */
 type ExitsInformation = Partial<Record<ExitKey, string>>;
 
 interface AllLookAtTypes {

--- a/src/map.ts
+++ b/src/map.ts
@@ -26,7 +26,7 @@ interface GameMap {
      * @param roomName The room name.
      * @returns The exits information or null if the room not found.
      */
-    describeExits(roomName: string): ExitsInformation;
+    describeExits(roomName: string): ExitsInformation | null;
     /**
      * Find the exit direction from the given room en route to another room.
      * @param fromRoom Start room name or room object.


### PR DESCRIPTION
### Brief Description

I just had my room-filler crash out because I was too close to the edge on a pserver. Turns out the comment hints about it happening, but the return type doesn't.

### Checklists

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
