### PR TITLE
Setting the Order type to ORDER_BUY | ORDER_SELL instead of string

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3173,7 +3173,7 @@ interface Order {
     id: string;
     created: number;
     active?: boolean;
-    type: string;
+    type: ORDER_BUY | ORDER_SELL;
     resourceType: MarketResourceConstant;
     roomName?: string;
     amount: number;

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -378,6 +378,21 @@ function resources(o: GenericStore): ResourceConstant[] {
     Game.market.createOrder({ type: ORDER_SELL, resourceType: RESOURCE_GHODIUM, price: 9.95, totalAmount: 10000, roomName: "W1N1" });
     Game.market.createOrder({ type: ORDER_SELL, resourceType: RESOURCE_GHODIUM, price: 9.95, totalAmount: 10000 });
 
+    // Testing the hardcoded string literal value of the `type` field
+    {
+        // error
+        Game.market.createOrder({
+            // @ts-expect-error
+            type: "BUY",
+            resourceType: RESOURCE_GHODIUM,
+            price: 9.95,
+            totalAmount: 10000,
+        });
+
+        // okay
+        Game.market.createOrder({ type: "buy", resourceType: RESOURCE_GHODIUM, price: 9.95, totalAmount: 10000 });
+    }
+
     // Game.market.deal(orderId, amount, [yourRoomName])
     Game.market.deal("57cd2b12cda69a004ae223a3", 1000, "W1N1");
 

--- a/src/market.ts
+++ b/src/market.ts
@@ -116,7 +116,7 @@ interface Order {
     id: string;
     created: number;
     active?: boolean;
-    type: string;
+    type: ORDER_BUY | ORDER_SELL;
     resourceType: MarketResourceConstant;
     roomName?: string;
     amount: number;


### PR DESCRIPTION


<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description
Setting the type to ORDER_BUY | ORDER_SELL instead of string

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
