### PR TITLE
Fix typing of `creep.body[n].boost` to use mineral boosts

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -642,8 +642,7 @@ declare const REACTION_TIME: {
     XGHO2: 150;
 };
 
-declare const BOOSTS: {
-    [part: string]: { [boost: string]: { [action: string]: number } };
+interface BoostsDefinition {
     work: {
         UO: {
             harvest: 3;
@@ -757,6 +756,14 @@ declare const BOOSTS: {
             damage: 0.3;
         };
     };
+}
+
+type IndexableBoostValue<V> = V & Partial<Record<MineralBoostConstant, Partial<Record<BoostModifier, number>>>>;
+
+declare const BOOSTS: {
+    [K in keyof BoostsDefinition]: IndexableBoostValue<BoostsDefinition[K]>;
+} & {
+    claim?: Partial<Record<MineralBoostConstant, Partial<Record<BoostModifier, number>>>>;
 };
 
 declare const INTERSHARD_RESOURCES: InterShardResourceConstant[];
@@ -2090,24 +2097,43 @@ interface HeapStatistics {
 /**
  * Describes one part of a creep’s body.
  */
-type BodyPartDefinition<T extends BodyPartConstant = BodyPartConstant> = T extends any
-    ? {
-          /**
-           * One of the {@link ResourceConstant RESOURCE_*} constants.
-           *
-           * If the body part is boosted, this property specifies the mineral type which is used for boosting.
-           */
-          boost?: keyof (typeof BOOSTS)[T];
-          /**
-           * One of the body part types constants.
-           */
-          type: T;
-          /**
-           * The remaining amount of hit points of this body part.
-           */
-          hits: number;
-      }
-    : never;
+type BodyPartDefinition<T extends BodyPartConstant = BodyPartConstant> = [BodyPartConstant] extends [T]
+    ? T extends any
+        ? {
+              /**
+               * One of the {@link MineralBoostConstant RESOURCE_*} constants.
+               *
+               * If the body part is boosted, this property specifies the mineral type which is used for boosting.
+               */
+              boost?: MineralBoostConstant;
+              /**
+               * One of the body part types constants.
+               */
+              type: T;
+              /**
+               * The remaining amount of hit points of this body part.
+               */
+              hits: number;
+          }
+        : never
+    : T extends any
+      ? {
+            /**
+             * One of the {@link MineralBoostConstant RESOURCE_*} constants.
+             *
+             * If the body part is boosted, this property specifies the mineral type which is used for boosting.
+             */
+            boost?: T extends typeof CLAIM ? never : keyof BoostsDefinition[Extract<T, keyof BoostsDefinition>];
+            /**
+             * One of the body part types constants.
+             */
+            type: T;
+            /**
+             * The remaining amount of hit points of this body part.
+             */
+            hits: number;
+        }
+      : never;
 
 interface Owner {
     /**
@@ -3150,6 +3176,21 @@ type DENSITY_HIGH = 3;
 type DENSITY_ULTRA = 4;
 
 type DensityConstant = DENSITY_LOW | DENSITY_MODERATE | DENSITY_HIGH | DENSITY_ULTRA;
+
+type BoostModifier =
+    | "harvest"
+    | "build"
+    | "repair"
+    | "dismantle"
+    | "upgradeController"
+    | "attack"
+    | "rangedAttack"
+    | "rangedMassAttack"
+    | "heal"
+    | "rangedHeal"
+    | "capacity"
+    | "fatigue"
+    | "damage";
 /**
  * The options that can be accepted by `findRoute()` and friends.
  */

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -1031,8 +1031,190 @@ function resources(o: GenericStore): ResourceConstant[] {
     EXTENSION_ENERGY_CAPACITY[Game.rooms.myRoom.controller!.level];
 
     REACTIONS[Object.keys(creep.carry)[0]];
+}
 
-    BOOSTS[creep.body[0].type];
+{
+    // Test the BOOSTS constant
+
+    // Can be used with a body part, returns a record of mineral -> boosted property -> level
+    creep.body[0].boost; // $ExpectType MineralBoostConstant | undefined
+    const c = BOOSTS[creep.body[0].type];
+
+    // Can be used with all body part types, returns undefined
+    const undef = BOOSTS["claim"];
+
+    // Accessing a valid BOOST is fine
+    BOOSTS.attack.UH2O.attack;
+
+    // Accessing something that might not be valid optionals
+    BOOSTS.claim?.GHO2?.capacity;
+
+    // Can still be iterated over
+    for (const bodyPart of Object.keys(BOOSTS) as BodyPartConstant[]) {
+        const boosts = BOOSTS[bodyPart];
+        if (!boosts) continue;
+        for (const mineral of Object.keys(boosts) as MineralBoostConstant[]) {
+            const upgrades = boosts[mineral];
+        }
+    }
+
+    function activeBodyPartBoosts(creep: Creep): MineralBoostConstant[] {
+        return creep.body
+            .filter((p) => p.hits > 0)
+            .map((p) => p.boost)
+            .filter((b) => !!b);
+    }
+
+    type CombatBoosts = BodyPartDefinition<ATTACK | RANGED_ATTACK | HEAL>["boost"];
+    (undefined as CombatBoosts); // $ExpectType "UH" | "KO" | "LO" | "UH2O" | "KHO2" | "LHO2" | "XUH2O" | "XKHO2" | "XLHO2" | undefined
+}
+
+{
+    // Boost estimation code lifted from Overmind
+
+    type HARVEST = "harvest";
+    const HARVEST: HARVEST = "harvest";
+    type BUILD = "build";
+    const BUILD: BUILD = "build";
+    type UPGRADE = "upgrade";
+    const UPGRADE: UPGRADE = "upgrade";
+    type REPAIR = "repair";
+    const REPAIR: REPAIR = "repair";
+    type DISMANTLE = "dismantle";
+    const DISMANTLE: DISMANTLE = "dismantle";
+
+    type BoostTier = "T1" | "T2" | "T3";
+    type BoostType = ATTACK | CARRY | RANGED_ATTACK | HEAL | MOVE | TOUGH | HARVEST | DISMANTLE | UPGRADE | BUILD | REPAIR;
+
+    const BOOST_TIERS: {
+        [boostType in BoostType]: {
+            [boostTier in BoostTier]: MineralBoostConstant;
+        };
+    } = {
+        attack: {
+            T1: "UH",
+            T2: "UH2O",
+            T3: "XUH2O",
+        },
+        carry: {
+            T1: "KH",
+            T2: "KH2O",
+            T3: "XKH2O",
+        },
+        ranged_attack: {
+            T1: "KO",
+            T2: "KHO2",
+            T3: "XKHO2",
+        },
+        heal: {
+            T1: "LO",
+            T2: "LHO2",
+            T3: "XLHO2",
+        },
+        move: {
+            T1: "ZO",
+            T2: "ZHO2",
+            T3: "XZHO2",
+        },
+        tough: {
+            T1: "GO",
+            T2: "GHO2",
+            T3: "XGHO2",
+        },
+        harvest: {
+            T1: "UO",
+            T2: "UHO2",
+            T3: "XUHO2",
+        },
+        build: {
+            T1: "LH",
+            T2: "LH2O",
+            T3: "XLH2O",
+        },
+        repair: {
+            T1: "LH",
+            T2: "LH2O",
+            T3: "XLH2O",
+        },
+        dismantle: {
+            T1: "ZH",
+            T2: "ZH2O",
+            T3: "XZH2O",
+        },
+        upgrade: {
+            T1: "GH",
+            T2: "GH2O",
+            T3: "XGH2O",
+        },
+    };
+
+    const BoostTypeBodyparts: {
+        [boostType in BoostType]: BodyPartConstant;
+    } = {
+        [ATTACK]: ATTACK,
+        [CARRY]: CARRY,
+        [RANGED_ATTACK]: RANGED_ATTACK,
+        [HEAL]: HEAL,
+        [MOVE]: MOVE,
+        [TOUGH]: TOUGH,
+        [HARVEST]: WORK,
+        [BUILD]: WORK,
+        [REPAIR]: WORK,
+        [DISMANTLE]: WORK,
+        [UPGRADE]: WORK,
+    };
+
+    const BoostTypeToModifierName: {
+        [boostType in BoostType]: BoostModifier;
+    } = {
+        [ATTACK]: ATTACK,
+        [CARRY]: "capacity",
+        [RANGED_ATTACK]: "rangedAttack",
+        // [RANGED_MASS_ATTACK]: "rangedMassAttack",
+        [HEAL]: HEAL,
+        [MOVE]: "fatigue",
+        [TOUGH]: "damage",
+        [HARVEST]: "harvest",
+        [BUILD]: "build",
+        [REPAIR]: "repair",
+        [DISMANTLE]: "dismantle",
+        [UPGRADE]: "upgradeController",
+    };
+
+    /**
+     *
+     * @param body
+     * @param type
+     * @param intendedBoosts
+     * @returns
+     */
+    function getBodyPotential(body: BodyPartDefinition[], type: BoostType, intendedBoosts: MineralBoostConstant[] = []): number {
+        const bodyPart = BoostTypeBodyparts[type];
+        return body.reduce((sum, part) => {
+            if (part.hits === 0) {
+                return sum;
+            }
+            if (part.type === bodyPart) {
+                let boost = part.boost;
+                if (!boost && intendedBoosts) {
+                    boost = intendedBoosts.find(
+                        (boost) => boost === BOOST_TIERS[type].T1 || boost === BOOST_TIERS[type].T2 || boost === BOOST_TIERS[type].T3,
+                    );
+                }
+                if (!boost) {
+                    return sum + 1;
+                }
+
+                const key = BoostTypeToModifierName[type];
+                const partBoost = BOOSTS[bodyPart] ?? {};
+                if (partBoost[boost]?.[key] !== undefined) {
+                    return sum + (partBoost[boost]?.[key] ?? 0);
+                }
+                return sum + 1;
+            }
+            return sum;
+        }, 0);
+    }
 }
 
 // Tombstones
@@ -1186,7 +1368,7 @@ function atackPower(creep: Creep) {
     return creep.body
         .map((part) => {
             if (part.type === ATTACK) {
-                const multiplier = part.boost ? BOOSTS[part.type][part.boost].attack : 1;
+                const multiplier = part.boost ? BOOSTS[part.type][part.boost]?.attack ?? 0 : 1;
                 return multiplier * ATTACK_POWER;
             }
             return 0;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -608,8 +608,7 @@ declare const REACTION_TIME: {
     XGHO2: 150;
 };
 
-declare const BOOSTS: {
-    [part: string]: { [boost: string]: { [action: string]: number } };
+interface BoostsDefinition {
     work: {
         UO: {
             harvest: 3;
@@ -723,6 +722,14 @@ declare const BOOSTS: {
             damage: 0.3;
         };
     };
+}
+
+type IndexableBoostValue<V> = V & Partial<Record<MineralBoostConstant, Partial<Record<BoostModifier, number>>>>;
+
+declare const BOOSTS: {
+    [K in keyof BoostsDefinition]: IndexableBoostValue<BoostsDefinition[K]>;
+} & {
+    claim?: Partial<Record<MineralBoostConstant, Partial<Record<BoostModifier, number>>>>;
 };
 
 declare const INTERSHARD_RESOURCES: InterShardResourceConstant[];

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -188,24 +188,43 @@ interface HeapStatistics {
 /**
  * Describes one part of a creep’s body.
  */
-type BodyPartDefinition<T extends BodyPartConstant = BodyPartConstant> = T extends any
-    ? {
-          /**
-           * One of the {@link ResourceConstant RESOURCE_*} constants.
-           *
-           * If the body part is boosted, this property specifies the mineral type which is used for boosting.
-           */
-          boost?: keyof (typeof BOOSTS)[T];
-          /**
-           * One of the body part types constants.
-           */
-          type: T;
-          /**
-           * The remaining amount of hit points of this body part.
-           */
-          hits: number;
-      }
-    : never;
+type BodyPartDefinition<T extends BodyPartConstant = BodyPartConstant> = [BodyPartConstant] extends [T]
+    ? T extends any
+        ? {
+              /**
+               * One of the {@link MineralBoostConstant RESOURCE_*} constants.
+               *
+               * If the body part is boosted, this property specifies the mineral type which is used for boosting.
+               */
+              boost?: MineralBoostConstant;
+              /**
+               * One of the body part types constants.
+               */
+              type: T;
+              /**
+               * The remaining amount of hit points of this body part.
+               */
+              hits: number;
+          }
+        : never
+    : T extends any
+      ? {
+            /**
+             * One of the {@link MineralBoostConstant RESOURCE_*} constants.
+             *
+             * If the body part is boosted, this property specifies the mineral type which is used for boosting.
+             */
+            boost?: T extends typeof CLAIM ? never : keyof BoostsDefinition[Extract<T, keyof BoostsDefinition>];
+            /**
+             * One of the body part types constants.
+             */
+            type: T;
+            /**
+             * The remaining amount of hit points of this body part.
+             */
+            hits: number;
+        }
+      : never;
 
 interface Owner {
     /**

--- a/src/literals.ts
+++ b/src/literals.ts
@@ -709,3 +709,18 @@ type DENSITY_HIGH = 3;
 type DENSITY_ULTRA = 4;
 
 type DensityConstant = DENSITY_LOW | DENSITY_MODERATE | DENSITY_HIGH | DENSITY_ULTRA;
+
+type BoostModifier =
+    | "harvest"
+    | "build"
+    | "repair"
+    | "dismantle"
+    | "upgradeController"
+    | "attack"
+    | "rangedAttack"
+    | "rangedMassAttack"
+    | "heal"
+    | "rangedHeal"
+    | "capacity"
+    | "fatigue"
+    | "damage";


### PR DESCRIPTION
### Brief Description

This fixes the typing of `const BOOSTS` so that the `keyof (typeof BOOSTS[T])` that's used for `BodyPartDefinition.boost` doesn't degrade into `string | number` (number not being a thing).

It's a bit mingled in with more changes I was trying to get in from Overmind about boost modifiers (the keys to the last level of `BOOSTS`). Tell me if it's not something we care about, and I think that can be taken out. The other thing I'd wanted to do was to use the actual `RESOURCE_*` constants for the 2nd key-level, but IIRC that got me into type-trouble.

### Checklists

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run dtslint` to update `index.d.ts`
