### PR TITLE
Fix a transferEnergy type error where it suggested a creep.

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -5159,11 +5159,9 @@ interface StructureLink extends OwnedStructure<STRUCTURE_LINK> {
      */
     store: Store<RESOURCE_ENERGY, false>;
     /**
-     * Transfer energy from the link to another link or a creep.
+     * Transfer energy from the link to another link.
      *
-     * If the target is a creep, it has to be at adjacent square to the link.
-     *
-     * If the target is a link, it can be at any location in the same room.
+     * The target link can be at any position within the room.
      *
      * Remote transfer process implies 3% energy loss and cooldown delay depending on the distance.
      * @param target The target object.

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -5169,7 +5169,7 @@ interface StructureLink extends OwnedStructure<STRUCTURE_LINK> {
      * @param target The target object.
      * @param amount The amount of energy to be transferred. If omitted, all the available energy is used.
      */
-    transferEnergy(target: Creep | StructureLink, amount?: number): ScreepsReturnCode;
+    transferEnergy(target: StructureLink, amount?: number): ScreepsReturnCode;
 }
 
 interface StructureLinkConstructor extends _Constructor<StructureLink>, _ConstructorById<StructureLink> {}

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -202,7 +202,7 @@ interface StructureLink extends OwnedStructure<STRUCTURE_LINK> {
      * @param target The target object.
      * @param amount The amount of energy to be transferred. If omitted, all the available energy is used.
      */
-    transferEnergy(target: Creep | StructureLink, amount?: number): ScreepsReturnCode;
+    transferEnergy(target: StructureLink, amount?: number): ScreepsReturnCode;
 }
 
 interface StructureLinkConstructor extends _Constructor<StructureLink>, _ConstructorById<StructureLink> {}

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -192,11 +192,9 @@ interface StructureLink extends OwnedStructure<STRUCTURE_LINK> {
      */
     store: Store<RESOURCE_ENERGY, false>;
     /**
-     * Transfer energy from the link to another link or a creep.
+     * Transfer energy from the link to another link.
      *
-     * If the target is a creep, it has to be at adjacent square to the link.
-     *
-     * If the target is a link, it can be at any location in the same room.
+     * The target link can be at any position within the room.
      *
      * Remote transfer process implies 3% energy loss and cooldown delay depending on the distance.
      * @param target The target object.


### PR DESCRIPTION
### Brief Description

`StructureLink.transferEnergy()` 

Offered either a `Creep` or a `StructureLink` as an option to send energy to.
Links cannot beam energy into a creeps mind.

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [ x] Test passed
- [ x] Coding style (indentation, etc)
- [ x] Edits have been made to `src/` files not `index.d.ts`
- [ x] Run `npm run dtslint` to update `index.d.ts`
