### PR TITLE
Fix #252: lookForAtArea matrix result type.

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1825,9 +1825,9 @@ interface LookAtResultMatrix<K extends LookConstant = LookConstant> {
     };
 }
 
-interface LookForAtAreaResultMatrix<T, K extends keyof LookAtTypes = keyof LookAtTypes> {
+interface LookForAtAreaResultMatrix<T> {
     [y: number]: {
-        [x: number]: Array<LookForAtAreaResult<T, K>>;
+        [x: number]: T[];
     };
 }
 
@@ -4546,7 +4546,7 @@ interface Room {
         bottom: number,
         right: number,
         asArray?: false,
-    ): LookForAtAreaResultMatrix<AllLookAtTypes[T], T>;
+    ): LookForAtAreaResultMatrix<AllLookAtTypes[T]>;
     /**
      * Get the given objets in the supplied area.
      * @param type One of the LOOK_* constants

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -908,13 +908,17 @@ function resources(o: GenericStore): ResourceConstant[] {
     const x = flags[10];
     const y = x[11];
     const entry = y[0];
-    entry.flag.remove();
+    entry.remove();
 
     const creeps = room.lookForAtArea(LOOK_CREEPS, 10, 10, 20, 20, true);
 
     creeps[0].x;
     creeps[0].y;
     creeps[0].creep.move(TOP);
+
+    const structuresMatrix = room.lookForAtArea(LOOK_STRUCTURES, 10, 10, 20, 20);
+
+    structuresMatrix[15][15].find((s) => s.structureType === STRUCTURE_CONTROLLER);
 }
 
 // StoreDefinition

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -916,9 +916,15 @@ function resources(o: GenericStore): ResourceConstant[] {
     creeps[0].y;
     creeps[0].creep.move(TOP);
 
-    const structuresMatrix = room.lookForAtArea(LOOK_STRUCTURES, 10, 10, 20, 20, false);
+    // #252
+    const structuresMatrix = room.lookForAtArea(LOOK_STRUCTURES, 10, 10, 20, 20);
 
     structuresMatrix[15][15].find((s) => s.structureType === STRUCTURE_CONTROLLER);
+
+    // #252 with explicit isArray=false
+    const structuresMatrix2 = room.lookForAtArea(LOOK_STRUCTURES, 10, 10, 20, 20, false);
+
+    structuresMatrix2[15][15].find((s) => s.structureType === STRUCTURE_CONTROLLER);
 }
 
 // StoreDefinition

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -916,7 +916,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     creeps[0].y;
     creeps[0].creep.move(TOP);
 
-    const structuresMatrix = room.lookForAtArea(LOOK_STRUCTURES, 10, 10, 20, 20);
+    const structuresMatrix = room.lookForAtArea(LOOK_STRUCTURES, 10, 10, 20, 20, false);
 
     structuresMatrix[15][15].find((s) => s.structureType === STRUCTURE_CONTROLLER);
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -226,9 +226,9 @@ interface LookAtResultMatrix<K extends LookConstant = LookConstant> {
     };
 }
 
-interface LookForAtAreaResultMatrix<T, K extends keyof LookAtTypes = keyof LookAtTypes> {
+interface LookForAtAreaResultMatrix<T> {
     [y: number]: {
-        [x: number]: Array<LookForAtAreaResult<T, K>>;
+        [x: number]: T[];
     };
 }
 

--- a/src/room.ts
+++ b/src/room.ts
@@ -247,7 +247,7 @@ interface Room {
         bottom: number,
         right: number,
         asArray?: false,
-    ): LookForAtAreaResultMatrix<AllLookAtTypes[T], T>;
+    ): LookForAtAreaResultMatrix<AllLookAtTypes[T]>;
     /**
      * Get the given objets in the supplied area.
      * @param type One of the LOOK_* constants


### PR DESCRIPTION
### Brief Description

Fix incorrect typing for return value of room.lookForAtArea matrix form (isArray = false)

### Checklists

- [x] Test passed
- [x] Coding style (indentation, etc) - hope so, I let workpace-defined formatter do its job
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
