### PR TITLE
Change the keys for `Game.map.describeExits` to be actual directions

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2042,7 +2042,7 @@ declare const InterShardMemory: InterShardMemory;
 
 type Terrain = "plain" | "swamp" | "wall";
 
-type ExitKey = "1" | "3" | "5" | "7";
+type ExitKey = TOP | RIGHT | BOTTOM | LEFT;
 
 type AnyCreep = Creep | PowerCreep;
 

--- a/src/literals.ts
+++ b/src/literals.ts
@@ -7,7 +7,7 @@
 
 type Terrain = "plain" | "swamp" | "wall";
 
-type ExitKey = "1" | "3" | "5" | "7";
+type ExitKey = TOP | RIGHT | BOTTOM | LEFT;
 
 type AnyCreep = Creep | PowerCreep;
 


### PR DESCRIPTION
### Brief Description

This makes it at least a bit clearer why the keys are odd numbers.

### Checklists

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
