### PR TITLE
Improve documentation for methods and their return types

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1461,7 +1461,7 @@ interface Creep extends RoomObject {
      * - ERR_NOT_IN_RANGE: The target is too far away.
      * - ERR_NO_BODYPART: There are no RANGED_ATTACK body parts in this creep’s body.
      */
-    rangedAttack(target: AnyCreep | Structure): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE | ERR_NO_BODYPART;
+    rangedAttack(target: AnyCreep | Structure): CreepActionReturnCode;
     /**
      * Heal another creep at a distance.
      *
@@ -1477,7 +1477,7 @@ interface Creep extends RoomObject {
      * - ERR_NOT_IN_RANGE: The target is too far away.
      * - ERR_NO_BODYPART: There are no HEAL body parts in this creep’s body.
      */
-    rangedHeal(target: AnyCreep): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE | ERR_NO_BODYPART;
+    rangedHeal(target: AnyCreep): CreepActionReturnCode;
     /**
      * A ranged attack against all hostile creeps or structures within 3 squares range.
      *
@@ -1503,9 +1503,7 @@ interface Creep extends RoomObject {
      * - ERR_NOT_IN_RANGE: The target is too far away.
      * - ERR_NO_BODYPART: There are no WORK body parts in this creep’s body.
      */
-    repair(
-        target: Structure,
-    ): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_ENOUGH_RESOURCES | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE | ERR_NO_BODYPART;
+    repair(target: Structure): CreepActionReturnCode | ERR_NOT_ENOUGH_RESOURCES;
     /**
      * Temporarily block a neutral controller from claiming by other players.
      *
@@ -1523,7 +1521,7 @@ interface Creep extends RoomObject {
      * - ERR_NOT_IN_RANGE: The target is too far away.
      * - ERR_NO_BODYPART: There are no CLAIM body parts in this creep’s body.
      */
-    reserveController(target: StructureController): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE | ERR_NO_BODYPART;
+    reserveController(target: StructureController): CreepActionReturnCode;
     /**
      * Display a visual speech balloon above the creep with the specified message.
      *
@@ -4052,7 +4050,7 @@ interface PowerCreep extends RoomObject {
      * - ERR_NOT_FOUND: The specified path doesn't match the creep's location.
      * - ERR_INVALID_ARGS: path is not a valid path array.
      */
-    moveByPath(path: PathStep[] | RoomPosition[] | string): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_FOUND | ERR_INVALID_ARGS;
+    moveByPath(path: PathStep[] | RoomPosition[] | string): CreepMoveReturnCode | ERR_NOT_FOUND | ERR_INVALID_ARGS;
     /**
      * Find the optimal path to the target within the same room and move to it.
      *
@@ -4101,7 +4099,7 @@ interface PowerCreep extends RoomObject {
      * - ERR_FULL: The creep cannot receive any more resource.
      * - ERR_NOT_IN_RANGE: The target is too far away.
      */
-    pickup(target: Resource): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_FULL | ERR_NOT_IN_RANGE;
+    pickup(target: Resource): CreepActionReturnCode | ERR_FULL;
     /**
      * Rename the power creep.
      *

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1059,7 +1059,7 @@ interface ConstructionSite<T extends BuildableStructureConstant = BuildableStruc
      */
     progressTotal: number;
     /**
-     * One of the {@link StructureConstant} constants.
+     * One of the {@link StructureConstant STRUCTURE_*} constants.
      */
     structureType: T;
     /**
@@ -1282,7 +1282,7 @@ interface Creep extends RoomObject {
     /**
      * Drop this resource on the ground.
      *
-     * @param resourceType One of the {@link ResourceConstant} constants.
+     * @param resourceType One of the {@link ResourceConstant RESOURCE_*} constants.
      * @param amount The amount of resource units to be dropped. If omitted, all the available carried amount is used.
      * @returns One of the following codes:
      * - OK: The operation has been scheduled successfully.
@@ -1356,7 +1356,7 @@ interface Creep extends RoomObject {
      * Move the creep one square in the specified direction or towards a creep that is pulling it.
      *
      * Requires the MOVE body part if not being pulled.
-     * @param direction The direction to move in (see {@link DirectionConstant}).
+     * @param direction The direction to move in ({@link DirectionConstant `TOP`, `TOP_LEFT`...}).
      * @param creep A creep nearby.
      * @return One of the following codes:
      * - OK: The operation has been scheduled successfully.
@@ -1568,7 +1568,7 @@ interface Creep extends RoomObject {
      *
      * The target has to be at adjacent square to the creep.
      * @param target The target object.
-     * @param resourceType One of the {@link ResourceConstant} constants
+     * @param resourceType One of the {@link ResourceConstant RESOURCE_*} constants
      * @param amount The amount of resources to be transferred. If omitted, all the available carried amount is used.
      * @returns One of the following codes:
      * - OK: The operation has been scheduled successfully.
@@ -1578,7 +1578,7 @@ interface Creep extends RoomObject {
      * - ERR_INVALID_TARGET: The target is not a valid object which can contain the specified resource.
      * - ERR_FULL: The target cannot receive any more resources.
      * - ERR_NOT_IN_RANGE: The target is too far away.
-     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant} constants, or the amount is incorrect.
+     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant RESOURCE_*} constants, or the amount is incorrect.
      */
     transfer(target: AnyCreep | Structure, resourceType: ResourceConstant, amount?: number): ScreepsReturnCode;
     /**
@@ -1613,7 +1613,7 @@ interface Creep extends RoomObject {
      * To transfer between creeps, use the {@link Creep.transfer} method on the original creep.
      *
      * @param target The target object.
-     * @param resourceType One of the {@link ResourceConstant} constants..
+     * @param resourceType One of the {@link ResourceConstant RESOURCE_*} constants.
      * @param amount The amount of resources to be transferred. If omitted, all the available amount is used.
      * @returns One of the following codes:
      * - OK: The operation has been scheduled successfully.
@@ -1623,7 +1623,7 @@ interface Creep extends RoomObject {
      * - ERR_INVALID_TARGET: The target is not a valid object which can contain the specified resource.
      * - ERR_FULL: The creep's carry is full.
      * - ERR_NOT_IN_RANGE: The target is too far away.
-     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant} constants, or the amount is incorrect.
+     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant RESOURCE_*} constants, or the amount is incorrect.
      */
     withdraw(target: Structure | Tombstone | Ruin, resourceType: ResourceConstant, amount?: number): ScreepsReturnCode;
 }
@@ -1680,7 +1680,7 @@ interface Flag extends RoomObject {
     readonly prototype: Flag;
 
     /**
-     * Flag color. One of the {@link ColorConstant} constants.
+     * Flag color. One of the {@link ColorConstant COLOR_*} constants.
      */
     color: ColorConstant;
     /**
@@ -1698,7 +1698,7 @@ interface Flag extends RoomObject {
      */
     name: string;
     /**
-     * Flag secondary color. One of the {@link ColorConstant} constants.
+     * Flag secondary color. One of the {@link ColorConstant COLOR_*} constants.
      */
     secondaryColor: ColorConstant;
     /**
@@ -1708,8 +1708,8 @@ interface Flag extends RoomObject {
     remove(): OK;
     /**
      * Set new color of the flag.
-     * @param color One of the {@link ColorConstant} constants.
-     * @param secondaryColor Secondary color of the flag. One of the {@link ColorConstant} constants.
+     * @param color One of the {@link ColorConstant COLOR_*} constants.
+     * @param secondaryColor Secondary color of the flag. One of the {@link ColorConstant COLOR_*} constants.
      * @returns One of the following codes:
      * - OK: The operation has been scheduled successfully.
      * - ERR_INVALID_ARGS: color or secondaryColor is not a valid color constant.
@@ -2011,7 +2011,7 @@ interface HeapStatistics {
 type BodyPartDefinition<T extends BodyPartConstant = BodyPartConstant> = T extends any
     ? {
           /**
-           * One of the {@link ResourceConstant} constants.
+           * One of the {@link ResourceConstant RESOURCE_*} constants.
            *
            * If the body part is boosted, this property specifies the mineral type which is used for boosting.
            */
@@ -3511,7 +3511,7 @@ interface Market {
     getAllOrders(filter?: OrderFilter | ((o: Order) => boolean)): Order[];
     /**
      * Get daily price history of the specified resource on the market for the last 14 days.
-     * @param resource One of the {@link MarketResourceConstant} constants. If undefined, returns history data for all resources. Optional
+     * @param resource One of the {@link MarketResourceConstant RESOURCE_*} constants. If undefined, returns history data for all resources. Optional
      * @returns An array of objects with resource info.
      */
     getHistory(resource?: MarketResourceConstant): PriceHistory[];
@@ -3634,7 +3634,7 @@ interface Mineral<T extends MineralConstant = MineralConstant> extends RoomObjec
      */
     readonly prototype: Mineral;
     /**
-     * The density of this mineral deposit, one of the {@link DensityConstant} constants.
+     * The density of this mineral deposit, one of the {@link DensityConstant DENSITY_*} constants.
      */
     density: number;
     /**
@@ -3642,7 +3642,7 @@ interface Mineral<T extends MineralConstant = MineralConstant> extends RoomObjec
      */
     mineralAmount: number;
     /**
-     * The resource type, one of the {@link MineralConstant} constants.
+     * The resource type, one of the {@link MineralConstant RESOURCE_*} constants.
      */
     mineralType: T;
     /**
@@ -3902,7 +3902,7 @@ interface PowerCreep extends RoomObject {
      */
     carryCapacity: number;
     /**
-     * The power creep's class, one of the {@link PowerClassConstant} constants.
+     * The power creep's class, one of the {@link PowerClassConstant POWER_CLASS} constants.
      */
     className: PowerClassConstant;
     /**
@@ -4004,14 +4004,14 @@ interface PowerCreep extends RoomObject {
     delete(cancel?: boolean): OK | ERR_NOT_OWNER | ERR_BUSY;
     /**
      * Drop this resource on the ground.
-     * @param resourceType One of the {@link ResourceConstant} constants.
+     * @param resourceType One of the {@link ResourceConstant RESOURCE_*} constants.
      * @param amount The amount of resource units to be dropped. If omitted, all the available carried amount is used.
      * @returns One of the following codes:
      * - OK: The operation has been scheduled successfully.
      * - ERR_NOT_OWNER: You are not the owner of this creep.
      * - ERR_BUSY: The power creep is not spawned in the world.
      * - ERR_NOT_ENOUGH_RESOURCES: The creep does not have the given amount of energy.
-     * - ERR_INVALID_ARGS: The resourceType is not a valid {@link ResourceConstant} constants.
+     * - ERR_INVALID_ARGS: The resourceType is not a valid {@link ResourceConstant RESOURCE_*} constants.
      */
     drop(resourceType: ResourceConstant, amount?: number): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_ENOUGH_RESOURCES;
     /**
@@ -4030,7 +4030,7 @@ interface PowerCreep extends RoomObject {
      * Move the creep one square in the specified direction or towards a creep that is pulling it.
      *
      * Requires the MOVE body part if not being pulled.
-     * @param direction The direction to move in (see {@link DirectionConstant})
+     * @param direction The direction to move in ({@link DirectionConstant `TOP`, `TOP_LEFT`...})
      * @returns One of the following codes:
      * - OK: The operation has been scheduled successfully.
      * - ERR_NOT_OWNER: You are not the owner of this creep.
@@ -4167,7 +4167,7 @@ interface PowerCreep extends RoomObject {
      *
      * The target has to be at adjacent square to the creep.
      * @param target The target object.
-     * @param resourceType One of the {@link ResourceConstant} constants
+     * @param resourceType One of the {@link ResourceConstant RESOURCE_*} constants
      * @param amount The amount of resources to be transferred. If omitted, all the available carried amount is used.
      * @returns
      * - OK: The operation has been scheduled successfully.
@@ -4177,14 +4177,14 @@ interface PowerCreep extends RoomObject {
      * - ERR_INVALID_TARGET: The target is not a valid object which can contain the specified resource.
      * - ERR_FULL: The target cannot receive any more resources.
      * - ERR_NOT_IN_RANGE: The target is too far away.
-     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant} constants, or the amount is incorrect.
+     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant RESOURCE_*} constants, or the amount is incorrect.
      */
     transfer(target: AnyCreep | Structure, resourceType: ResourceConstant, amount?: number): ScreepsReturnCode;
     /**
      * Upgrade the creep, adding a new power ability to it or increasing the level of the existing power.
      *
      * You need one free Power Level in your account to perform this action.
-     * @param power	The power ability to upgrade, one of the {@link PowerConstant} constants.
+     * @param power	The power ability to upgrade, one of the {@link PowerConstant PWR_*} constants.
      * @returns
      * - OK: The operation has been scheduled successfully.
      * - ERR_NOT_OWNER: You are not the owner of the creep.
@@ -4196,7 +4196,7 @@ interface PowerCreep extends RoomObject {
     /**
      * Apply one of the creep's powers on the specified target.
      *
-     * @param power The power ability to use, one of the {@link PowerConstant} constants.
+     * @param power The power ability to use, one of the {@link PowerConstant PWR_*} constants.
      * @param target A target object in the room.
      * @returns
      * - OK: The operation has been scheduled successfully.
@@ -4220,7 +4220,7 @@ interface PowerCreep extends RoomObject {
      *
      * Your creeps can withdraw resources from hostile structures as well, in case if there is no hostile rampart on top of it.
      * @param target The target object.
-     * @param resourceType The target One of the {@link ResourceConstant} constants..
+     * @param resourceType The target One of the {@link ResourceConstant RESOURCE_*} constants.
      * @param amount The amount of resources to be transferred. If omitted, all the available amount is used.
      * @returns
      * - OK: The operation has been scheduled successfully.
@@ -4230,7 +4230,7 @@ interface PowerCreep extends RoomObject {
      * - ERR_INVALID_TARGET: The target is not a valid object which can contain the specified resource.
      * - ERR_FULL: The creep's carry is full.
      * - ERR_NOT_IN_RANGE: The target is too far away.
-     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant} constants, or the amount is incorrect.
+     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant RESOURCE_*} constants, or the amount is incorrect.
      */
     withdraw(target: Structure | Tombstone | Ruin, resourceType: ResourceConstant, amount?: number): ScreepsReturnCode;
 }
@@ -4244,7 +4244,7 @@ interface PowerCreepConstructor extends _Constructor<PowerCreep>, _ConstructorBy
      * You need one free Power Level in your account to perform this action.
      *
      * @param name The name of the power creep.
-     * @param className The class of the new power creep, one of the {@link PowerClassConstant} constants
+     * @param className The class of the new power creep, one of the {@link PowerClassConstant POWER_CLASS} constants
      */
     create(name: string, className: PowerClassConstant): OK | ERR_NAME_EXISTS | ERR_NOT_ENOUGH_RESOURCES;
 }
@@ -4383,7 +4383,7 @@ interface Resource<T extends ResourceConstant = ResourceConstant> extends RoomOb
      */
     id: Id<this>;
     /**
-     * One of the {@link ResourceConstant} constants.
+     * One of the {@link ResourceConstant RESOURCE_*} constants.
      */
     resourceType: T;
 }
@@ -4435,7 +4435,7 @@ interface NaturalEffect {
     /**
      * Effect ID of the applied effect.
      *
-     * One of the {@link EffectConstant} constants.
+     * One of the {@link EffectConstant EFFECT_*} constants.
      */
     effect: EffectConstant;
     /**
@@ -4455,7 +4455,7 @@ interface PowerEffect {
     /**
      * Effect ID of the applied effect.
      *
-     * One of the {@link PowerConstant} constants.
+     * One of the {@link PowerConstant PWR_*} constants.
      */
     effect: PowerConstant;
     /**
@@ -4463,7 +4463,7 @@ interface PowerEffect {
      *
      * @deprecated Use {@link PowerEffect.effect} instead.
      *
-     * One of the {@link PowerConstant} constants.
+     * One of the {@link PowerConstant PWR_*} constants.
      */
     power: PowerConstant;
     /**
@@ -4495,7 +4495,7 @@ interface RoomPosition {
     y: number;
     /**
      * Create a new {@link ConstructionSite} at the specified location.
-     * @param structureType One of {@link BuildableStructureConstant}.
+     * @param structureType One of {@link BuildableStructureConstant Buildable STRUCTURE_*}.
      * @returns
      * - OK: The operation has been scheduled successfully.
      * - ERR_NOT_OWNER: You don't have ownership of the targetted room.
@@ -4507,7 +4507,7 @@ interface RoomPosition {
     createConstructionSite(structureType: BuildableStructureConstant): ScreepsReturnCode;
     /**
      * Create a new {@link ConstructionSite} at the specified location.
-     * @param structureType One of {@link BuildableStructureConstant}.
+     * @param structureType One of {@link BuildableStructureConstant Buildable STRUCTURE_*}.
      * @param name The name of the structure, for structures that support it (currently only spawns). The name length limit is 100 characters.
      * @returns
      * - OK: The operation has been scheduled successfully.
@@ -4523,8 +4523,8 @@ interface RoomPosition {
      * @param name The name of a new flag.
      * It should be unique, i.e. the Game.flags object should not contain another flag with the same name (hash key).
      * If not defined, a random name will be generated.
-     * @param color The color of a new flag. Should be one of the {@link ColorConstant} constants
-     * @param secondaryColor The secondary color of a new flag. Should be one of the {@link ColorConstant} constants. The default value is equal to color.
+     * @param color The color of a new flag. Should be one of the {@link ColorConstant COLOR_*} constants
+     * @param secondaryColor The secondary color of a new flag. Should be one of the {@link ColorConstant COLOR_*} constants. The default value is equal to color.
      * @returns The name of the flag if created, or one of the following error codes: ERR_NAME_EXISTS, ERR_INVALID_ARGS
      */
     createFlag(name?: string, color?: ColorConstant, secondaryColor?: ColorConstant): ERR_NAME_EXISTS | ERR_INVALID_ARGS | string;
@@ -4532,7 +4532,7 @@ interface RoomPosition {
      * Find the object with the shortest path from the given position.
      *
      * Uses A* search algorithm and Dijkstra's algorithm.
-     * @param type Any of the {@link FindConstant} constants.
+     * @param type Any of the {@link FindConstant FIND_*} constants.
      * @param opts An object containing pathfinding options (see {@link Room.findPath}), or one of the following: filter, algorithm
      * @returns An instance of a RoomObject.
      */
@@ -4561,7 +4561,7 @@ interface RoomPosition {
     ): S | null;
     /**
      * Find the object with the shortest linear distance from the given position.
-     * @param type Any of the {@link FindConstant} constants.
+     * @param type Any of the {@link FindConstant FIND_*} constants.
      * @param opts An object containing pathfinding options (see {@link Room.findPath}), or one of the following: filter, algorithm
      */
     findClosestByRange<K extends FindConstant, S extends FindTypes[K]>(type: K, opts?: FilterOptions<FindTypes[K], S>): S | null;
@@ -4577,7 +4577,7 @@ interface RoomPosition {
     findClosestByRange<T extends _HasRoomPosition | RoomPosition, S extends T = T>(objects: T[], opts?: FilterOptions<T, S>): S | null;
     /**
      * Find all objects in the specified linear range.
-     * @param type Any of the {@link FindConstant} constants.
+     * @param type Any of the {@link FindConstant FIND_*} constants.
      * @param range The range distance.
      * @param opts See Room.find.
      */
@@ -5042,7 +5042,7 @@ interface Room {
      * Create new {@link ConstructionSite} at the specified location.
      * @param x The X position
      * @param y The Y position
-     * @param structureType One of {@link BuildableStructureConstant}.
+     * @param structureType One of {@link BuildableStructureConstant Buildable STRUCTURE_*}.
      * @returns
      * - OK: The operation has been scheduled successfully.
      * - ERR_NOT_OWNER: The room is claimed or reserved by a hostile player.
@@ -5055,7 +5055,7 @@ interface Room {
     /**
      * Create new {@link ConstructionSite} at the specified location.
      * @param pos Can be a {@link RoomPosition} object or any object containing RoomPosition.
-     * @param structureType One of {@link BuildableStructureConstant}.
+     * @param structureType One of {@link BuildableStructureConstant Buildable STRUCTURE_*}.
      * @returns
      * - OK: The operation has been scheduled successfully.
      * - ERR_NOT_OWNER: The room is claimed or reserved by a hostile player.
@@ -5069,7 +5069,7 @@ interface Room {
      * Create new {@link ConstructionSite} at the specified location.
      * @param x The X position
      * @param y The Y position
-     * @param structureType One of {@link BuildableStructureConstant}.
+     * @param structureType One of {@link BuildableStructureConstant Buildable STRUCTURE_*}.
      * @returns
      * - OK: The operation has been scheduled successfully.
      * - ERR_NOT_OWNER: The room is claimed or reserved by a hostile player.
@@ -5082,7 +5082,7 @@ interface Room {
     /**
      * Create new {@link ConstructionSite} at the specified location.
      * @param pos Can be a {@link RoomPosition} object or any object containing RoomPosition.
-     * @param structureType One of {@link BuildableStructureConstant}.
+     * @param structureType One of {@link BuildableStructureConstant Buildable STRUCTURE_*}.
      * @returns
      * - OK: The operation has been scheduled successfully.
      * - ERR_NOT_OWNER: The room is claimed or reserved by a hostile player.
@@ -5142,7 +5142,7 @@ interface Room {
     ): ERR_NAME_EXISTS | ERR_INVALID_ARGS | string;
     /**
      * Find all objects of the specified type in the room.
-     * @param type One of the {@link FindConstant} constants.
+     * @param type One of the {@link FindConstant FIND_*} constants.
      * @param opts An object with additional options
      * @returns An array with the objects found.
      */
@@ -5209,17 +5209,23 @@ interface Room {
     /**
      * Get the objects at the given position.
      *
-     * @param type One of the {@link LookConstant} constants.
+     * @param type One of the {@link LookConstant LOOK_*} constants.
      * @param x The X position.
      * @param y The Y position.
-     * @param target A RoomPosition. Its room name will be ignored.
      * @returns An array of objects of the requested type at the given position, or ERR_INVALID_ARGS.
      */
     lookForAt<T extends keyof AllLookAtTypes>(type: T, x: number, y: number): Array<AllLookAtTypes[T]>;
+    /**
+     * Get the objects at the given position.
+     *
+     * @param type One of the {@link LookConstant LOOK_*} constants.
+     * @param target A RoomPosition. Its room name will be ignored.
+     * @returns An array of objects of the requested type at the given position, or ERR_INVALID_ARGS.
+     */
     lookForAt<T extends keyof AllLookAtTypes>(type: T, target: RoomPosition | _HasRoomPosition): Array<AllLookAtTypes[T]>;
     /**
      * Get the given objects in the supplied area.
-     * @param type One of the {@link LookConstant} constants
+     * @param type One of the {@link LookConstant LOOK_*} constants
      * @param top The top (Y) boundary of the area.
      * @param left The left (X) boundary of the area.
      * @param bottom The bottom (Y) boundary of the area.
@@ -5708,7 +5714,7 @@ interface Structure<T extends StructureConstant = StructureConstant> extends Roo
      */
     room: Room;
     /**
-     * One of the {@link StructureConstant} constants.
+     * One of the {@link StructureConstant STRUCTURE_*} constants.
      */
     structureType: T;
     /**
@@ -5839,7 +5845,7 @@ interface StructureController extends OwnedStructure<STRUCTURE_CONTROLLER> {
     activateSafeMode(): ScreepsReturnCode;
     /**
      * Make your claimed controller neutral again.
-     * @returnsOne of the following codes:
+     * @returns One of the following codes:
      * - OK: The operation has been scheduled successfully.
      * - ERR_NOT_OWNER: You are not the owner of this controller.
      */
@@ -6361,7 +6367,7 @@ interface StructureTerminal extends OwnedStructure<STRUCTURE_TERMINAL> {
     storeCapacity: number;
     /**
      * Sends resource to a Terminal in another room with the specified name.
-     * @param resourceType One of the {@link ResourceConstant} constants.
+     * @param resourceType One of the {@link ResourceConstant RESOURCE_*} constants.
      * @param amount The amount of resources to be sent.
      * @param destination The name of the target room. You don't have to gain visibility in this room.
      * @param description The description of the transaction. It is visible to the recipient. The maximum length is 100 characters.
@@ -6389,7 +6395,7 @@ interface StructureContainer extends Structure<STRUCTURE_CONTAINER> {
     /**
      * An object with the structure contents.
      *
-     * Each object key is one of the {@link ResourceConstant} constants, values are resources
+     * Each object key is one of the {@link ResourceConstant RESOURCE_*} constants, values are resources
      * amounts. Use `_.sum(structure.store)` to get the total amount of contents.
      */
     store: StoreDefinition;
@@ -6516,7 +6522,7 @@ interface StructureFactory extends OwnedStructure<STRUCTURE_FACTORY> {
      * Produces the specified commodity.
      *
      * All ingredients should be available in the factory store.
-     * @param resource One of the {@link ResourceConstant} constants.
+     * @param resource One of the {@link CommoditiesTypes producible RESOURCE_*} constants.
      * @returns One of the following codes:
      * - OK: The operation has been scheduled successfully.
      * - ERR_NOT_OWNER: You are not the owner of this structure.
@@ -6653,7 +6659,7 @@ interface Tombstone extends RoomObject {
     /**
      * An object with the tombstone contents.
      *
-     * Each object key is one of the {@link ResourceConstant} constants, values are resources amounts.
+     * Each object key is one of the {@link ResourceConstant RESOURCE_*} constants, values are resources amounts.
      * {@link RESOURCE_ENERGY} is always defined and equals to 0 when empty, other resources are undefined when empty.
      * You can use `_.sum(tombstone.store)` to get the total amount of contents.
      */

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1027,11 +1027,19 @@ declare const POWER_INFO: {
 };
 /**
  * A site of a structure which is currently under construction.
+ *
+ * A construction site can be created using the 'Construct' button at the left of the game field or the {@link Room.createConstructionSite} method.
+ *
+ * To build a structure on the construction site, give a worker creep some amount of energy and perform {@link Creep.build} action.
+ *
+ * You can remove enemy construction sites by moving a creep on it.
  */
 interface ConstructionSite<T extends BuildableStructureConstant = BuildableStructureConstant> extends RoomObject {
     readonly prototype: ConstructionSite;
     /**
-     * A unique object identifier. You can use `Game.getObjectById` method to retrieve an object instance by its `id`.
+     * A unique object identifier.
+     *
+     * You can use {@link Game.getObjectById} to retrieve an object instance by its `id`.
      */
     id: Id<this>;
     /**
@@ -1051,7 +1059,7 @@ interface ConstructionSite<T extends BuildableStructureConstant = BuildableStruc
      */
     progressTotal: number;
     /**
-     * One of the `STRUCTURE_*` constants.
+     * One of the {@link StructureConstant} constants.
      */
     structureType: T;
     /**
@@ -1066,8 +1074,30 @@ interface ConstructionSiteConstructor extends _Constructor<ConstructionSite>, _C
 declare const ConstructionSite: ConstructionSiteConstructor;
 /**
  * Creeps are your units.
+ *
  * Creeps can move, harvest energy, construct structures, attack another creeps, and perform other actions.
- * Each creep consists of up to 50 body parts with the following possible types:
+ * Each creep consists of up to 50 body parts represented by {@link BodyPartConstant}:.
+ *
+ * | Body part       | Build cost | Effect per one body part
+ * | :-------------- | :--------: | :-----------------------
+ * | MOVE            | 50         | Decreases fatigue by 2 points per tick.
+ * | WORK            | 100        | Harvests 2 energy units from a source per tick.
+ * |                 |            | Harvests 1 resource unit from a mineral or a deposit per tick.
+ * |                 |            | Builds a structure for 5 energy units per tick.
+ * |                 |            | Repairs a structure for 100 hits per tick consuming 1 energy unit per tick.
+ * |                 |            | Dismantles a structure for 50 hits per tick returning 0.25 energy unit per tick.
+ * |                 |            | Upgrades a controller for 1 energy unit per tick.
+ * | CARRY           | 50         | Can contain up to 50 resource units.
+ * | ATTACK          | 80         | Attacks another creep/structure with 30 hits per tick in a short-ranged attack.
+ * | RANGED_ATTACK   | 150        | Attacks another single creep/structure with 10 hits per tick in a long-range attack up to 3 squares long.
+ * |                 |            | Attacks all hostile creeps/structures within 3 squares range with 1-4-10 hits (depending on the range).
+ * | HEAL            | 250        | Heals self or another creep restoring 12 hits per tick in short range or 4 hits per tick at a distance.
+ * | CLAIM           | 600        | Claims a neutral room controller.
+ * |                 |            | Reserves a neutral room controller for 1 tick per body part.
+ * |                 |            | Attacks a hostile room controller downgrading its timer by 300 ticks per body parts.
+ * |                 |            | Attacks a neutral room controller reservation timer by 1 tick per body parts.
+ * |                 |            | A creep with this body part will have a reduced life time of 600 ticks and cannot be renewed.
+ * | TOUGH           | 10         | No effect, just additional hit points to the creep's body. Can be boosted to resist damage.
  */
 interface Creep extends RoomObject {
     readonly prototype: Creep;
@@ -1083,11 +1113,13 @@ interface Creep extends RoomObject {
     carry: StoreDefinition;
     /**
      * The total amount of resources the creep can carry.
-     * @deprecated alias for Creep.store.getCapacity
+     * @deprecated alias for {@link Creep.store.getCapacity}
      */
     carryCapacity: number;
     /**
-     * The movement fatigue indicator. If it is greater than zero, the creep cannot move.
+     * The movement fatigue indicator.
+     *
+     * If it is greater than zero, the creep cannot move.
      */
     fatigue: number;
     /**
@@ -1099,11 +1131,15 @@ interface Creep extends RoomObject {
      */
     hitsMax: number;
     /**
-     * A unique object identifier. You can use `Game.getObjectById` method to retrieve an object instance by its `id`.
+     * A unique object identifier.
+     *
+     * You can use {@link Game.getObjectById} to retrieve an object instance by its `id`.
      */
     id: Id<this>;
     /**
-     * A shorthand to `Memory.creeps[creep.name]`. You can use it for quick access the creep’s specific memory data object.
+     * A shorthand to `Memory.creeps[creep.name]`.
+     *
+     * You can use it for quick access the creep’s specific memory data object.
      */
     memory: CreepMemory;
     /**
@@ -1111,7 +1147,10 @@ interface Creep extends RoomObject {
      */
     my: boolean;
     /**
-     * Creep’s name. You can choose the name while creating a new creep, and it cannot be changed later. This name is a hash key to access the creep via the `Game.creeps` object.
+     * The creep’s name.
+     *
+     * You can choose the name while creating a new creep, and it cannot be changed later.
+     * This name is a hash key to access the creep via the {@link Game.creeps} object.
      */
     name: string;
     /**
@@ -1119,7 +1158,9 @@ interface Creep extends RoomObject {
      */
     owner: Owner;
     /**
-     * The link to the Room object. Always defined because creeps give visibility into the room they're in.
+     * The {@link Room} the creep is in.
+     *
+     * Always defined because creeps give visibility into the room they're in.
      */
     room: Room;
     /**
@@ -1141,78 +1182,135 @@ interface Creep extends RoomObject {
      */
     ticksToLive: number | undefined;
     /**
-     * Attack another creep or structure in a short-ranged attack. Needs the
-     * ATTACK body part. If the target is inside a rampart, then the rampart is
-     * attacked instead.
+     * Attack another creep or structure in a short-ranged attack.
      *
-     * The target has to be at adjacent square to the creep. If the target is a
-     * creep with ATTACK body parts and is not inside a rampart, it will
+     * Needs the ATTACK body part.
+     * If the target is inside a rampart, then the rampart is attacked instead.
+     *
+     * The target has to be at adjacent square to the creep.
+     * If the target is a creep with ATTACK body parts and is not inside a rampart, it will
      * automatically hit back at the attacker.
      *
-     * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target is not a valid attackable object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no ATTACK body parts in this creep’s body.
      */
     attack(target: AnyCreep | Structure): CreepActionReturnCode;
     /**
-     * Decreases the controller's downgrade or reservation timer for 1 tick per
-     * every 5 `CLAIM` body parts (so the creep must have at least 5x`CLAIM`).
+     * Attack a controller.
+     *
+     * Decreases the controller's downgrade or reservation timer for 1 tick per every 5 `CLAIM` body parts (so the creep must have at least 5x`CLAIM`).
      *
      * The controller under attack cannot be upgraded for the next 1,000 ticks.
      * The target has to be at adjacent square to the creep.
      *
-     * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART, ERR_TIRED
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target is not a valid owned or reserved controller object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_TIRED: You have to wait until the next attack is possible.
+     * - ERR_NO_BODYPART: There are not enough CLAIM body parts in this creep’s body.
      */
     attackController(target: StructureController): CreepActionReturnCode;
     /**
      * Build a structure at the target construction site using carried energy.
-     * Needs WORK and CARRY body parts.
      *
+     * Needs WORK and CARRY body parts.
      * The target has to be within 3 squares range of the creep.
      *
      * @param target The target construction site to be built.
-     * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_NOT_ENOUGH_RESOURCES, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART, ERR_RCL_NOT_ENOUGH
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_NOT_ENOUGH_RESOURCES: The creep does not have any carried energy.
+     * - ERR_INVALID_TARGET: The target is not a valid construction site object or the structure cannot be built here (probably because of a creep at the same square).
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no WORK body parts in this creep’s body.
      */
     build(target: ConstructionSite): CreepActionReturnCode | ERR_NOT_ENOUGH_RESOURCES | ERR_RCL_NOT_ENOUGH;
     /**
      * Cancel the order given during the current game tick.
      * @param methodName The name of a creep's method to be cancelled.
-     * @returns Result Code: OK, ERR_NOT_FOUND
+     * @returns One of the following codes:
+     * - OK: The operation has been cancelled successfully.
+     * - ERR_NOT_FOUND: The order with the specified name is not found.
      */
     cancelOrder(methodName: string): OK | ERR_NOT_FOUND;
     /**
-     * Requires the CLAIM body part.
+     * Claim a controller.
      *
+     * Requires the CLAIM body part.
      * If applied to a neutral controller, claims it under your control.
      * If applied to a hostile controller, decreases its downgrade or reservation timer depending on the CLAIM body parts count.
      *
      * The target has to be at adjacent square to the creep.
      * @param target The target controller object.
-     * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_FULL, ERR_NOT_IN_RANGE, ERR_NO_BODYPART, ERR_GCL_NOT_ENOUGH
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target is not a valid neutral controller object.
+     * - ERR_FULL: You cannot claim more than 3 rooms in the Novice Area.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no CLAIM body parts in this creep’s body.
+     * - ERR_GCL_NOT_ENOUGH: Your Global Control Level is not enough.
      */
     claimController(target: StructureController): CreepActionReturnCode | ERR_FULL | ERR_GCL_NOT_ENOUGH;
     /**
-     * Dismantles any (even hostile) structure returning 50% of the energy spent on its repair.
+     * Dismantles any structure that can be constructed (even hostile) returning 50% of the energy spent on its repair.
      *
-     * Requires the WORK body part. If the creep has an empty CARRY body part, the energy is put into it; otherwise it is dropped on the ground.
-     *
+     * Requires the WORK body part.
+     * If the creep has an empty CARRY body part, the energy is put into it; otherwise it is dropped on the ground.
      * The target has to be at adjacent square to the creep.
      * @param target The target structure.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target is not a valid structure object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no WORK body parts in this creep’s body.
      */
     dismantle(target: Structure): CreepActionReturnCode;
     /**
      * Drop this resource on the ground.
-     * @param resourceType One of the RESOURCE_* constants.
+     *
+     * @param resourceType One of the {@link ResourceConstant} constants.
      * @param amount The amount of resource units to be dropped. If omitted, all the available carried amount is used.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_NOT_ENOUGH_RESOURCES: The creep does not have the given amount of resources.
+     * - ERR_INVALID_ARGS: The resourceType is not a valid RESOURCE_* constants.
      */
     drop(resourceType: ResourceConstant, amount?: number): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_ENOUGH_RESOURCES;
     /**
-     * Add one more available safe mode activation to a room controller. The creep has to be at adjacent square to the target room controller and have 1000 ghodium resource.
+     * Add one more available safe mode activation to a room controller.
+     *
+     * The creep has to be at adjacent square to the target room controller and have 1000 ghodium resource.
      * @param target The target room controller.
-     * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_NOT_ENOUGH_RESOURCES, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_NOT_ENOUGH_RESOURCES: The creep does not have enough ghodium.
+     * - ERR_INVALID_TARGET: The target is not a valid controller object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
      */
     generateSafeMode(target: StructureController): CreepActionReturnCode;
     /**
-     * Get the quantity of live body parts of the given type. Fully damaged parts do not count.
-     * @param type A body part type, one of the following body part constants: MOVE, WORK, CARRY, ATTACK, RANGED_ATTACK, HEAL, TOUGH, CLAIM
+     * Get the quantity of live body parts of the given type.
+     *
+     * Fully damaged parts do not count.
+     * @param type A body part type, one of the {@link BodyPartConstant} constants.
      */
     getActiveBodyparts(type: BodyPartConstant): number;
     /**
@@ -1224,28 +1322,58 @@ interface Creep extends RoomObject {
      *
      * The target has to be at an adjacent square to the creep.
      * @param target The source object to be harvested.
+     * @return One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep, or the room controller is owned or reserved by another player.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_NOT_FOUND: Extractor not found. You must build an extractor structure to harvest minerals. Learn more
+     * - ERR_NOT_ENOUGH_RESOURCES: The target does not contain any harvestable energy or mineral.
+     * - ERR_INVALID_TARGET: The target is not a valid source or mineral object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_TIRED: The extractor or the deposit is still cooling down.
+     * - ERR_NO_BODYPART: There are no WORK body parts in this creep’s body.
      */
     harvest(target: Source | Mineral | Deposit): CreepActionReturnCode | ERR_NOT_FOUND | ERR_NOT_ENOUGH_RESOURCES;
     /**
-     * Heal self or another creep. It will restore the target creep’s damaged body parts function and increase the hits counter.
+     * Heal self or another creep.
+     *
+     * It will restore the target creep’s damaged body parts function and increase the hits counter.
      *
      * Needs the HEAL body part.
      *
      * The target has to be at adjacent square to the creep.
      * @param target The target creep object.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target is not a valid creep object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no HEAL body parts in this creep’s body.
      */
     heal(target: AnyCreep): CreepActionReturnCode;
     /**
      * Move the creep one square in the specified direction or towards a creep that is pulling it.
      *
      * Requires the MOVE body part if not being pulled.
-     * @param direction The direction to move in (`TOP`, `TOP_LEFT`...)
+     * @param direction The direction to move in (see {@link DirectionConstant}).
+     * @param creep A creep nearby.
+     * @return One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_NOT_IN_RANGE: The target creep is too far away
+     * - ERR_INVALID_ARGS: The provided direction is incorrect.
+     * - ERR_TIRED: The fatigue indicator of the creep is non-zero.
+     * - ERR_NO_BODYPART: There are no MOVE body parts in this creep’s body.
      */
     move(direction: DirectionConstant): CreepMoveReturnCode;
     move(target: Creep): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_IN_RANGE | ERR_INVALID_ARGS;
     /**
-     * Move the creep using the specified predefined path. Needs the MOVE body part.
-     * @param path A path value as returned from Room.findPath or RoomPosition.findPathTo methods. Both array form and serialized string form are accepted.
+     * Move the creep using the specified predefined path.
+     *
+     * Needs the MOVE body part.
+     * @param path A path value as returned from {@link Room.findPath} or {@link RoomPosition.findPathTo} methods. Both array form and serialized string form are accepted.
      */
     moveByPath(path: PathStep[] | RoomPosition[] | string): CreepMoveReturnCode | ERR_NOT_FOUND | ERR_INVALID_ARGS;
     /**
@@ -1273,31 +1401,67 @@ interface Creep extends RoomObject {
         opts?: MoveToOpts,
     ): CreepMoveReturnCode | ERR_NO_PATH | ERR_INVALID_TARGET | ERR_NOT_FOUND;
     /**
-     * Toggle auto notification when the creep is under attack. The notification will be sent to your account email. Turned on by default.
+     * Toggle auto notification when the creep is under attack.
+     *
+     * The notification will be sent to your account email. Turned on by default.
      * @param enabled Whether to enable notification or disable.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_ARGS: enable argument is not a boolean value.
      */
     notifyWhenAttacked(enabled: boolean): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_ARGS;
     /**
-     * Pick up an item (a dropped piece of energy). Needs the CARRY body part. The target has to be at adjacent square to the creep or at the same square.
+     * Pick up an item (a dropped piece of energy).
+     *
+     * Needs the CARRY body part.
+     * The target has to be at adjacent square to the creep or at the same square.
      * @param target The target object to be picked up.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target is not a valid object to pick up.
+     * - ERR_FULL: The creep cannot receive any more resource.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no CARRY body parts in this creep’s body.
      */
     pickup(target: Resource): CreepActionReturnCode | ERR_FULL;
     /**
-     * Allow another creep to follow this creep. The fatigue generated for the target's move will be added to the creep instead of the target.
+     * Allow another creep to follow this creep.
      *
-     * Requires the MOVE body part. The target must be adjacent to the creep. The creep must move elsewhere, and the target must move towards the creep.
+     * Requires the MOVE body part.
+     *
+     * The fatigue generated for the target's move will be added to the creep instead of the target.
+     * The target must be adjacent to the creep. The creep must move elsewhere, and the target must move towards the creep.
      * @param target The target creep to be pulled.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target provided is invalid.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no MOVE body parts in this creep’s body.
      */
     pull(target: Creep): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE | ERR_NO_BODYPART;
     /**
      * A ranged attack against another creep or structure.
      *
-     * Needs the RANGED_ATTACK body part. If the target is inside a rampart, the rampart is attacked instead.
+     * Needs the RANGED_ATTACK body part.
      *
+     * If the target is inside a rampart, the rampart is attacked instead.
      * The target has to be within 3 squares range of the creep.
      * @param target The target object to be attacked.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target is not a valid attackable object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no RANGED_ATTACK body parts in this creep’s body.
      */
-    rangedAttack(target: AnyCreep | Structure): CreepActionReturnCode;
+    rangedAttack(target: AnyCreep | Structure): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE | ERR_NO_BODYPART;
     /**
      * Heal another creep at a distance.
      *
@@ -1305,21 +1469,43 @@ interface Creep extends RoomObject {
      *
      * Needs the HEAL body part. The target has to be within 3 squares range of the creep.
      * @param target The target creep object.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target is not a valid creep object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no HEAL body parts in this creep’s body.
      */
-    rangedHeal(target: AnyCreep): CreepActionReturnCode;
+    rangedHeal(target: AnyCreep): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE | ERR_NO_BODYPART;
     /**
      * A ranged attack against all hostile creeps or structures within 3 squares range.
      *
      * Needs the RANGED_ATTACK body part.
      *
      * The attack power depends on the range to each target. Friendly units are not affected.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_NO_BODYPART: There are no RANGED_ATTACK body parts in this creep’s body.
      */
     rangedMassAttack(): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NO_BODYPART;
     /**
      * Repair a damaged structure using carried energy. Needs the WORK and CARRY body parts. The target has to be within 3 squares range of the creep.
      * @param target The target structure to be repaired.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_NOT_ENOUGH_RESOURCES: The creep does not carry any energy.
+     * - ERR_INVALID_TARGET: The target is not a valid structure object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no WORK body parts in this creep’s body.
      */
-    repair(target: Structure): CreepActionReturnCode | ERR_NOT_ENOUGH_RESOURCES;
+    repair(
+        target: Structure,
+    ): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_ENOUGH_RESOURCES | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE | ERR_NO_BODYPART;
     /**
      * Temporarily block a neutral controller from claiming by other players.
      *
@@ -1329,9 +1515,15 @@ interface Creep extends RoomObject {
      *
      * The target has to be at adjacent square to the creep....
      * @param target The target controller object to be reserved.
-     * @return Result code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART
+     * @return One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target is not a valid neutral controller object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no CLAIM body parts in this creep’s body.
      */
-    reserveController(target: StructureController): CreepActionReturnCode;
+    reserveController(target: StructureController): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE | ERR_NO_BODYPART;
     /**
      * Display a visual speech balloon above the creep with the specified message.
      *
@@ -1340,53 +1532,98 @@ interface Creep extends RoomObject {
      * Only the creep's owner can see the speech message unless toPublic is true.
      * @param message The message to be displayed. Maximum length is 10 characters.
      * @param set to 'true' to allow other players to see this message. Default is 'false'.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
      */
     say(message: string, toPublic?: boolean): OK | ERR_NOT_OWNER | ERR_BUSY;
     /**
-     * Sign a controller with a random text visible to all players. This text will appear in the room UI, in the world map, and can be accessed via the API.
-     * You can sign unowned and hostile controllers. The target has to be at adjacent square to the creep. Pass an empty string to remove the sign.
+     * Sign a controller with a random text visible to all players.
+     *
+     * This text will appear in the room UI, in the world map, and can be accessed via the API.
+     * You can sign unowned and hostile controllers.
+     *
+     * The target has to be at adjacent square to the creep. Pass an empty string to remove the sign.
      * @param target The target controller object to be signed.
      * @param text The sign text. The maximum text length is 100 characters.
-     * @returns Result Code: OK, ERR_BUSY, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target is not a valid controller object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
      */
     signController(target: StructureController, text: string): OK | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE;
     /**
      * Kill the creep immediately.
+     *
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
      */
     suicide(): OK | ERR_NOT_OWNER | ERR_BUSY;
     /**
-     * Transfer resource from the creep to another object. The target has to be at adjacent square to the creep.
+     * Transfer resource from the creep to another object.
+     *
+     * The target has to be at adjacent square to the creep.
      * @param target The target object.
-     * @param resourceType One of the RESOURCE_* constants
+     * @param resourceType One of the {@link ResourceConstant} constants
      * @param amount The amount of resources to be transferred. If omitted, all the available carried amount is used.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_NOT_ENOUGH_RESOURCES: The creep does not have the given amount of resources.
+     * - ERR_INVALID_TARGET: The target is not a valid object which can contain the specified resource.
+     * - ERR_FULL: The target cannot receive any more resources.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant} constants, or the amount is incorrect.
      */
     transfer(target: AnyCreep | Structure, resourceType: ResourceConstant, amount?: number): ScreepsReturnCode;
     /**
      * Upgrade your controller to the next level using carried energy.
      *
      * Upgrading controllers raises your Global Control Level in parallel.
+     * Requires WORK and CARRY body parts. The target has to be within 3 squares range of the creep.
      *
-     * Needs WORK and CARRY body parts.
-     *
-     * The target has to be at adjacent square to the creep.
-     *
-     * A fully upgraded level 8 controller can't be upgraded with the power over 15 energy units per tick regardless of creeps power.
-     *
+     * A fully upgraded level 8 controller can't be upgraded over 15 energy units per tick regardless of creeps abilities.
      * The cumulative effect of all the creeps performing upgradeController in the current tick is taken into account.
+     * This limit can be increased by using ghodium mineral boost.
+     *
+     * Upgrading the controller raises its ticksToDowngrade timer by 100. The timer must be full in order for controller to be levelled up.
      * @param target The target controller object to be upgraded.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep or the target controller.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_NOT_ENOUGH_RESOURCES: The creep does not have any carried energy.
+     * - ERR_INVALID_TARGET: The target is not a valid controller object, or the controller upgrading is blocked.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no WORK body parts in this creep’s body.
      */
     upgradeController(target: StructureController): ScreepsReturnCode;
     /**
      * Withdraw resources from a structure, a tombstone or a ruin.
      *
-     * The target has to be at adjacent square to the creep.
+     * The target has to be at adjacent square to the creep. Multiple creeps can withdraw from the same object in the same tick.
+     * Your creeps can withdraw resources from hostile structures/tombstones as well, in case if there is no hostile rampart on top of it.
      *
-     * Multiple creeps can withdraw from the same structure in the same tick.
+     * This method should not be used to transfer resources between creeps.
+     * To transfer between creeps, use the {@link Creep.transfer} method on the original creep.
      *
-     * Your creeps can withdraw resources from hostile structures as well, in case if there is no hostile rampart on top of it.
      * @param target The target object.
-     * @param resourceType The target One of the RESOURCE_* constants..
+     * @param resourceType One of the {@link ResourceConstant} constants..
      * @param amount The amount of resources to be transferred. If omitted, all the available amount is used.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep, or there is a hostile rampart on top of the target.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_NOT_ENOUGH_RESOURCES: The target does not have the given amount of resources.
+     * - ERR_INVALID_TARGET: The target is not a valid object which can contain the specified resource.
+     * - ERR_FULL: The creep's carry is full.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant} constants, or the amount is incorrect.
      */
     withdraw(target: Structure | Tombstone | Ruin, resourceType: ResourceConstant, amount?: number): ScreepsReturnCode;
 }
@@ -1396,21 +1633,25 @@ interface CreepConstructor extends _Constructor<Creep>, _ConstructorById<Creep> 
 declare const Creep: CreepConstructor;
 /**
  * A rare resource deposit needed for producing commodities.
- * Can be harvested by creeps with a WORK body part.
- * Each harvest operation triggers a cooldown period, which becomes longer and longer over time.
+ *
+ * Can be harvested by creeps with a WORK body part. Each harvest operation triggers a cooldown period, which becomes longer and longer over time.
+ *
+ * Learn more about deposits from [this article](https://docs.screeps.com/resources.html).
+ *
+ * |              |             |
+ * | ------------ | ----------- |
+ * | **Cooldown** | 0.001 * totalHarvested ^ 1.2
+ * | **Decay**    | 50,000 ticks after appearing or last harvest operation
  */
 interface Deposit extends RoomObject {
     /**
-     * A unique object identificator.
-     * You can use {@link Game.getObjectById} method to retrieve an object instance by its id.
+     * A unique object identifier.
+     *
+     * You can use {@link Game.getObjectById} to retrieve an object instance by its id.
      */
     id: Id<this>;
     /**
-     * The deposit type, one of the following constants:
-     * * `RESOURCE_MIST`
-     * * `RESOURCE_BIOMASS`
-     * * `RESOURCE_METAL`
-     * * `RESOURCE_SILICON`
+     * The deposit type, one of the {@link DepositConstant}.
      */
     depositType: DepositConstant;
     /**
@@ -1431,29 +1672,33 @@ interface DepositConstructor extends _Constructor<Deposit>, _ConstructorById<Dep
 
 declare const Deposit: DepositConstructor;
 /**
- * A flag. Flags can be used to mark particular spots in a room. Flags are visible to their owners only.
+ * A flag.
+ *
+ * Flags can be used to mark particular spots in a room. Flags are visible to their owners only. You cannot have more than 10,000 flags.
  */
 interface Flag extends RoomObject {
     readonly prototype: Flag;
 
     /**
-     * Flag color. One of the `COLOR_*` constants.
+     * Flag color. One of the {@link ColorConstant} constants.
      */
     color: ColorConstant;
     /**
+     * The flag's memory.
+     *
      * A shorthand to Memory.flags[flag.name]. You can use it for quick access the flag's specific memory data object.
      */
     memory: FlagMemory;
     /**
-     * Flag’s name.
+     * The flag’s name.
      *
      * You can choose the name while creating a new flag, and it cannot be changed later.
      *
-     * This name is a hash key to access the flag via the `Game.flags` object. The maximum name length is 60 characters.
+     * This name is a hash key to access the flag via the {@link Game.flags} object. The maximum name length is 60 characters.
      */
     name: string;
     /**
-     * Flag secondary color. One of the `COLOR_*` constants.
+     * Flag secondary color. One of the {@link ColorConstant} constants.
      */
     secondaryColor: ColorConstant;
     /**
@@ -1463,22 +1708,28 @@ interface Flag extends RoomObject {
     remove(): OK;
     /**
      * Set new color of the flag.
-     * @param color One of the following constants: COLOR_WHITE, COLOR_GREY, COLOR_RED, COLOR_PURPLE, COLOR_BLUE, COLOR_CYAN, COLOR_GREEN, COLOR_YELLOW, COLOR_ORANGE, COLOR_BROWN
-     * @parma secondaryColor Secondary color of the flag. One of the COLOR_* constants.
-     * @returns Result Code: OK, ERR_INVALID_ARGS
+     * @param color One of the {@link ColorConstant} constants.
+     * @param secondaryColor Secondary color of the flag. One of the {@link ColorConstant} constants.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_INVALID_ARGS: color or secondaryColor is not a valid color constant.
      */
     setColor(color: ColorConstant, secondaryColor?: ColorConstant): OK | ERR_INVALID_ARGS;
     /**
      * Set new position of the flag.
      * @param x The X position in the room.
      * @param y The Y position in the room.
-     * @returns Result Code: OK, ERR_INVALID_TARGET
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_INVALID_TARGET: The target provided is invalid.
      */
     setPosition(x: number, y: number): OK | ERR_INVALID_ARGS;
     /**
      * Set new position of the flag.
-     * @param pos Can be a RoomPosition object or any object containing RoomPosition.
-     * @returns Result Code: OK, ERR_INVALID_TARGET
+     * @param pos Can be a {@link RoomPosition} object or any object containing RoomPosition.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_INVALID_TARGET: The target provided is invalid.
      */
     setPosition(pos: RoomPosition | { pos: RoomPosition }): OK | ERR_INVALID_ARGS;
 }
@@ -1522,15 +1773,20 @@ interface Game {
      */
     market: Market;
     /**
-     * A hash containing all your power creeps with their names as hash keys. Even power creeps not spawned in the world can be accessed here.
+     * A hash containing all your power creeps with their names as hash keys.
+     *
+     * Even power creeps not spawned in the world can be accessed here.
      */
     powerCreeps: { [creepName: string]: PowerCreep };
     /**
-     * An object with your global resources that are bound to the account, like pixels or cpu unlocks. Each object key is a resource constant, values are resources amounts.
+     * An object with your global resources that are bound to the account, like pixels or cpu unlocks.
+     *
+     * Each object key is a resource constant, values are resources amounts.
      */
     resources: { [key: string]: any };
     /**
      * A hash containing all the rooms available to you with room names as hash keys.
+     *
      * A room is visible if you have a creep or an owned structure in it.
      */
     rooms: { [roomName: string]: Room };
@@ -1554,12 +1810,16 @@ interface Game {
     shard: Shard;
 
     /**
-     * System game tick counter. It is automatically incremented on every tick.
+     * System game tick counter.
+     *
+     * It is automatically incremented on every tick.
      */
     time: number;
 
     /**
-     * Get an object with the specified unique ID. It may be a game object of any type. Only objects from the rooms which are visible to you can be accessed.
+     * Get an object with the specified unique ID.
+     *
+     * It may be a game object of any type. Only objects from the rooms which are visible to you can be accessed.
      * @param id The unique identifier.
      * @returns an object instance or null if it cannot be found.
      */
@@ -1571,12 +1831,15 @@ interface Game {
      *
      * This way, you can set up notifications to yourself on any occasion within the game.
      *
-     * You can schedule up to 20 notifications during one game tick. Not available in the Simulation Room.
+     * You can schedule up to 20 notifications during one game tick. Not available in the Simulator.
      * @param message Custom text which will be sent in the message. Maximum length is 1000 characters.
      * @param groupInterval If set to 0 (default), the notification will be scheduled immediately.
      * Otherwise, it will be grouped with other notifications and mailed out later using the specified time in minutes.
+     * @returns One of the following codes:
+     * - OK: The message has been sent successfully.
+     * - ERR_FULL: More than 20 notifications sent this tick.
      */
-    notify(message: string, groupInterval?: number): undefined;
+    notify(message: string, groupInterval?: number): OK | ERR_FULL;
 }
 
 declare var Game: Game;
@@ -1639,16 +1902,21 @@ interface CPU {
      */
     limit: number;
     /**
-     * An amount of available CPU time at the current game tick. Usually it is higher than `Game.cpu.limit`.
+     * An amount of available CPU time at the current game tick.
+     *
+     * Usually it is higher than {@link Game.cpu.limit}.
      */
     tickLimit: number;
     /**
      * An amount of unused CPU accumulated in your bucket.
+     *
      * @see http://docs.screeps.com/cpu-limit.html#Bucket
      */
     bucket: number;
     /**
-     * An object with limits for each shard with shard names as keys. You can use `setShardLimits` method to re-assign them.
+     * An object with limits for each shard with shard names as keys.
+     *
+     * You can use {@link Game.cpu.setShardLimits} method to re-assign them.
      */
     shardLimits: CPUShardLimits;
     /**
@@ -1657,20 +1925,28 @@ interface CPU {
     unlocked: boolean;
     /**
      * The time in milliseconds since UNIX epoch time until full CPU is unlocked for your account.
+     *
      * This property is not defined when full CPU is not unlocked for your account or it's unlocked with a subscription.
      */
     unlockedTime: number | undefined;
 
     /**
-     * Get amount of CPU time used from the beginning of the current game tick. Always returns 0 in the Simulation mode.
+     * Get amount of CPU time used from the beginning of the current game tick.
+     *
+     * Always returns 0 in the simulator.
      */
     getUsed(): number;
     /**
-     * Allocate CPU limits to different shards. Total amount of CPU should remain equal to `Game.cpu.shardLimits`.
+     * Allocate CPU limits to different shards.
+     *
+     * Total amount of CPU should remain equal to {@link Game.cpu.shardLimits}.
      * This method can be used only once per 12 hours.
      *
-     * @param limits An object with CPU values for each shard in the same format as `Game.cpu.shardLimits`.
-     * @returns One of the following codes: `OK | ERR_BUSY | ERR_INVALID_ARGS`
+     * @param limits An object with CPU values for each shard in the same format as {@link Game.cpu.shardLimits}.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_BUSY: 12-hours cooldown period is not over yet.
+     * - ERR_INVALID_ARGS: The argument is not a valid shard limits object.
      */
     setShardLimits(limits: CPUShardLimits): OK | ERR_BUSY | ERR_INVALID_ARGS;
 
@@ -1679,7 +1955,8 @@ interface CPU {
      *
      * This method will be undefined if you are not using IVM.
      *
-     * The return value is almost identical to the Node.js function v8.getHeapStatistics().
+     * The return value is almost identical to Node's [v8.getHeapStatistics()](https://nodejs.org/docs/latest-v10.x/api/v8.html#v8_v8_getheapstatistics).
+     *
      * This function returns one additional property: externally_allocated_size which is the total amount of currently
      * allocated memory which is not included in the v8 heap but counts against this isolate's memory limit.
      * ArrayBuffer instances over a certain size are externally allocated and will be counted here.
@@ -1695,13 +1972,22 @@ interface CPU {
     halt?(): never;
     /**
      * Generate 1 pixel resource unit for 10000 CPU from your bucket.
+     *
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_ENOUGH_RESOURCES: Your bucket does not have enough CPU.
      */
     generatePixel(): OK | ERR_NOT_ENOUGH_RESOURCES;
 
     /**
      * Unlock full CPU for your account for additional 24 hours.
-     * This method will consume 1 CPU unlock bound to your account (See `Game.resources`).
+     *
+     * This method will consume 1 CPU unlock bound to your account (See {@link Game.resources}).
      * If full CPU is not currently unlocked for your account, it may take some time (up to 5 minutes) before unlock is applied to your account.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_ENOUGH_RESOURCES: Your account does not have enough cpuUnlock resource.
+     * - ERR_FULL: Your CPU is unlocked with a subscription.
      */
     unlock(): OK | ERR_NOT_ENOUGH_RESOURCES | ERR_FULL;
 }
@@ -1725,7 +2011,7 @@ interface HeapStatistics {
 type BodyPartDefinition<T extends BodyPartConstant = BodyPartConstant> = T extends any
     ? {
           /**
-           * One of the `RESOURCE_*` constants.
+           * One of the {@link ResourceConstant} constants.
            *
            * If the body part is boosted, this property specifies the mineral type which is used for boosting.
            */
@@ -1869,28 +2155,37 @@ interface FindTypes {
 
 interface FindPathOpts {
     /**
-     * Treat squares with creeps as walkable. Can be useful with too many moving creeps around or in some other cases. The default
-     * value is false.
+     * Treat squares with creeps as walkable.
+     *
+     * Can be useful with too many moving creeps around or in some other cases.
+     * @default false
      */
     ignoreCreeps?: boolean;
 
     /**
-     * Treat squares with destructible structures (constructed walls, ramparts, spawns, extensions) as walkable. Use this flag when
-     * you need to move through a territory blocked by hostile structures. If a creep with an ATTACK body part steps on such a square,
-     * it automatically attacks the structure. The default value is false.
+     * Treat squares with destructible structures (constructed walls, ramparts, spawns, extensions) as walkable.
+     *
+     * Use this flag when you need to move through a territory blocked by hostile structures.
+     * If a creep with an ATTACK body part steps on such a square, it automatically attacks the structure.
+     * @default false
      */
     ignoreDestructibleStructures?: boolean;
 
     /**
-     * Ignore road structures. Enabling this option can speed up the search. The default value is false. This is only used when the
-     * new PathFinder is enabled.
+     * Ignore road structures.
+     *
+     * Enabling this option can speed up the search. This is only used when the new PathFinder is enabled.
+     *
+     * @default false
      */
     ignoreRoads?: boolean;
 
     /**
-     * You can use this callback to modify a CostMatrix for any room during the search. The callback accepts two arguments, roomName
-     * and costMatrix. Use the costMatrix instance to make changes to the positions costs. If you return a new matrix from this callback,
-     * it will be used instead of the built-in cached one. This option is only used when the new PathFinder is enabled.
+     * You can use this callback to modify a CostMatrix for any room during the search.
+     *
+     * The callback accepts two arguments, roomName and costMatrix. Use the costMatrix instance to make changes to the positions costs.
+     * If you return a new matrix from this callback, it will be used instead of the built-in cached one.
+     * This option is only used when the new PathFinder is enabled.
      *
      * @param roomName The name of the room.
      * @param costMatrix The current CostMatrix
@@ -1899,78 +2194,103 @@ interface FindPathOpts {
     costCallback?: (roomName: string, costMatrix: CostMatrix) => void | CostMatrix;
 
     /**
-     * An array of the room's objects or RoomPosition objects which should be treated as walkable tiles during the search. This option
-     * cannot be used when the new PathFinder is enabled (use costCallback option instead).
+     * An array of the room's objects or RoomPosition objects which should be treated as walkable tiles during the search.
+     *
+     * This option cannot be used when the new PathFinder is enabled (use costCallback option instead).
      */
     ignore?: any[] | RoomPosition[];
 
     /**
-     * An array of the room's objects or RoomPosition objects which should be treated as obstacles during the search. This option cannot
-     * be used when the new PathFinder is enabled (use costCallback option instead).
+     * An array of the room's objects or RoomPosition objects which should be treated as obstacles during the search.
+     *
+     * This option cannot be used when the new PathFinder is enabled (use costCallback option instead).
      */
     avoid?: any[] | RoomPosition[];
 
     /**
-     * The maximum limit of possible pathfinding operations. You can limit CPU time used for the search based on ratio 1 op ~ 0.001 CPU.
-     * The default value is 2000.
+     * The maximum limit of possible pathfinding operations.
+     *
+     * You can limit CPU time used for the search based on ratio 1 op ~ 0.001 CPU.
+     * @default 2000
      */
     maxOps?: number;
 
     /**
-     * Weight to apply to the heuristic in the A* formula F = G + weight * H. Use this option only if you understand the underlying
-     * A* algorithm mechanics! The default value is 1.2.
+     * Weight to apply to the heuristic in the A* formula `F = G + weight * H`.
+     *
+     * Use this option only if you understand the underlying A* algorithm mechanics!
+     * @default 1.2
      */
     heuristicWeight?: number;
 
     /**
-     * If true, the result path will be serialized using Room.serializePath. The default is false.
+     * If true, the result path will be serialized using {@link Room.serializePath}.
+     * @default false
      */
     serialize?: boolean;
 
     /**
-     * The maximum allowed rooms to search. The default (and maximum) is 16. This is only used when the new PathFinder is enabled.
+     * The maximum allowed rooms to search.
+     *
+     * This is only used when the new PathFinder is enabled.
+     * @default 16 (also maximum)
      */
     maxRooms?: number;
 
     /**
-     * Path to within (range) tiles of target tile. The default is to path to the tile that the target is on (0).
+     * Path to within (range) tiles of target tile.
+     *
+     * The default is to path to the tile that the target is on.
+     *
+     * @default 0
      */
     range?: number;
 
     /**
-     * Cost for walking on plain positions. The default is 1.
+     * Cost for walking on plain positions.
+     * @default 1
      */
     plainCost?: number;
 
     /**
-     * Cost for walking on swamp positions. The default is 5.
+     * Cost for walking on swamp positions.
+     * @default 5
      */
     swampCost?: number;
 }
 
 interface MoveToOpts extends FindPathOpts {
     /**
-     * This option enables reusing the path found along multiple game ticks. It allows to save CPU time, but can result in a slightly
-     * slower creep reaction behavior. The path is stored into the creep's memory to the `_move` property. The `reusePath` value defines
-     * the amount of ticks which the path should be reused for. The default value is 5. Increase the amount to save more CPU, decrease
-     * to make the movement more consistent. Set to 0 if you want to disable path reusing.
+     * This option enables reusing the path found along multiple game ticks.
+     *
+     * It allows to save CPU time, but can result in a slightly slower creep reaction behavior.
+     * The path is stored into the creep's memory to the `_move` property.
+     * The `reusePath` value defines the amount of ticks which the path should be reused for.
+     * Increase the amount to save more CPU, decrease to make the movement more consistent.
+     * Set to 0 if you want to disable path reusing.
+     * @default 5
      */
     reusePath?: number;
 
     /**
-     * If `reusePath` is enabled and this option is set to true, the path will be stored in memory in the short serialized form using
-     * `Room.serializePath`. The default value is true.
+     * If `reusePath` is enabled and this option is set to true, the path will be stored in memory in the short serialized form using {@link Room.serializePath}.
+     * @default true
      */
     serializeMemory?: boolean;
 
     /**
-     * If this option is set to true, `moveTo` method will return `ERR_NOT_FOUND` if there is no memorized path to reuse. This can
-     * significantly save CPU time in some cases. The default value is false.
+     * Force the use of a cached path.
+     *
+     * If this option is set to true, `moveTo` method will return `ERR_NOT_FOUND` if there is no memorized path to reuse.
+     * This can significantly save CPU time in some cases.
+     * @default false
      */
     noPathFinding?: boolean;
 
     /**
-     * Draw a line along the creep’s path using `RoomVisual.poly`. You can provide either an empty object or custom style parameters.
+     * Draw a line along the creep’s path using {@link RoomVisual.poly}.
+     *
+     * You can provide either an empty object or custom style parameters.
      */
     visualizePathStyle?: PolyStyle;
 }
@@ -2005,8 +2325,9 @@ type Id<T extends _HasId> = string & Tag.OpaqueTag<T>;
 type fromId<T> = T extends Id<infer R> ? R : never;
 /**
  * `InterShardMemory` object provides an interface for communicating between shards.
- * Your script is executed separatedly on each shard, and their `Memory` objects are isolated from each other.
- * In order to pass messages and data between shards, you need to use `InterShardMemory` instead.
+ *
+ * Your script is executed separatedly on each shard, and their {@link Memory} objects are isolated from each other.
+ * In order to pass messages and data between shards, you need to use {@link InterShardMemory} instead.
  *
  * Every shard can have its own data string that can be accessed by all other shards.
  * A shard can write only to its own data, other shards' data is read-only.
@@ -2019,15 +2340,17 @@ interface InterShardMemory {
      */
     getLocal(): string;
     /**
-     * Replace the current shard's data with the new value
+     * Replace the current shard's data with the new value.
+     *
      * @param value New data value in string format.
+     * @throws if `value` isn't a string or contains more than `100 * 2014` characters.
      */
     setLocal(value: string): void;
     /**
      * Returns the string contents of another shard's data, null if shard exists but data is not set.
      *
      * @param shard Shard name.
-     * @throws Error if shard name is invalid
+     * @throws if shard name is invalid
      */
     getRemote(shard: string): string | null;
 }
@@ -2760,7 +3083,9 @@ interface RoomStatusTemporary {
 type RoomStatus = RoomStatusPermanent | RoomStatusTemporary;
 
 /**
- * A global object representing world map. Use it to navigate between rooms. The object is accessible via Game.map property.
+ * A global object representing world map.
+ *
+ * Use it to navigate between rooms. The object is accessible via the {@link Game.map} property.
  */
 interface GameMap {
     /**
@@ -2789,8 +3114,9 @@ interface GameMap {
      */
     findRoute(fromRoom: string | Room, toRoom: string | Room, opts?: RouteOptions): { exit: ExitConstant; room: string }[] | ERR_NO_PATH;
     /**
-     * Get the linear distance (in rooms) between two rooms. You can use this function to estimate the energy cost of
-     * sending resources through terminals, or using observers and nukes.
+     * Get the linear distance (in rooms) between two rooms.
+     *
+     * You can use this function to estimate the energy cost of sending resources through terminals, or using observers and nukes.
      * @param roomName1 The name of the first room.
      * @param roomName2 The name of the second room.
      * @param continuous Whether to treat the world map continuous on borders. Set to true if you
@@ -2798,26 +3124,34 @@ interface GameMap {
      */
     getRoomLinearDistance(roomName1: string, roomName2: string, continuous?: boolean): number;
     /**
-     * Get terrain type at the specified room position. This method works for any room in the world even if you have no access to it.
+     * Get terrain type at the specified room position.
+     *
+     * This method works for any room in the world even if you have no access to it.
      * @param x X position in the room.
      * @param y Y position in the room.
      * @param roomName The room name.
-     * @deprecated use `Game.map.getRoomTerrain` instead
+     * @deprecated use {@link Game.map.getRoomTerrain} instead
      */
     getTerrainAt(x: number, y: number, roomName: string): Terrain;
     /**
-     * Get terrain type at the specified room position. This method works for any room in the world even if you have no access to it.
+     * Get terrain type at the specified room position.
+     *
+     * This method works for any room in the world even if you have no access to it.
      * @param pos The position object.
-     * @deprecated use `Game.map.getRoomTerrain` instead
+     * @deprecated use {@link Game.map.getRoomTerrain} instead
      */
     getTerrainAt(pos: RoomPosition): Terrain;
     /**
-     * Get room terrain for the specified room. This method works for any room in the world even if you have no access to it.
+     * Get room terrain for the specified room.
+     *
+     * This method works for any room in the world even if you have no access to it.
      * @param roomName String name of the room.
      */
     getRoomTerrain(roomName: string): RoomTerrain;
     /**
-     * Returns the world size as a number of rooms between world corners. For example, for a world with rooms from W50N50 to E50S50 this method will return 102.
+     * Returns the world size as a number of rooms between world corners.
+     *
+     * For example, for a world with rooms from W50N50 to E50S50 this method will return 102.
      */
     getWorldSize(): number;
 
@@ -2832,13 +3166,13 @@ interface GameMap {
     /**
      * Get the room status to determine if it's available, or in a reserved area.
      * @param roomName The room name.
-     * @returns An object with the following properties {status: "normal" | "closed" | "novice" | "respawn", timestamp: number}
+     * @returns A {@link RoomStatus} object.
      */
     getRoomStatus(roomName: string): RoomStatus;
 
     /**
      * Map visuals provide a way to show various visual debug info on the game map.
-     * You can use the `Game.map.visual` object to draw simple shapes that are visible only to you.
+     * You can use the {@link Game.map.visual} object to draw simple shapes that are visible only to you.
      *
      * Map visuals are not stored in the database, their only purpose is to display something in your browser.
      * All drawings will persist for one tick and will disappear if not updated.
@@ -2850,8 +3184,18 @@ interface GameMap {
     visual: MapVisual;
 }
 
-// No static is available
-
+/**
+ * Map visuals provide a way to show various visual debug info on the game map.
+ *
+ * You can use the {@link Game.map.visual} object to draw simple shapes that are visible only to you.
+ *
+ *  Map visuals are not stored in the database, their only purpose is to display something in your browser.
+ * All drawings will persist for one tick and will disappear if not updated.
+ * All `Game.map.visual` calls have no added CPU cost (their cost is natural and mostly related to simple `JSON.serialize` calls).
+ * However, there is a usage limit: you cannot post more than 1000 KB of serialized data.
+ *
+ * All draw coordinates are measured in global game coordinates ({@link RoomPosition}).
+ */
 interface MapVisual {
     /**
      * Draw a line.
@@ -2904,7 +3248,9 @@ interface MapVisual {
     clear(): MapVisual;
 
     /**
-     * Get the stored size of all visuals added on the map in the current tick. It must not exceed 1024,000 (1000 KB).
+     * Get the stored size of all visuals added on the map in the current tick.
+     *
+     * It must not exceed 1024,000 (1000 KB).
      * @returns The size of the visuals in bytes.
      */
     getSize(): number;
@@ -2916,7 +3262,7 @@ interface MapVisual {
     export(): string;
 
     /**
-     * Add previously exported (with `Game.map.visual.export`) map visuals to the map visual data of the current tick.
+     * Add previously exported (with {@link Game.map.visual.export}) map visuals to the map visual data of the current tick.
      * @param data The string returned from `Game.map.visual.export`.
      * @returns The MapVisual object itself, so that you can chain calls.
      */
@@ -2925,64 +3271,77 @@ interface MapVisual {
 
 interface MapLineStyle {
     /**
-     * Line width, default is 0.1.
+     * Line width.
+     * @default 0.1
      */
     width?: number;
     /**
-     * Line color in the following format: #ffffff (hex triplet). Default is #ffffff.
+     * Line color in the following format: #ffffff (hex triplet).
+     * @default #ffffff
      */
     color?: string;
     /**
-     * Opacity value, default is 0.5.
+     * Opacity value
+     * @default 0.5
      */
     opacity?: number;
     /**
-     * Either undefined (solid line), dashed, or dotted. Default is undefined.
+     * Either undefined (solid line), dashed, or dotted.
+     * @default undefined.
      */
     lineStyle?: "dashed" | "dotted" | "solid" | undefined;
 }
 
 interface MapPolyStyle {
     /**
-     * Fill color in the following format: #ffffff (hex triplet). Default is undefined (no fill).
+     * Fill color in the following format: #ffffff (hex triplet).
+     * @default undefined (no fill).
      */
     fill?: string | undefined;
     /**
-     * Opacity value, default is 0.5.
+     * Opacity value
+     * @default 0.5
      */
     opacity?: number;
     /**
-     * Stroke color in the following format: #ffffff (hex triplet). Default is #ffffff.
+     * Stroke color in the following format: #ffffff (hex triplet).
+     * @default #ffffff
      */
     stroke?: string;
     /**
-     * Stroke line width, default is 0.5.
+     * Stroke line width.
+     * @default 0.5
      */
     strokeWidth?: number;
     /**
-     * Either undefined (solid line), dashed, or dotted. Default is undefined.
+     * Either undefined (solid line), dashed, or dotted.
+     * @default is undefined
      */
     lineStyle?: "dashed" | "dotted" | "solid" | undefined;
 }
 
 interface MapCircleStyle extends MapPolyStyle {
     /**
-     * Circle radius, default is 10.
+     * Circle radius.
+     * @default 10
      */
     radius?: number;
 }
 
 interface MapTextStyle {
     /**
-     * Font color in the following format: #ffffff (hex triplet). Default is #ffffff.
+     * Font color in the following format: #ffffff (hex triplet).
+     * @default #ffffff
      */
     color?: string;
     /**
-     * The font family, default is sans-serif
+     * The font family.
+     * @default sans-serif
      */
     fontFamily?: string;
     /**
-     * The font size in game coordinates, default is 10
+     * The font size in game coordinates.
+     * @default 10
      */
     fontSize?: number;
     /**
@@ -2994,33 +3353,45 @@ interface MapTextStyle {
      */
     fontVariant?: string;
     /**
-     * Stroke color in the following format: #ffffff (hex triplet). Default is undefined (no stroke).
+     * Stroke color in the following format: #ffffff (hex triplet)
+     * @default undefined (no stroke).
      */
     stroke?: string | undefined;
     /**
-     * Stroke width, default is 0.15.
+     * Stroke width.
+     * @default 0.15
      */
     strokeWidth?: number;
     /**
-     * Background color in the following format: #ffffff (hex triplet). Default is undefined (no background). When background is enabled, text vertical align is set to middle (default is baseline).
+     * Background color in the following format: #ffffff (hex triplet).
+     *
+     * When background is enabled, text vertical align is set to middle (default is baseline).
+     * @default undefined (no background).
      */
     backgroundColor?: string | undefined;
     /**
-     * Background rectangle padding, default is 2.
+     * Background rectangle padding.
+     * @default 2
      */
     backgroundPadding?: number;
     /**
-     * Text align, either center, left, or right. Default is center.
+     * Text align, either center, left, or right.
+     * @default center
      */
     align?: "center" | "left" | "right";
     /**
-     * Opacity value, default is 0.5.
+     * Opacity value.
+     * @default 0.5
      */
     opacity?: number;
 }
 /**
- * A global object representing the in-game market. You can use this object to track resource transactions to/from your
- * terminals, and your buy/sell orders. The object is accessible via the singleton Game.market property.
+ * A global object representing the in-game market.
+ *
+ * You can use this object to track resource transactions to/from your terminals, and your buy/sell orders.
+ * The object is accessible via the singleton {@link Game.market} property.
+ *
+ * Learn more about the market system from [this article](https://docs.screeps.com/market.html).
  */
 interface Market {
     /**
@@ -3040,7 +3411,9 @@ interface Market {
      */
     outgoingTransactions: Transaction[];
     /**
-     * Estimate the energy transaction cost of StructureTerminal.send and Market.deal methods. The formula:
+     * Estimate the energy transaction cost of {@link StructureTerminal.send} and {@link Market.deal} methods.
+     *
+     * The formula:
      *
      * ```
      * Math.ceil( amount * (Math.log(0.1*linearDistanceBetweenRooms + 0.9) + 0.1) )
@@ -3053,20 +3426,32 @@ interface Market {
      */
     calcTransactionCost(amount: number, roomName1: string, roomName2: string): number;
     /**
-     * Cancel a previously created order. The 5% fee is not returned.
+     * Cancel a previously created order.
+     *
+     * The 5% fee is not returned.
      * @param orderId The order ID as provided in Game.market.orders
-     * @returns Result Code: OK, ERR_INVALID_ARGS
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_INVALID_ARGS: The order ID is not valid.
      */
     cancelOrder(orderId: string): ScreepsReturnCode;
     /**
-     * Change the price of an existing order. If `newPrice` is greater than old price, you will be charged `(newPrice-oldPrice)*remainingAmount*0.05` credits.
+     * Change the price of an existing order.
+     *
+     * If `newPrice` is greater than old price, you will be charged `(newPrice-oldPrice)*remainingAmount*0.05` credits.
      * @param orderId The order ID as provided in Game.market.orders
      * @param newPrice The new order price.
-     * @returns Result Code: OK, ERR_NOT_OWNER, ERR_NOT_ENOUGH_RESOURCES, ERR_INVALID_ARGS
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of the room's terminal or there is no terminal.
+     * - ERR_NOT_ENOUGH_RESOURCES: You don't have enough credits to pay a fee.
+     * - ERR_INVALID_ARGS: The arguments provided are invalid.
      */
     changeOrderPrice(orderId: string, newPrice: number): ScreepsReturnCode;
     /**
-     * Create a market order in your terminal. You will be charged `price*amount*0.05` credits when the order is placed.
+     * Create a market order in your terminal.
+     *
+     * You will be charged `price*amount*0.05` credits when the order is placed.
      *
      * The maximum orders count is 300 per player. You can create an order at any time with any amount,
      * it will be automatically activated and deactivated depending on the resource/credits availability.
@@ -3084,7 +3469,7 @@ interface Market {
      * Execute a trade deal from your Terminal to another player's Terminal using the specified buy/sell order.
      *
      * Your Terminal will be charged energy units of transfer cost regardless of the order resource type.
-     * You can use Game.market.calcTransactionCost method to estimate it.
+     * You can use {@link Game.market.calcTransactionCost} method to estimate it.
      *
      * When multiple players try to execute the same deal, the one with the shortest distance takes precedence.
      *
@@ -3095,15 +3480,27 @@ interface Market {
      * @param yourRoomName The name of your room which has to contain an active Terminal with enough amount of energy.
      * This argument is not used when the order resource type is one of account-bound resources (@see {@link InterShardResourceConstant}).
      *
-     * @returns Result Code: OK, ERR_NOT_OWNER, ERR_NOT_ENOUGH_RESOURCES, ERR_FULL, ERR_INVALID_ARGS, ERR_TIRED
+     * @returns One of the following error codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You don't have a terminal in the target room.
+     * - ERR_NOT_ENOUGH_RESOURCES: You don't have enough credits or resource units.
+     * - ERR_FULL: You cannot execute more than 10 deals during one tick.
+     * - ERR_INVALID_ARGS: The arguments provided are invalid.
+     * - ERR_TIRED: The target terminal is still cooling down.
      */
     deal(orderId: string, amount: number, yourRoomName?: string): ScreepsReturnCode;
     /**
-     * Add more capacity to an existing order. It will affect `remainingAmount` and `totalAmount` properties. You will be charged `price*addAmount*0.05` credits.
+     * Add more capacity to an existing order.
+     *
+     * It will affect `remainingAmount` and `totalAmount` properties. You will be charged `price*addAmount*0.05` credits.
      * Extending the order doesn't update its expiration time.
+     *
      * @param orderId The order ID as provided in Game.market.orders
      * @param addAmount How much capacity to add. Cannot be a negative value.
-     * @returns One of the following codes: `OK`, `ERR_NOT_ENOUGH_RESOURCES`, `ERR_INVALID_ARGS`
+     * @returns One of the following error codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_ENOUGH_RESOURCES: You don't have enough credits to pay a fee.
+     * - ERR_INVALID_ARGS:  The arguments provided are invalid.
      */
     extendOrder(orderId: string, addAmount: number): ScreepsReturnCode;
     /**
@@ -3114,14 +3511,14 @@ interface Market {
     getAllOrders(filter?: OrderFilter | ((o: Order) => boolean)): Order[];
     /**
      * Get daily price history of the specified resource on the market for the last 14 days.
-     * @param resource One of the RESOURCE_* constants. If undefined, returns history data for all resources. Optional
+     * @param resource One of the {@link MarketResourceConstant} constants. If undefined, returns history data for all resources. Optional
      * @returns An array of objects with resource info.
      */
     getHistory(resource?: MarketResourceConstant): PriceHistory[];
     /**
      * Retrieve info for specific market order.
      * @param orderId The order ID.
-     * @returns An object with the order info. See `getAllOrders` for properties explanation.
+     * @returns An object with the order info. See {@link Order}.
      */
     getOrderById(id: string): Order | null;
 }
@@ -3142,15 +3539,33 @@ interface Transaction {
 }
 
 interface Order {
+    /** The unique order ID. */
     id: string;
+    /**
+     * The order creation time in milliseconds since UNIX epoch time.
+     *
+     * This property is absent for old orders.
+     */
     created: number;
+    /** Whether the order is active or not.
+     *
+     * Only exists for your own orders. */
     active?: boolean;
+    /** The order type. */
     type: ORDER_BUY | ORDER_SELL;
+    /**
+     * The type of resource requested by the order. See {@link MarketResourceConstant}.
+     */
     resourceType: MarketResourceConstant;
+    /** The room where this order is placed. */
     roomName?: string;
+    /** Currently available quantity of resource to trade. */
     amount: number;
+    /** Remaining quantity of resources to trade. */
     remainingAmount: number;
+    /** Total quantity of resources traded */
     totalAmount?: number;
+    /** The current price per unit. */
     price: number;
 }
 
@@ -3195,8 +3610,23 @@ interface SpawnMemory {}
 
 declare const Memory: Memory;
 /**
- * A mineral deposit object. Can be harvested by creeps with a WORK body part using the extractor structure.
- * @see http://docs.screeps.com/api/#Mineral
+ * A mineral deposit.
+ *
+ * Can be harvested by creeps with a WORK body part using the extractor structure.
+ * Learn more about minerals from [this article](http://docs.screeps.com/api/#Mineral).
+ *
+ *
+ * |                            |                              |
+ * | ---------------------------| ---------------------------- |
+ * | Regeneration amount        | DENSITY_LOW: 15,000
+ * |                            | DENSITY_MODERATE: 35,000
+ * |                            | DENSITY_HIGH: 70,000
+ * |                            | DENSITY_ULTRA: 100,000
+ * | Regeneration time          | 50,000 ticks
+ * | Density change probability | DENSITY_LOW: 100% chance
+ * |                            | DENSITY_MODERATE: 5% chance
+ * |                            | DENSITY_HIGH: 5% chance
+ * |                            | DENSITY_ULTRA: 100% chance*
  */
 interface Mineral<T extends MineralConstant = MineralConstant> extends RoomObject {
     /**
@@ -3204,7 +3634,7 @@ interface Mineral<T extends MineralConstant = MineralConstant> extends RoomObjec
      */
     readonly prototype: Mineral;
     /**
-     * The density of this mineral deposit, one of the `DENSITY_*` constants.
+     * The density of this mineral deposit, one of the {@link DensityConstant} constants.
      */
     density: number;
     /**
@@ -3212,11 +3642,13 @@ interface Mineral<T extends MineralConstant = MineralConstant> extends RoomObjec
      */
     mineralAmount: number;
     /**
-     * The resource type, one of the `RESOURCE_*` constants.
+     * The resource type, one of the {@link MineralConstant} constants.
      */
     mineralType: T;
     /**
-     * A unique object identifier. You can use `Game.getObjectById` method to retrieve an object instance by its `id`.
+     * A unique object identifier.
+     *
+     * You can use {@link Game.getObjectById} to retrieve an object instance by its `id`.
      */
     id: Id<this>;
     /**
@@ -3229,13 +3661,32 @@ interface MineralConstructor extends _Constructor<Mineral>, _ConstructorById<Min
 
 declare const Mineral: MineralConstructor;
 /**
- * A nuke landing position. This object cannot be removed or modified. You can find incoming nukes in the room using the FIND_NUKES constant.
+ * A nuke landing position.
+ *
+ * This object cannot be removed or modified. You can find incoming nukes in the room using the {@link FIND_NUKES} constant.
+ *
+ * Landing time: 50,000 ticks
+ * All creeps, construction sites and dropped resources in the room are removed immediately, even inside ramparts.
+ *
+ * Damage to structures:
+ * - 10,000,000 hits at the landing position;
+ * - 5,000,000 hits to all structures in 5x5 area.
+ *
+ * Note that you can stack multiple nukes from different rooms at the same target position to increase damage.
+ *
+ * Nuke landing does not generate tombstones and ruins, and destroys all existing tombstones and ruins in the room.
+ *
+ * If the room is in safe mode, then the safe mode is cancelled immediately, and the safe mode cooldown is reset to 0.
+ *
+ * The room controller is hit by triggering {@link StructureController.upgradeBlocked} period, which means it is unavailable to activate safe mode again within the next 200 ticks.
  */
 interface Nuke extends RoomObject {
     readonly prototype: Nuke;
 
     /**
-     * A unique object identifier. You can use Game.getObjectById method to retrieve an object instance by its id.
+     * A unique object identifier.
+     *
+     * You can use {@link Game.getObjectById} to retrieve an object instance by its id.
      */
     id: Id<this>;
     /**
@@ -3252,12 +3703,15 @@ interface NukeConstructor extends _Constructor<Nuke>, _ConstructorById<Nuke> {}
 
 declare const Nuke: NukeConstructor;
 /**
- * Contains powerful methods for pathfinding in the game world. Support exists for custom navigation costs and paths which span multiple rooms.
+ * Contains powerful methods for pathfinding in the game world.
+ *
+ * This module is written in fast native C++ code and supports custom navigation costs and paths which span multiple rooms.
+ *
  * Additionally PathFinder can search for paths through rooms you can't see, although you won't be able to detect any dynamic obstacles like creeps or buildings.
  */
 interface PathFinder {
     /**
-     * Creates a new CostMatrix containing 0's for all positions.
+     * Creates a new {@link CostMatrix} containing 0's for all positions.
      */
     CostMatrix: CostMatrixConstructor;
 
@@ -3276,10 +3730,10 @@ interface PathFinder {
     /**
      * Specify whether to use this new experimental pathfinder in game objects methods.
      * This method should be invoked every tick. It affects the following methods behavior:
-     * * `Room.findPath`
-     * * `RoomPosition.findPathTo`
-     * * `RoomPosition.findClosestByPath`
-     * * `Creep.moveTo`
+     * - {@link Room.findPath}
+     * - {@link RoomPosition.findPathTo}
+     * - {@link RoomPosition.findClosestByPath}
+     * - {@link Creep.moveTo}
      *
      * @deprecated This method is deprecated and will be removed soon.
      * @param isEnabled Whether to activate the new pathfinder or deactivate.
@@ -3297,7 +3751,7 @@ interface PathFinder {
  */
 interface PathFinderPath {
     /**
-     * An array of RoomPosition objects.
+     * An array of {@link RoomPosition} objects.
      */
     path: RoomPosition[];
     /**
@@ -3305,7 +3759,7 @@ interface PathFinderPath {
      */
     ops: number;
     /**
-     * The total cost of the path as derived from `plainCost`, `swampCost` and any given CostMatrix instances.
+     * The total cost of the path as derived from `plainCost`, `swampCost` and any given {@link CostMatrix} instances.
      */
     cost: number;
     /**
@@ -3321,42 +3775,56 @@ interface PathFinderPath {
  */
 interface PathFinderOpts {
     /**
-     * Cost for walking on plain positions. The default is 1.
+     * Cost for walking on plain positions.
+     * @default 1
      */
     plainCost?: number;
     /**
-     * Cost for walking on swamp positions. The default is 5.
+     * Cost for walking on swamp positions.
+     * @default 5
      */
     swampCost?: number;
     /**
      * Instead of searching for a path to the goals this will search for a path away from the goals.
-     * The cheapest path that is out of range of every goal will be returned. The default is false.
+     *
+     * The cheapest path that is out of range of every goal will be returned.
+     * @default false
      */
     flee?: boolean;
     /**
-     * The maximum allowed pathfinding operations. You can limit CPU time used for the search based on ratio 1 op ~ 0.001 CPU. The default value is 2000.
+     * The maximum allowed pathfinding operations.
+     *
+     * You can limit CPU time used for the search based on ratio 1 op ~ 0.001 CPU.
+     * @default 2000
      */
     maxOps?: number;
     /**
-     * The maximum allowed rooms to search. The default (and maximum) is 16.
+     * The maximum allowed rooms to search.
+     * @default 16 (also maximum)
      */
     maxRooms?: number;
     /**
-     * The maximum allowed cost of the path returned. If at any point the pathfinder detects that it is impossible to find
-     * a path with a cost less than or equal to maxCost it will immediately halt the search. The default is Infinity.
+     * The maximum allowed cost of the path returned.
+     *
+     * If at any point the pathfinder detects that it is impossible to find a path with a cost less than or equal to maxCost it will immediately halt the search.
+     * @default Infinity
      */
     maxCost?: number;
     /**
-     * Weight to apply to the heuristic in the A* formula F = G + weight * H. Use this option only if you understand
-     * the underlying A* algorithm mechanics! The default value is 1.
+     * Weight to apply to the heuristic in the A* formula `F = G + weight * H`.
+     *
+     * Use this option only if you understand the underlying A* algorithm mechanics!
+     * @default 1
      */
     heuristicWeight?: number;
 
     /**
-     * Request from the pathfinder to generate a CostMatrix for a certain room. The callback accepts one argument, roomName.
+     * Request from the pathfinder to generate a CostMatrix for a certain room.
+     *
+     * The callback accepts one argument, roomName.
      * This callback will only be called once per room per search. If you are running multiple pathfinding operations in a
-     * single room and in a single tick you may consider caching your CostMatrix to speed up your code. Please read the
-     * CostMatrix documentation below for more information on CostMatrix.
+     * single room and in a single tick you may consider caching your {@link CostMatrix} to speed up your code.
+     * Please read the {@link CostMatrix} documentation below for more information on CostMatrix.
      *
      * @param roomName The name of the room the pathfinder needs a cost matrix for.
      */
@@ -3375,6 +3843,14 @@ interface CostMatrixConstructor extends _Constructor<CostMatrix> {
 
 /**
  * Container for custom navigation cost data.
+ *
+ * By default PathFinder will only consider terrain data (plain, swamp, wall) — if you need to route around obstacles such as buildings or creeps you must put them into a CostMatrix.
+ *
+ * Generally you will create your CostMatrix from within {@link PathFinderOpts.roomCallback}.
+ * If a non-0 value is found in a room's CostMatrix then that value will be used instead of the default terrain cost.
+ *
+ * You should avoid using large values in your CostMatrix and terrain cost flags.
+ * For example, running {@link PathFinder.search} with `{ plainCost: 1, swampCost: 5 }` is faster than running it with `{plainCost: 2, swampCost: 10 }` even though your paths will be the same.
  */
 interface CostMatrix {
     /**
@@ -3403,7 +3879,16 @@ interface CostMatrix {
 declare const PathFinder: PathFinder;
 /**
  * Power Creeps are immortal "heroes" that are tied to your account and can be respawned in any PowerSpawn after death.
- * You can upgrade their abilities ("powers") up to your account Global Power Level (see `Game.gpl`).
+ *
+ * You can upgrade their abilities ("powers") up to your account Global Power Level (see {@link Game.gpl}).
+ *
+ * |                   |                  |
+ * | ----------------- | ---------------- |
+ * | **Time to live**  | 5,000
+ * | **Hits**          | 1,000 per level
+ * | **Capacity**      | 100 per level
+ *
+ * [Full list of available powers](https://docs.screeps.com/power.html#Powers)
  */
 interface PowerCreep extends RoomObject {
     /**
@@ -3417,7 +3902,7 @@ interface PowerCreep extends RoomObject {
      */
     carryCapacity: number;
     /**
-     * The power creep's class, one of the `POWER_CLASS` constants.
+     * The power creep's class, one of the {@link PowerClassConstant} constants.
      */
     className: PowerClassConstant;
     /**
@@ -3433,7 +3918,9 @@ interface PowerCreep extends RoomObject {
      */
     hitsMax: number;
     /**
-     * A unique identifier. You can use `Game.getObjectById` method to retrieve an object instance by its id.
+     * A unique identifier.
+     *
+     * You can use the {@link Game.getObjectById} to retrieve an object instance by its id.
      */
     id: Id<this>;
     /**
@@ -3441,7 +3928,11 @@ interface PowerCreep extends RoomObject {
      */
     level: number;
     /**
-     * A shorthand to `Memory.powerCreeps[creep.name]`. You can use it for quick access to the creep's specific memory data object.
+     * The power creep's memory.
+     *
+     * A shorthand to `Memory.powerCreeps[creep.name]`.
+     *
+     * You can use it for quick access to the creep's specific memory data object.
      */
     memory: PowerCreepMemory;
     /**
@@ -3449,7 +3940,10 @@ interface PowerCreep extends RoomObject {
      */
     my: boolean;
     /**
-     * Power creep name. You can choose the name while creating a new power creep, and `rename` it while unspawned. This name is a hash key to access the creep via the `Game.powerCreeps` object.
+     * The power creep name.
+     *
+     * You can choose the name while creating a new power creep, and `rename` it while unspawned.
+     * This name is a hash key to access the creep via the {@link Game.powerCreeps} object.
      */
     name: string;
     /**
@@ -3473,90 +3967,163 @@ interface PowerCreep extends RoomObject {
      */
     shard: string | undefined;
     /**
-     * The timestamp when spawning or deleting this creep will become available. Undefined if the power creep is spawned in the world.
+     * The timestamp when spawning or deleting this creep will become available.
+     *
+     * Undefined if the power creep is spawned in the world.
+     *
      * Note: This is a timestamp, not ticks as powerCreeps are not shard dependent.
      */
     spawnCooldownTime: number | undefined;
     /**
-     * The remaining amount of game ticks after which the creep will die and become unspawned. Undefined if the creep is not spawned in the world.
+     * The remaining amount of game ticks after which the creep will die and become unspawned.
+     *
+     * Undefined if the creep is not spawned in the world.
      */
     ticksToLive: number | undefined;
     /**
-     *
+     * Cancel the order given during the current game tick.
      * @param methodName Cancel the order given during the current game tick.
+     * @returns One of the following codes:
+     * - OK: The operation has been cancelled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of the creep.
+     * - ERR_BUSY: The power creep is not spawned in the world.
+     * - ERR_NOT_FOUND: The order with the specified name is not found.
      */
     cancelOrder(methodName: string): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_FOUND;
     /**
      * Delete the power creep permanently from your account.
-     * It should NOT be spawned in the world. The creep is not deleted immediately, but a 24-hour delete time is started (see `deleteTime`).
+     *
+     * It should NOT be spawned in the world.
+     * The creep is not deleted immediately, but a 24-hour delete time is started (see {@link PowerCreep.deleteTime}).
      * You can cancel deletion by calling `delete(true)`.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of the creep.
+     * - ERR_BUSY: The power creep is spawned in the world.
      */
     delete(cancel?: boolean): OK | ERR_NOT_OWNER | ERR_BUSY;
     /**
      * Drop this resource on the ground.
-     * @param resourceType One of the RESOURCE_* constants.
+     * @param resourceType One of the {@link ResourceConstant} constants.
      * @param amount The amount of resource units to be dropped. If omitted, all the available carried amount is used.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The power creep is not spawned in the world.
+     * - ERR_NOT_ENOUGH_RESOURCES: The creep does not have the given amount of energy.
+     * - ERR_INVALID_ARGS: The resourceType is not a valid {@link ResourceConstant} constants.
      */
     drop(resourceType: ResourceConstant, amount?: number): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_ENOUGH_RESOURCES;
     /**
-     * Enable power usage in this room. The room controller should be at adjacent tile.
+     * Enable power usage in this room.
+     *
+     * The room controller should be at adjacent tile.
      * @param controller The room controller
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_INVALID_TARGET: The target is not a controller structure.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
      */
     enableRoom(controller: StructureController): OK | ERR_NOT_OWNER | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE;
     /**
      * Move the creep one square in the specified direction or towards a creep that is pulling it.
      *
      * Requires the MOVE body part if not being pulled.
-     * @param direction The direction to move in (`TOP`, `TOP_LEFT`...)
+     * @param direction The direction to move in (see {@link DirectionConstant})
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The power creep is not spawned in the world.
+     * - ERR_NOT_IN_RANGE: The target creep is too far away
+     * - ERR_INVALID_ARGS: The provided direction is incorrect.
      */
     move(direction: DirectionConstant): CreepMoveReturnCode;
     move(target: Creep): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_IN_RANGE | ERR_INVALID_ARGS;
     /**
-     * Move the creep using the specified predefined path. Needs the MOVE body part.
-     * @param path A path value as returned from Room.findPath or RoomPosition.findPathTo methods. Both array form and serialized string form are accepted.
+     * Move the creep using the specified predefined path.
+     *
+     * @param path A path value as returned from {@link Room.findPath} or {@link RoomPosition.findPathTo} methods.
+     * Both array form and serialized string form are accepted.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The power creep is not spawned in the world.
+     * - ERR_NOT_FOUND: The specified path doesn't match the creep's location.
+     * - ERR_INVALID_ARGS: path is not a valid path array.
      */
-    moveByPath(path: PathStep[] | RoomPosition[] | string): CreepMoveReturnCode | ERR_NOT_FOUND | ERR_INVALID_ARGS;
+    moveByPath(path: PathStep[] | RoomPosition[] | string): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_FOUND | ERR_INVALID_ARGS;
     /**
      * Find the optimal path to the target within the same room and move to it.
-     * A shorthand to consequent calls of pos.findPathTo() and move() methods.
+     *
+     * A shorthand to consequent calls of {@link RoomPosition.findPathTo()} and {@link Creep.move()} methods.
      * If the target is in another room, then the corresponding exit will be used as a target.
      *
-     * Needs the MOVE body part.
      * @param x X position of the target in the room.
      * @param y Y position of the target in the room.
-     * @param opts An object containing pathfinding options flags (see Room.findPath for more info) or one of the following: reusePath, serializeMemory, noPathFinding
-     */
-    moveTo(x: number, y: number, opts?: MoveToOpts): CreepMoveReturnCode | ERR_NO_PATH | ERR_INVALID_TARGET;
-    /**
-     * Find the optimal path to the target within the same room and move to it.
-     * A shorthand to consequent calls of pos.findPathTo() and move() methods.
-     * If the target is in another room, then the corresponding exit will be used as a target.
-     *
-     * Needs the MOVE body part.
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
-     * @param opts An object containing pathfinding options flags (see Room.findPath for more info) or one of the following: reusePath, serializeMemory, noPathFinding
+     * @param opts An object containing pathfinding options flags (see {@link Room.findPath} for more info) or one of the following: reusePath, serializeMemory, noPathFinding
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_NO_PATH: No path to the target could be found.
+     * - ERR_BUSY: The power creep is not spawned in the world.
+     * - ERR_NOT_FOUND: The creep has no memorized path to reuse.
+     * - ERR_INVALID_TARGET: The target provided is invalid.
      */
+    moveTo(x: number, y: number, opts?: MoveToOpts): OK | ERR_NOT_OWNER | ERR_NO_PATH | ERR_BUSY | ERR_NOT_FOUND | ERR_INVALID_TARGET;
     moveTo(
         target: RoomPosition | { pos: RoomPosition },
         opts?: MoveToOpts,
     ): CreepMoveReturnCode | ERR_NO_PATH | ERR_INVALID_TARGET | ERR_NOT_FOUND;
     /**
-     * Toggle auto notification when the creep is under attack. The notification will be sent to your account email. Turned on by default.
+     * Toggle auto notification when the creep is under attack.
+     *
+     * The notification will be sent to your account email. Turned on by default.
      * @param enabled Whether to enable notification or disable.
+     * * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The power creep is not spawned in the world.
+     * - ERR_INVALID_ARGS: enable argument is not a boolean value.
      */
     notifyWhenAttacked(enabled: boolean): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_ARGS;
     /**
-     * Pick up an item (a dropped piece of energy). Needs the CARRY body part. The target has to be at adjacent square to the creep or at the same square.
+     * Pick up an item (a dropped piece of energy).
+     *
+     * The target has to be at adjacent square to the creep or at the same square.
      * @param target The target object to be picked up.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The power creep is not spawned in the world.
+     * - ERR_INVALID_TARGET: The target is not a valid object to pick up.
+     * - ERR_FULL: The creep cannot receive any more resource.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
      */
-    pickup(target: Resource): CreepActionReturnCode | ERR_FULL;
+    pickup(target: Resource): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_FULL | ERR_NOT_IN_RANGE;
     /**
-     * Rename the power creep. It must not be spawned in the world.
+     * Rename the power creep.
+     *
+     * It must not be spawned in the world.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of the creep.
+     * - ERR_NAME_EXISTS: A power creep with the specified name already exists.
+     * - ERR_BUSY: The power creep is spawned in the world.
      */
     rename(name: string): OK | ERR_NOT_OWNER | ERR_NAME_EXISTS | ERR_BUSY;
     /**
-     * Instantly restore time to live to the maximum using a Power Spawn or a Power Bank nearby. It has to be at adjacent tile.
+     * Instantly restore time to live to the maximum using a Power Spawn or a Power Bank nearby.
+     *
+     * It has to be at adjacent tile.
      * @param target The target structure
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The power creep is not spawned in the world.
+     * - ERR_INVALID_TARGET: The target is not a valid power bank or power spawn.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
      */
     renew(target: StructurePowerBank | StructurePowerSpawn): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE;
     /**
@@ -3567,30 +4134,81 @@ interface PowerCreep extends RoomObject {
      * Only the creep's owner can see the speech message unless toPublic is true.
      * @param message The message to be displayed. Maximum length is 10 characters.
      * @param set to 'true' to allow other players to see this message. Default is 'false'.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The power creep is not spawned in the world.
      */
     say(message: string, toPublic?: boolean): OK | ERR_NOT_OWNER | ERR_BUSY;
     /**
      * Spawn this power creep in the specified Power Spawn.
      * @param powerSpawn Your Power Spawn structure
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of the creep or the spawn.
+     * - ERR_BUSY: The power creep is already spawned in the world.
+     * - ERR_INVALID_TARGET: The specified object is not a Power Spawn.
+     * - ERR_TIRED: The power creep cannot be spawned because of the cooldown.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use the spawn.
      */
     spawn(powerSpawn: StructurePowerSpawn): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_TIRED | ERR_RCL_NOT_ENOUGH;
     /**
-     * Kill the power creep immediately. It will not be destroyed permanently, but will become unspawned, so that you can `spawn` it again.
+     * Kill the power creep immediately.
+     *
+     * It will not be destroyed permanently, but will become unspawned, so that you can `spawn` it again.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The power creep is not spawned in the world.
      */
     suicide(): OK | ERR_NOT_OWNER | ERR_BUSY;
     /**
-     * Transfer resource from the creep to another object. The target has to be at adjacent square to the creep.
+     * Transfer resource from the creep to another object.
+     *
+     * The target has to be at adjacent square to the creep.
      * @param target The target object.
-     * @param resourceType One of the RESOURCE_* constants
+     * @param resourceType One of the {@link ResourceConstant} constants
      * @param amount The amount of resources to be transferred. If omitted, all the available carried amount is used.
+     * @returns
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The power creep is not spawned in the world.
+     * - ERR_NOT_ENOUGH_RESOURCES: The creep does not have the given amount of resources.
+     * - ERR_INVALID_TARGET: The target is not a valid object which can contain the specified resource.
+     * - ERR_FULL: The target cannot receive any more resources.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant} constants, or the amount is incorrect.
      */
     transfer(target: AnyCreep | Structure, resourceType: ResourceConstant, amount?: number): ScreepsReturnCode;
     /**
-     * Upgrade the creep, adding a new power ability to it or increasing the level of the existing power. You need one free Power Level in your account to perform this action.
+     * Upgrade the creep, adding a new power ability to it or increasing the level of the existing power.
+     *
+     * You need one free Power Level in your account to perform this action.
+     * @param power	The power ability to upgrade, one of the {@link PowerConstant} constants.
+     * @returns
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of the creep.
+     * - ERR_NOT_ENOUGH_RESOURCES: You account Power Level is not enough.
+     * - ERR_FULL: The specified power cannot be upgraded on this creep's level, or the creep reached the maximum level.
+     * - ERR_INVALID_ARGS: The specified power ID is not valid.
      */
     upgrade(power: PowerConstant): OK | ERR_NOT_OWNER | ERR_NOT_ENOUGH_RESOURCES | ERR_FULL | ERR_INVALID_ARGS;
     /**
      * Apply one of the creep's powers on the specified target.
+     *
+     * @param power The power ability to use, one of the {@link PowerConstant} constants.
+     * @param target A target object in the room.
+     * @returns
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of the creep.
+     * - ERR_BUSY: The creep is not spawned in the world.
+     * - ERR_NOT_ENOUGH_RESOURCES: The creep doesn't have enough resources to use the power.
+     * - ERR_INVALID_TARGET: The specified target is not valid.
+     * - ERR_FULL: The target has the same active effect of a higher level.
+     * - ERR_NOT_IN_RANGE: The specified target is too far away.
+     * - ERR_INVALID_ARGS: Using powers is not enabled on the Room Controller.
+     * - ERR_TIRED: The power ability is still on cooldown.
+     * - ERR_NO_BODYPART: The creep doesn't have the specified power ability.
      */
     usePower(power: PowerConstant, target?: RoomObject): ScreepsReturnCode;
     /**
@@ -3602,21 +4220,31 @@ interface PowerCreep extends RoomObject {
      *
      * Your creeps can withdraw resources from hostile structures as well, in case if there is no hostile rampart on top of it.
      * @param target The target object.
-     * @param resourceType The target One of the RESOURCE_* constants..
+     * @param resourceType The target One of the {@link ResourceConstant} constants..
      * @param amount The amount of resources to be transferred. If omitted, all the available amount is used.
+     * @returns
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep, or there is a hostile rampart on top of the target.
+     * - ERR_BUSY: The power creep is not spawned in the world.
+     * - ERR_NOT_ENOUGH_RESOURCES: The target does not have the given amount of resources.
+     * - ERR_INVALID_TARGET: The target is not a valid object which can contain the specified resource.
+     * - ERR_FULL: The creep's carry is full.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant} constants, or the amount is incorrect.
      */
     withdraw(target: Structure | Tombstone | Ruin, resourceType: ResourceConstant, amount?: number): ScreepsReturnCode;
 }
 
 interface PowerCreepConstructor extends _Constructor<PowerCreep>, _ConstructorById<PowerCreep> {
     /**
-     * A static method to create new Power Creep instance in your account. It will be added in an unspawned state,
-     * use spawn method to spawn it in the world.
+     * A static method to create new Power Creep instance in your account.
+     *
+     * It will be added in an unspawned state, use the {@link PowerCreep.spawn} method to spawn it in the world.
      *
      * You need one free Power Level in your account to perform this action.
      *
      * @param name The name of the power creep.
-     * @param className The class of the new power creep, one of the `POWER_CLASS` constants
+     * @param className The class of the new power creep, one of the {@link PowerClassConstant} constants
      */
     create(name: string, className: PowerClassConstant): OK | ERR_NAME_EXISTS | ERR_NOT_ENOUGH_RESOURCES;
 }
@@ -3633,23 +4261,31 @@ interface PowerCreepPowers {
          */
         level: number;
         /**
-         * Cooldown ticks remaining, or undefined if the power creep is not spawned in the world.
+         * Cooldown ticks remaining
+         *
+         * Will be undefined if the power creep is not spawned in the world.
          */
         cooldown: number | undefined;
     };
 }
 /**
  * RawMemory object allows to implement your own memory stringifier instead of built-in serializer based on JSON.stringify.
+ *
+ * It also allows to request up to 10 MB of additional memory using asynchronous memory segments feature.
+ *
+ * You can also access memory segments of other players using methods below.
  */
 interface RawMemory {
     /**
-     * An object with asynchronous memory segments available on this tick. Each object key is the segment ID with data in string values.
-     * Use RawMemory.setActiveSegments to fetch segments on the next tick. Segments data is saved automatically in the end of the tick.
+     * An object with asynchronous memory segments available on this tick.
+     *
+     * Each object key is the segment ID with data in string values.
+     * Use {@link RawMemory.setActiveSegments} to fetch segments on the next tick. Segments data is saved automatically in the end of the tick.
      */
     segments: { [segmentId: number]: string };
 
     /**
-     * An object with a memory segment of another player available on this tick. Use `setActiveForeignSegment` to fetch segments on the next tick.
+     * An object with a memory segment of another player available on this tick. Use {@link RawMemory.setActiveForeignSegment} to fetch segments on the next tick.
      */
     foreignSegment: {
         username: string;
@@ -3677,43 +4313,60 @@ interface RawMemory {
     /**
      * Set new memory value.
      * @param value New memory value as a string.
+     * @throws if the new value is not a string or contains more than `2 * 1024 * 1024` characters.
      */
     set(value: string): undefined;
     /**
-     * Request memory segments using the list of their IDs. Memory segments will become available on the next tick in RawMemory.segments object.
-     * @param ids An array of segment IDs. Each ID should be a number from 0 to 99. Maximum 10 segments can be active at the same time. Subsequent calls of setActiveSegments override previous ones.
+     * Request memory segments using the list of their IDs.
+     *
+     * Memory segments will become available on the next tick in {@link RawMemory.segments} object.
+     * Segment IDs are a number from 0 to 99. A maximum of 10 segments can be active at the same time.
+     * Subsequent calls to {@link RawMemory.setActiveSegments} overrides previous ones.
+     *
+     * @param ids An array of segment IDs.
+     * @throws if `ids` isn't an array, more than 10 segments are active, or the ids aren't all integers.
      */
     setActiveSegments(ids: number[]): undefined;
     /**
      * Request a memory segment of another user.
      *
-     * The segment should be marked by its owner as public using `setPublicSegments`.
+     * The segment should be marked by its owner as public using {@link RawMemory.setPublicSegments}.
      *
-     * The segment data will become available on the next tick in `foreignSegment` object.
+     * The segment data will become available on the next tick in {@link foreignSegment} object.
      *
      * You can only have access to one foreign segment at the same time.
      *
      * @param username The name of another user. Pass `null` to clear the foreign segment.
-     * @param id The ID of the requested segment from 0 to 99. If undefined, the user's default public segment is requested as set by `setDefaultPublicSegment`.
+     * @param id The ID of the requested segment from 0 to 99. If undefined, the user's default public segment is requested as set by {@link RawMemory.setDefaultPublicSegment}.
+     * @throws if `id` is passed and isn't an integer.
      */
     setActiveForeignSegment(username: string | null, id?: number): undefined;
     /**
-     * Set the specified segment as your default public segment. It will be returned if no id parameter is passed to `setActiveForeignSegment` by another user.
+     * Set the specified segment as your default public segment.
+     *
+     * It will be returned if no id parameter is passed to {@link RawMemory.setActiveForeignSegment} by another user.
      *
      * @param id The ID of the requested segment from 0 to 99. Pass `null` to clear the foreign segment.
+     * @throws if `id` is passed and isn't an integer.
      */
     setDefaultPublicSegment(id: number | null): undefined;
     /**
-     * Set specified segments as public. Other users will be able to request access to them using `setActiveForeignSegment`.
+     * Set specified segments as public.
      *
-     * @param ids An array of segment IDs. Each ID should be a number from 0 to 99. Subsequent calls of `setPublicSegments` override previous ones.
+     * Other users will be able to request access to them using {@link setActiveForeignSegment}.
+     *
+     * @param ids An array of segment IDs. Each ID should be a number from 0 to 99. Subsequent calls of {@link RawMemory.setPublicSegments} override previous ones.
+     * @throws if `ids` isn't an array or the ids aren't all integers.
      */
     setPublicSegments(ids: number[]): undefined;
 }
 
 declare const RawMemory: RawMemory;
 /**
- * A dropped piece of resource. It will decay after a while if not picked up. Dropped resource pile decays for ceil(amount/1000) units per tick.
+ * A dropped piece of resource.
+ *
+ * It will decay after a while if not picked up.
+ * Dropped resource pile decays for `ceil(amount/1000)` units per tick.
  */
 
 interface Resource<T extends ResourceConstant = ResourceConstant> extends RoomObject {
@@ -3724,11 +4377,13 @@ interface Resource<T extends ResourceConstant = ResourceConstant> extends RoomOb
      */
     amount: number;
     /**
-     * A unique object identifier. You can use `Game.getObjectById` method to retrieve an object instance by its `id`.
+     * A unique object identifier.
+     *
+     * You can use {@link Game.getObjectById} to retrieve an object instance by its `id`.
      */
     id: Id<this>;
     /**
-     * One of the `RESOURCE_*` constants.
+     * One of the {@link ResourceConstant} constants.
      */
     resourceType: T;
 }
@@ -3737,14 +4392,15 @@ interface ResourceConstructor extends _Constructor<Resource>, _ConstructorById<R
 
 declare const Resource: ResourceConstructor;
 /**
- * Any object with a position in a room. Almost all game objects prototypes
- * are derived from RoomObject.
+ * Any object with a position in a room.
+ *
+ * Almost all game objects prototypes are derived from RoomObject.
  */
 
 interface RoomObject {
     readonly prototype: RoomObject;
     /**
-     * Applied effects, an array of objects with the following properties:
+     * Effects currently being applied to the object.
      */
     effects?: RoomObjectEffect[];
     /**
@@ -3752,8 +4408,9 @@ interface RoomObject {
      */
     pos: RoomPosition;
     /**
-     * The link to the Room object. May be undefined in case if an object is a
-     * flag or a construction site and is placed in a room that is not visible
+     * The link to the {@link Room} object.
+     *
+     * May be `undefined` if the object is a {@link Flag} or a {@link ConstructionSite} and is placed in a room that is not visible
      * to you.
      */
     room: Room | undefined;
@@ -3776,7 +4433,9 @@ type RoomObjectEffect = NaturalEffect | PowerEffect;
  */
 interface NaturalEffect {
     /**
-     * Effect ID of the applied effect. `EFFECT_*` constant.
+     * Effect ID of the applied effect.
+     *
+     * One of the {@link EffectConstant} constants.
      */
     effect: EffectConstant;
     /**
@@ -3786,7 +4445,7 @@ interface NaturalEffect {
 }
 
 /**
- * Effect applied to room object as result of a `PowerCreep.usePower`.
+ * Effect applied to room object as result of a {@link PowerCreep.usePower}.
  */
 interface PowerEffect {
     /**
@@ -3794,11 +4453,17 @@ interface PowerEffect {
      */
     level: number;
     /**
-     * Effect ID of the applied effect. `PWR_*` constant.
+     * Effect ID of the applied effect.
+     *
+     * One of the {@link PowerConstant} constants.
      */
     effect: PowerConstant;
     /**
-     * @deprecated Power ID of the applied effect. `PWR_*` constant. No longer documented, will be removed.
+     * Power ID of the applied effect.
+     *
+     * @deprecated Use {@link PowerEffect.effect} instead.
+     *
+     * One of the {@link PowerConstant} constants.
      */
     power: PowerConstant;
     /**
@@ -3809,9 +4474,9 @@ interface PowerEffect {
 /**
  * An object representing the specified position in the room.
  *
- * Every object in the room contains RoomPosition as the pos property.
+ * Every object in the room contains one of these as its `pos` property.
  *
- * The position object of a custom location can be obtained using the Room.getPositionAt() method or using the constructor.
+ * The position object of a custom location can be obtained using the {@link Room.getPositionAt()} method or using the constructor.
  */
 interface RoomPosition {
     readonly prototype: RoomPosition;
@@ -3829,42 +4494,46 @@ interface RoomPosition {
      */
     y: number;
     /**
-     * Create new ConstructionSite at the specified location.
-     * @param structureType One of the following constants:
-     *  * STRUCTURE_EXTENSION
-     *  * STRUCTURE_RAMPART
-     *  * STRUCTURE_ROAD
-     *  * STRUCTURE_SPAWN
-     *  * STRUCTURE_WALL
-     *  * STRUCTURE_LINK
+     * Create a new {@link ConstructionSite} at the specified location.
+     * @param structureType One of {@link BuildableStructureConstant}.
+     * @returns
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You don't have ownership of the targetted room.
+     * - ERR_INVALID_TARGET: The structure cannot be placed at the specified location.
+     * - ERR_FULL: You have too many construction sites. The maximum number of construction sites per player is 100.
+     * - ERR_INVALID_ARGS: The location is incorrect.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient.
      */
     createConstructionSite(structureType: BuildableStructureConstant): ScreepsReturnCode;
     /**
-     * Create new ConstructionSite at the specified location.
-     * @param structureType One of the following constants:
-     *  * STRUCTURE_EXTENSION
-     *  * STRUCTURE_RAMPART
-     *  * STRUCTURE_ROAD
-     *  * STRUCTURE_SPAWN
-     *  * STRUCTURE_WALL
-     *  * STRUCTURE_LINK
-     * @param name The name of the structure, for structures that support it (currently only spawns).
+     * Create a new {@link ConstructionSite} at the specified location.
+     * @param structureType One of {@link BuildableStructureConstant}.
+     * @param name The name of the structure, for structures that support it (currently only spawns). The name length limit is 100 characters.
+     * @returns
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You don't have ownership of the targetted room.
+     * - ERR_INVALID_TARGET: The structure cannot be placed at the specified location.
+     * - ERR_FULL: You have too many construction sites. The maximum number of construction sites per player is 100.
+     * - ERR_INVALID_ARGS: The location is incorrect.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient.
      */
     createConstructionSite(structureType: STRUCTURE_SPAWN, name?: string): ScreepsReturnCode;
     /**
-     * Create new Flag at the specified location.
+     * Create a new {@link Flag} at the specified location.
      * @param name The name of a new flag.
      * It should be unique, i.e. the Game.flags object should not contain another flag with the same name (hash key).
      * If not defined, a random name will be generated.
-     * @param color The color of a new flag. Should be one of the COLOR_* constants
-     * @param secondaryColor The secondary color of a new flag. Should be one of the COLOR_* constants. The default value is equal to color.
+     * @param color The color of a new flag. Should be one of the {@link ColorConstant} constants
+     * @param secondaryColor The secondary color of a new flag. Should be one of the {@link ColorConstant} constants. The default value is equal to color.
      * @returns The name of the flag if created, or one of the following error codes: ERR_NAME_EXISTS, ERR_INVALID_ARGS
      */
     createFlag(name?: string, color?: ColorConstant, secondaryColor?: ColorConstant): ERR_NAME_EXISTS | ERR_INVALID_ARGS | string;
     /**
-     * Find the object with the shortest path from the given position. Uses A* search algorithm and Dijkstra's algorithm.
-     * @param type Any of the FIND_* constants.
-     * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
+     * Find the object with the shortest path from the given position.
+     *
+     * Uses A* search algorithm and Dijkstra's algorithm.
+     * @param type Any of the {@link FindConstant} constants.
+     * @param opts An object containing pathfinding options (see {@link Room.findPath}), or one of the following: filter, algorithm
      * @returns An instance of a RoomObject.
      */
     findClosestByPath<K extends FindConstant, S extends FindTypes[K]>(
@@ -3876,9 +4545,11 @@ interface RoomPosition {
         opts?: FindPathOpts & FilterOptions<FindTypes[FIND_STRUCTURES], S> & { algorithm?: FindClosestByPathAlgorithm },
     ): S | null;
     /**
-     * Find the object with the shortest path from the given position. Uses A* search algorithm and Dijkstra's algorithm.
+     * Find the object with the shortest path from the given position.
+     *
+     * Uses A* search algorithm and Dijkstra's algorithm.
      * @param objects An array of RoomPositions or objects with a RoomPosition
-     * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
+     * @param opts An object containing pathfinding options (see {@link Room.findPath}), or one of the following: filter, algorithm
      * @returns One of the supplied objects
      */
     findClosestByPath<T extends _HasRoomPosition | RoomPosition, S extends T = T>(
@@ -3890,8 +4561,8 @@ interface RoomPosition {
     ): S | null;
     /**
      * Find the object with the shortest linear distance from the given position.
-     * @param type Any of the FIND_* constants.
-     * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
+     * @param type Any of the {@link FindConstant} constants.
+     * @param opts An object containing pathfinding options (see {@link Room.findPath}), or one of the following: filter, algorithm
      */
     findClosestByRange<K extends FindConstant, S extends FindTypes[K]>(type: K, opts?: FilterOptions<FindTypes[K], S>): S | null;
     findClosestByRange<S extends AnyStructure>(
@@ -3901,12 +4572,12 @@ interface RoomPosition {
     /**
      * Find the object with the shortest linear distance from the given position.
      * @param objects An array of RoomPositions or objects with a RoomPosition.
-     * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
+     * @param opts An object containing pathfinding options (see {@link Room.findPath}), or one of the following: filter, algorithm
      */
     findClosestByRange<T extends _HasRoomPosition | RoomPosition, S extends T = T>(objects: T[], opts?: FilterOptions<T, S>): S | null;
     /**
      * Find all objects in the specified linear range.
-     * @param type Any of the FIND_* constants.
+     * @param type Any of the {@link FindConstant} constants.
      * @param range The range distance.
      * @param opts See Room.find.
      */
@@ -3920,24 +4591,24 @@ interface RoomPosition {
      * Find all objects in the specified linear range.
      * @param objects An array of room's objects or RoomPosition objects that the search should be executed against.
      * @param range The range distance.
-     * @param opts See Room.find.
+     * @param opts See {@link Room.find}.
      */
     findInRange<T extends _HasRoomPosition | RoomPosition, S extends T = T>(objects: T[], range: number, opts?: FilterOptions<T, S>): S[];
     /**
      * Find an optimal path to the specified position using A* search algorithm.
      *
-     * This method is a shorthand for Room.findPath. If the target is in another room, then the corresponding exit will be used as a target.
+     * This method is a shorthand for {@link Room.findPath}. If the target is in another room, then the corresponding exit will be used as a target.
      * @param x X position in the room.
      * @param y Y position in the room.
-     * @param opts An object containing pathfinding options flags (see Room.findPath for more details).
+     * @param opts An object containing pathfinding options flags (see {@link Room.findPath} for more details).
      */
     findPathTo(x: number, y: number, opts?: FindPathOpts): PathStep[];
     /**
      * Find an optimal path to the specified position using A* search algorithm.
      *
-     * This method is a shorthand for Room.findPath. If the target is in another room, then the corresponding exit will be used as a target.
+     * This method is a shorthand for {@link Room.findPath}. If the target is in another room, then the corresponding exit will be used as a target.
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
-     * @param opts An object containing pathfinding options flags (see Room.findPath for more details).
+     * @param opts An object containing pathfinding options flags (see {@link Room.findPath} for more details).
      */
     findPathTo(target: RoomPosition | _HasRoomPosition, opts?: FindPathOpts): PathStep[];
     /**
@@ -3987,13 +4658,17 @@ interface RoomPosition {
      */
     isEqualTo(target: RoomPosition | { pos: RoomPosition }): boolean;
     /**
-     * Check whether this position is on the adjacent square to the specified position. The same as inRangeTo(target, 1).
+     * Check whether this position is on the adjacent square to the specified position.
+     *
+     * Equivalent to `inRangeTo(target, 1)`.
      * @param x X position in the room.
      * @param y Y position in the room.
      */
     isNearTo(x: number, y: number): boolean;
     /**
-     * Check whether this position is on the adjacent square to the specified position. The same as inRangeTo(target, 1).
+     * Check whether this position is on the adjacent square to the specified position.
+     *
+     * Equivalent to inRangeTo(target, 1).
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
      */
     isNearTo(target: RoomPosition | { pos: RoomPosition }): boolean;
@@ -4014,6 +4689,7 @@ interface RoomPositionConstructor extends _Constructor<RoomPosition> {
      * @param x X position in the room.
      * @param y Y position in the room.
      * @param roomName The room name.
+     * @throws if `x` or `y` are out of bounds, or `roomName` isn't a valid room name.
      */
     new (x: number, y: number, roomName: string): RoomPosition;
     (x: number, y: number, roomName: string): RoomPosition;
@@ -4021,18 +4697,24 @@ interface RoomPositionConstructor extends _Constructor<RoomPosition> {
 
 declare const RoomPosition: RoomPositionConstructor;
 /**
- * Result of Object that contains all terrain for a room
+ * An object which provides fast access to room terrain data.
+ *
+ * These objects can be constructed for any room in the world even if you have no access to it.
+ *
+ * Technically every Room.Terrain object is a very lightweight adapter to underlying static terrain buffers with corresponding minimal accessors.
  */
 interface RoomTerrain {
     /**
-     * Get terrain type at the specified room position. This method works for any room in the world even if you have no access to it.
+     * Get terrain type at the specified room position.
+     *
+     * This method works for any room in the world even if you have no access to it.
      * @param x X position in the room.
      * @param y Y position in the room.
-     * @return number Number of terrain mask like: TERRAIN_MASK_SWAMP | TERRAIN_MASK_WALL
+     * @return A bitmask of {@link TERRAIN_MASK_WALL}, {@link TERRAIN_MASK_SWAMP}.
      */
     get(x: number, y: number): 0 | TERRAIN_MASK_WALL | TERRAIN_MASK_SWAMP;
     /**
-     * Get copy of underlying static terrain buffer.
+     * Get a copy of the underlying static terrain buffer.
      * @param destinationArray (optional) A typed array view in which terrain will be copied to.
      * @throws {RangeError} if `destinationArray` is provided, it must have a length of at least 2500 (`50*50`).
      * @return Copy of underlying room terrain as a new typed array of size 2500.
@@ -4056,11 +4738,26 @@ interface RoomTerrain {
 
 interface RoomTerrainConstructor extends _Constructor<RoomTerrain> {
     /**
-     * Get room terrain for the specified room. This method works for any room in the world even if you have no access to it.
+     * Get room terrain for the specified room.
+     *
+     * This method works for any room in the world even if you have no access to it.
      * @param roomName String name of the room.
      */
     new (roomName: string): RoomTerrain;
 }
+/**
+ * Room visuals provide a way to show various visual debug info in game rooms.
+ *
+ * You can use the RoomVisual object to draw simple shapes that are visible only to you.
+ * Every existing Room object already contains the visual property, but you also can create new RoomVisual objects for any room (even without visibility) using the constructor.
+ *
+ * Room visuals are not stored in the database, their only purpose is to display something in your browser.
+ * All drawings will persist for one tick and will disappear if not updated. All RoomVisual API calls have no added CPU cost (their cost is natural and mostly related to simple `JSON.serialize` calls).
+ * However, there is a usage limit: you cannot post more than 500 KB of serialized data per one room (see {@link RoomVisual.getSize} method).
+ *
+ * All draw coordinates are measured in game coordinates and centered to tile centers, i.e. (10,10) will point to the center of the creep at x:10; y:10 position.
+ * Fractional coordinates are allowed.
+ */
 declare class RoomVisual {
     /**
      * You can create new RoomVisual object using its constructor.
@@ -4149,7 +4846,9 @@ declare class RoomVisual {
     text(text: string, x: number, y: number, style?: TextStyle): RoomVisual;
 
     /**
-     * Draw a text label. You can use any valid Unicode characters, including emoji.
+     * Draw a text label.
+     *
+     * You can use any valid Unicode characters, including emoji.
      * @param text The text message.
      * @param pos The position object of the center.
      * @param style An object describing the style.
@@ -4177,7 +4876,7 @@ declare class RoomVisual {
     export(): string;
 
     /**
-     * Add previously exported (with `RoomVisual.export`) room visuals to the room visual data of the current tick.
+     * Add previously exported (with {@link RoomVisual.export}) room visuals to the room visual data of the current tick.
      * @param data The string returned from `RoomVisual.export`.
      * @returns The RoomVisual object itself, so that you can chain calls.
      */
@@ -4186,26 +4885,31 @@ declare class RoomVisual {
 
 interface LineStyle {
     /**
-     * Line width, default is 0.1.
+     * Line width.
+     * @default 0.1
      */
     width?: number;
     /**
-     * Line color in any web format, default is #ffffff(white).
+     * Line color in any web format.
+     * @default #ffffff (white)
      */
     color?: string;
     /**
-     * Opacity value, default is 0.5.
+     * Opacity value.
+     * @default 0.5
      */
     opacity?: number;
     /**
-     * Either undefined (solid line), dashed, or dotted.Default is undefined.
+     * Either undefined (solid line), dashed, or dotted.
+     * @default undefined
      */
     lineStyle?: "dashed" | "dotted" | "solid" | undefined;
 }
 
 interface PolyStyle {
     /**
-     * Fill color in any web format, default is undefined (no fill).
+     * Fill color in any web format.
+     * @default undefined (no fill).
      */
     fill?: string | undefined;
     /**
@@ -4213,59 +4917,70 @@ interface PolyStyle {
      */
     opacity?: number;
     /**
-     * Stroke color in any web format, default is #ffffff (white).
+     * Stroke color in any web format.
+     * @default #ffffff (white)
      */
     stroke?: string;
     /**
-     * Stroke line width, default is 0.1.
+     * Stroke line width.
+     * @default 0.1
      */
     strokeWidth?: number;
     /**
-     * Either undefined (solid line), dashed, or dotted. Default is undefined.
+     * Either undefined (solid line), dashed, or dotted.
+     * @default undefined
      */
     lineStyle?: "dashed" | "dotted" | "solid" | undefined;
 }
 
 interface CircleStyle extends PolyStyle {
     /**
-     * Circle radius, default is 0.15.
+     * Circle radius.
+     * @default 0.15
      */
     radius?: number;
 }
 
 interface TextStyle {
     /**
-     * Font color in any web format, default is #ffffff(white).
+     * Font color in any web format.
+     * @default #ffffff (white)
      */
     color?: string;
     /**
      * Either a number or a string in one of the following forms:
-     * 0.7 - relative size in game coordinates
-     * 20px - absolute size in pixels
-     * 0.7 serif
-     * bold italic 1.5 Times New Roman
+     * - 0.7 - relative size in game coordinates
+     * - 20px - absolute size in pixels
+     * - 0.7 serif
+     * - bold italic 1.5 Times New Roman
      */
     font?: number | string;
     /**
-     * Stroke color in any web format, default is undefined (no stroke).
+     * Stroke color in any web format.
+     * @default undefined (no stroke)
      */
     stroke?: string | undefined;
     /**
-     * Stroke width, default is 0.15.
+     * Stroke width.
+     * @default 0.15
      */
     strokeWidth?: number;
     /**
-     * Background color in any web format, default is undefined (no background).When background is enabled, text vertical align is set to middle (default is baseline).
+     * Background color in any web format.
+     * When background is enabled, text vertical align is set to middle (default is baseline).
+     * @default undefined (no background)
      */
     backgroundColor?: string | undefined;
 
     /**
-     * Background rectangle padding, default is 0.3.
+     * Background rectangle padding
+     * @default 0.3
      */
     backgroundPadding?: number;
     align?: "center" | "left" | "right";
     /**
-     * Opacity value, default is 1.0.
+     * Opacity value.
+     * @default 1.0
      */
     opacity?: number;
 }
@@ -4274,7 +4989,7 @@ interface TextStyle {
  *
  * It can be used to look around, find paths, etc.
  *
- * Every object in the room contains its linked Room instance in the room property.
+ * Every object in the room contains its linked Room instance in the {@link RoomObject.room} property.
  */
 interface Room {
     readonly prototype: Room;
@@ -4300,6 +5015,8 @@ interface Room {
      */
     getEventLog(raw: true): string;
     /**
+     * The room's memory.
+     *
      * A shorthand to `Memory.rooms[room.name]`. You can use it for quick access the room’s specific memory data object.
      */
     memory: RoomMemory;
@@ -4308,51 +5025,75 @@ interface Room {
      */
     readonly name: string;
     /**
-     * The Storage structure of this room, if present, otherwise undefined.
+     * The {@link StructureStorage} of this room, if present, otherwise undefined.
      */
     storage?: StructureStorage;
     /**
-     * The Terminal structure of this room, if present, otherwise undefined.
+     * The {@link StructureTerminal} of this room, if present, otherwise undefined.
      */
     terminal?: StructureTerminal;
     /**
-     * A RoomVisual object for this room. You can use this object to draw simple shapes (lines, circles, text labels) in the room.
+     * A {@link RoomVisual} object for this room.
+     *
+     * You can use this object to draw simple shapes (lines, circles, text labels) in the room.
      */
     visual: RoomVisual;
     /**
-     * Create new ConstructionSite at the specified location.
-     * @param x The X position.
-     * @param y The Y position.
-     * @param structureType One of the following constants: STRUCTURE_EXTENSION, STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_SPAWN, STRUCTURE_WALL, STRUCTURE_LINK
-     * @returns Result Code: OK, ERR_INVALID_TARGET, ERR_INVALID_ARGS, ERR_RCL_NOT_ENOUGH
+     * Create new {@link ConstructionSite} at the specified location.
+     * @param x The X position
+     * @param y The Y position
+     * @param structureType One of {@link BuildableStructureConstant}.
+     * @returns
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: The room is claimed or reserved by a hostile player.
+     * - ERR_INVALID_TARGET: The structure cannot be placed at the specified location.
+     * - ERR_FULL: You have too many construction sites. The maximum number of construction sites per player is 100.
+     * - ERR_INVALID_ARGS: The location is incorrect.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient.
      */
     createConstructionSite(x: number, y: number, structureType: BuildableStructureConstant): ScreepsReturnCode;
     /**
-     * Create new ConstructionSite at the specified location.
-     * @param pos Can be a RoomPosition object or any object containing RoomPosition.
-     * @param structureType One of the following constants: STRUCTURE_EXTENSION, STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_SPAWN, STRUCTURE_WALL, STRUCTURE_LINK
-     * @returns Result Code: OK, ERR_INVALID_TARGET, ERR_INVALID_ARGS, ERR_RCL_NOT_ENOUGH
+     * Create new {@link ConstructionSite} at the specified location.
+     * @param pos Can be a {@link RoomPosition} object or any object containing RoomPosition.
+     * @param structureType One of {@link BuildableStructureConstant}.
+     * @returns
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: The room is claimed or reserved by a hostile player.
+     * - ERR_INVALID_TARGET: The structure cannot be placed at the specified location.
+     * - ERR_FULL: You have too many construction sites. The maximum number of construction sites per player is 100.
+     * - ERR_INVALID_ARGS: The location is incorrect.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient.
      */
     createConstructionSite(pos: RoomPosition | _HasRoomPosition, structureType: StructureConstant): ScreepsReturnCode;
     /**
-     * Create new ConstructionSite at the specified location.
-     * @param x The X position.
-     * @param y The Y position.
-     * @param structureType One of the following constants: STRUCTURE_EXTENSION, STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_SPAWN, STRUCTURE_WALL, STRUCTURE_LINK
-     * @param name The name of the structure, for structures that support it (currently only spawns).
-     * @returns Result Code: OK, ERR_INVALID_TARGET, ERR_INVALID_ARGS, ERR_RCL_NOT_ENOUGH
+     * Create new {@link ConstructionSite} at the specified location.
+     * @param x The X position
+     * @param y The Y position
+     * @param structureType One of {@link BuildableStructureConstant}.
+     * @returns
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: The room is claimed or reserved by a hostile player.
+     * - ERR_INVALID_TARGET: The structure cannot be placed at the specified location.
+     * - ERR_FULL: You have too many construction sites. The maximum number of construction sites per player is 100.
+     * - ERR_INVALID_ARGS: The location is incorrect.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient.
      */
     createConstructionSite(x: number, y: number, structureType: STRUCTURE_SPAWN, name?: string): ScreepsReturnCode;
     /**
-     * Create new ConstructionSite at the specified location.
-     * @param pos Can be a RoomPosition object or any object containing RoomPosition.
-     * @param structureType One of the following constants: STRUCTURE_EXTENSION, STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_SPAWN, STRUCTURE_WALL, STRUCTURE_LINK
-     * @param name The name of the structure, for structures that support it (currently only spawns).
-     * @returns Result Code: OK, ERR_INVALID_TARGET, ERR_INVALID_ARGS, ERR_RCL_NOT_ENOUGH
+     * Create new {@link ConstructionSite} at the specified location.
+     * @param pos Can be a {@link RoomPosition} object or any object containing RoomPosition.
+     * @param structureType One of {@link BuildableStructureConstant}.
+     * @returns
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: The room is claimed or reserved by a hostile player.
+     * - ERR_INVALID_TARGET: The structure cannot be placed at the specified location.
+     * - ERR_FULL: You have too many construction sites. The maximum number of construction sites per player is 100.
+     * - ERR_INVALID_ARGS: The location is incorrect.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient.
      */
     createConstructionSite(pos: RoomPosition | _HasRoomPosition, structureType: STRUCTURE_SPAWN, name?: string): ScreepsReturnCode;
     /**
-     * Create new Flag at the specified location.
+     * Create new {@link Flag} at the specified location.
      * @param x The X position.
      * @param y The Y position.
      * @param name (optional) The name of a new flag.
@@ -4364,7 +5105,10 @@ interface Room {
      * The maximum length is 60 characters.
      * @param color The color of a new flag. Should be one of the COLOR_* constants. The default value is COLOR_WHITE.
      * @param secondaryColor The secondary color of a new flag. Should be one of the COLOR_* constants. The default value is equal to color.
-     * @returns The name of a new flag, or one of the following error codes: ERR_NAME_EXISTS, ERR_INVALID_ARGS
+     * @returns The name of a new flag, or one of the following error codes:
+     * - ERR_NAME_EXISTS: There is a flag with the same name already.
+     * - ERR_FULL: You have too many flags. The maximum number of flags per player is 10000.
+     * - ERR_INVALID_ARGS: The location or the name or the color constant is incorrect.
      */
     createFlag(
         x: number,
@@ -4374,8 +5118,8 @@ interface Room {
         secondaryColor?: ColorConstant,
     ): ERR_NAME_EXISTS | ERR_INVALID_ARGS | string;
     /**
-     * Create new Flag at the specified location.
-     * @param pos Can be a RoomPosition object or any object containing RoomPosition.
+     * Create new {@link Flag} at the specified location.
+     * @param pos Can be a {@link RoomPosition} object or any object containing RoomPosition.
      * @param name (optional) The name of a new flag.
      *
      * It should be unique, i.e. the Game.flags object should not contain another flag with the same name (hash key).
@@ -4385,7 +5129,10 @@ interface Room {
      * The maximum length is 60 characters.
      * @param color The color of a new flag. Should be one of the COLOR_* constants. The default value is COLOR_WHITE.
      * @param secondaryColor The secondary color of a new flag. Should be one of the COLOR_* constants. The default value is equal to color.
-     * @returns The name of a new flag, or one of the following error codes: ERR_NAME_EXISTS, ERR_INVALID_ARGS
+     * @returns The name of a new flag, or one of the following error codes:
+     * - ERR_NAME_EXISTS: There is a flag with the same name already.
+     * - ERR_FULL: You have too many flags. The maximum number of flags per player is 10000.
+     * - ERR_INVALID_ARGS: The location or the name or the color constant is incorrect.
      */
     createFlag(
         pos: RoomPosition | { pos: RoomPosition },
@@ -4395,25 +5142,7 @@ interface Room {
     ): ERR_NAME_EXISTS | ERR_INVALID_ARGS | string;
     /**
      * Find all objects of the specified type in the room.
-     * @param type One of the following constants:
-     *  * FIND_CREEPS
-     *  * FIND_MY_CREEPS
-     *  * FIND_HOSTILE_CREEPS
-     *  * FIND_MY_SPAWNS
-     *  * FIND_HOSTILE_SPAWNS
-     *  * FIND_SOURCES
-     *  * FIND_SOURCES_ACTIVE
-     *  * FIND_DROPPED_RESOURCES
-     *  * FIND_STRUCTURES
-     *  * FIND_MY_STRUCTURES
-     *  * FIND_HOSTILE_STRUCTURES
-     *  * FIND_FLAGS
-     *  * FIND_CONSTRUCTION_SITES
-     *  * FIND_EXIT_TOP
-     *  * FIND_EXIT_RIGHT
-     *  * FIND_EXIT_BOTTOM
-     *  * FIND_EXIT_LEFT
-     *  * FIND_EXIT
+     * @param type One of the {@link FindConstant} constants.
      * @param opts An object with additional options
      * @returns An array with the objects found.
      */
@@ -4433,19 +5162,20 @@ interface Room {
      * Find an optimal path inside the room between fromPos and toPos using A* search algorithm.
      * @param fromPos The start position.
      * @param toPos The end position.
-     * @param opts (optional) An object containing additonal pathfinding flags
+     * @param opts (optional) An object containing additional pathfinding flags
      * @returns An array with path steps
      */
     findPath(fromPos: RoomPosition, toPos: RoomPosition, opts?: FindPathOpts): PathStep[];
     /**
-     * Creates a RoomPosition object at the specified location.
+     * Creates a {@link RoomPosition} object at the specified location.
      * @param x The X position.
      * @param y The Y position.
      * @returns A RoomPosition object or null if it cannot be obtained.
      */
     getPositionAt(x: number, y: number): RoomPosition | null;
     /**
-     * Get a Room.Terrain object which provides fast access to static terrain data.
+     * Get a {@link RoomTerrain} object which provides fast access to static terrain data.
+     *
      * This method works for any room in the world even if you have no access to it.
      */
     getTerrain(): RoomTerrain;
@@ -4454,6 +5184,7 @@ interface Room {
      * @param x The X position.
      * @param y The Y position.
      * @returns An array with objects at the specified position
+     * @throws if `x` or `y` are out of bounds.
      */
     lookAt(x: number, y: number): LookAtResult[];
     /**
@@ -4463,7 +5194,9 @@ interface Room {
      */
     lookAt(target: RoomPosition | { pos: RoomPosition }): LookAtResult[];
     /**
-     * Get the list of objects at the specified room area. This method is more CPU efficient in comparison to multiple lookAt calls.
+     * Get the list of objects at the specified room area.
+     *
+     * This method is more CPU efficient in comparison to multiple {@link Room.lookAt} calls.
      * @param top The top Y boundary of the area.
      * @param left The left X boundary of the area.
      * @param bottom The bottom Y boundary of the area.
@@ -4472,40 +5205,27 @@ interface Room {
      * @returns An object with all the objects in the specified area
      */
     lookAtArea(top: number, left: number, bottom: number, right: number, asArray?: false): LookAtResultMatrix;
-    /**
-     * Get the list of objects at the specified room area. This method is more CPU efficient in comparison to multiple lookAt calls.
-     * @param top The top Y boundary of the area.
-     * @param left The left X boundary of the area.
-     * @param bottom The bottom Y boundary of the area.
-     * @param right The right X boundary of the area.
-     * @param asArray Set to true if you want to get the result as a plain array.
-     * @returns An object with all the objects in the specified area
-     */
     lookAtArea(top: number, left: number, bottom: number, right: number, asArray: true): LookAtResultWithPos[];
     /**
      * Get the objects at the given position.
-     * @param type One of the LOOK_* constants.
+     *
+     * @param type One of the {@link LookConstant} constants.
      * @param x The X position.
      * @param y The Y position.
-     * @returns An array of Creep at the given position.
+     * @param target A RoomPosition. Its room name will be ignored.
+     * @returns An array of objects of the requested type at the given position, or ERR_INVALID_ARGS.
      */
     lookForAt<T extends keyof AllLookAtTypes>(type: T, x: number, y: number): Array<AllLookAtTypes[T]>;
-    /**
-     * Get the objects at the given RoomPosition.
-     * @param type One of the LOOK_* constants.
-     * @param target Can be a RoomPosition object or any object containing RoomPosition.
-     * @returns An array of Creeps at the specified position if found.
-     */
     lookForAt<T extends keyof AllLookAtTypes>(type: T, target: RoomPosition | _HasRoomPosition): Array<AllLookAtTypes[T]>;
     /**
-     * Get the given objets in the supplied area.
-     * @param type One of the LOOK_* constants
-     * @param top The top (Y) boundry of the area.
-     * @param left The left (X) boundry of the area.
-     * @param bottom The bottom (Y) boundry of the area.
-     * @param right The right(X) boundry of the area.
+     * Get the given objects in the supplied area.
+     * @param type One of the {@link LookConstant} constants
+     * @param top The top (Y) boundary of the area.
+     * @param left The left (X) boundary of the area.
+     * @param bottom The bottom (Y) boundary of the area.
+     * @param right The right(X) boundary of the area.
      * @param asArray Flatten the results into an array?
-     * @returns An object with the sstructure object[X coord][y coord] as an array of found objects.
+     * @returns Either an array of found objects with an x & y property or a nested object keyed by x, then y coordinate.
      */
     lookForAtArea<T extends keyof AllLookAtTypes>(
         type: T,
@@ -4515,16 +5235,6 @@ interface Room {
         right: number,
         asArray?: false,
     ): LookForAtAreaResultMatrix<AllLookAtTypes[T]>;
-    /**
-     * Get the given objets in the supplied area.
-     * @param type One of the LOOK_* constants
-     * @param top The top (Y) boundry of the area.
-     * @param left The left (X) boundry of the area.
-     * @param bottom The bottom (Y) boundry of the area.
-     * @param right The right(X) boundry of the area.
-     * @param asArray Flatten the results into an array?
-     * @returns An array of found objects with an x & y property for their position
-     */
     lookForAtArea<T extends keyof AllLookAtTypes>(
         type: T,
         top: number,
@@ -4533,18 +5243,6 @@ interface Room {
         right: number,
         asArray: true,
     ): LookForAtAreaResultArray<AllLookAtTypes[T], T>;
-
-    /**
-     * Serialize a path array into a short string representation, which is suitable to store in memory.
-     * @param path A path array retrieved from Room.findPath.
-     * @returns A serialized string form of the given path.
-     */
-
-    /**
-     * Deserialize a short string path representation into an array form.
-     * @param path A serialized path string.
-     * @returns A path array.
-     */
 }
 
 interface RoomConstructor extends _Constructor<Room> {
@@ -4554,7 +5252,7 @@ interface RoomConstructor extends _Constructor<Room> {
 
     /**
      * Serialize a path array into a short string representation, which is suitable to store in memory.
-     * @param path A path array retrieved from `Room.findPath`.
+     * @param path A path array retrieved from {@link Room.findPath}.
      * @returns A serialized string form of the given path.
      */
     serializePath(path: PathStep[]): string;
@@ -4568,15 +5266,16 @@ interface RoomConstructor extends _Constructor<Room> {
 
 declare const Room: RoomConstructor;
 /**
- * A destroyed structure. This is a walkable object.
- * <ul>
- *     <li>Decay: 500 ticks except some special cases</li>
- * </ul>
+ * A destroyed structure.
+ *
+ * This is a walkable object.
+ *
+ * Usually decays in 500 ticks except some special cases.
  */
 interface Ruin extends RoomObject {
     /**
-     * A unique object identificator.
-     * You can use {@link Game.getObjectById} method to retrieve an object instance by its id.
+     * A unique object identifier.
+     * You can use {@link Game.getObjectById} to retrieve an object instance by its id.
      */
     id: Id<this>;
     /**
@@ -4601,7 +5300,16 @@ interface RuinConstructor extends _Constructor<Ruin>, _ConstructorById<Ruin> {}
 
 declare const Ruin: RuinConstructor;
 /**
- * An energy source object. Can be harvested by creeps with a WORK body part.
+ * An energy source object.
+ *
+ * Can be harvested by creeps with a WORK body part.
+ *
+ * |                     |                                    |
+ * | ------------------- | ---------------------------------- |
+ * | Energy amount       | 4000 in center rooms
+ * |                     | 3000 in an owned or reserved room
+ * |                     | 1500 in an unreserved room
+ * | Energy regeneration | Every 300 game ticks
  */
 interface Source extends RoomObject {
     /**
@@ -4613,16 +5321,19 @@ interface Source extends RoomObject {
      */
     energy: number;
     /**
-     * The total amount of energy in the source. Equals to 3000 in most cases.
+     * The total amount of energy in the source.
+     *
+     * Equals to 3000 in most cases.
      */
     energyCapacity: number;
     /**
-     * A unique object identifier. You can use Game.getObjectById method to retrieve an object instance by its id.
+     * A unique object identifier.
+     *
+     * You can use {@link Game.getObjectById} to retrieve an object instance by its id.
      */
     id: Id<this>;
     /**
-     * If you can get an instance of Source, you can see it.
-     * If you can see a Source, you can see the room it's in.
+     * The room the source is in.
      */
     room: Room;
     /**
@@ -4635,10 +5346,25 @@ interface SourceConstructor extends _Constructor<Source>, _ConstructorById<Sourc
 
 declare const Source: SourceConstructor;
 /**
- * Spawns are your colony centers. This structure can create, renew, and recycle
- * creeps. All your spawns are accessible through `Game.spawns` hash list.
- * Spawns auto-regenerate a little amount of energy each tick, so that you can
- * easily recover even if all your creeps died.
+ * Spawns are your colony centers.
+ *
+ * This structure can create, renew, and recycle creeps.
+ * All your spawns are accessible through {@link Game.spawns} hash list.
+ * Spawns auto-regenerate a little amount of energy each tick, so that you can easily recover even if all your creeps died.
+ *
+ * | Controller level |          |
+ * | ---------------- | -------- |
+ * |  1-6             | 1 spawn  |
+ * |  7               | 2 spawns |
+ * |  8               | 3 spawns |
+ *
+ * |                               |               |
+ * | ----------------------------- | ------------- |
+ * | **Cost**                      | 15,000
+ * | **Hits**                      | 5,000
+ * | **Capacity**                  | 300
+ * | **Spawn time**                | 3 ticks per each body part
+ * | **Energy auto-regeneration**  | 1 energy unit per tick while energy available | in the room (in all spawns and extensions) is less than 300
  */
 interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
     readonly prototype: StructureSpawn;
@@ -4648,21 +5374,23 @@ interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
      */
     energy: number;
     /**
-     * The total amount of energy the spawn can contain
+     * The total amount of energy the spawn can contain.
      * @deprecated An alias for .store.getCapacity(RESOURCE_ENERGY).
      */
     energyCapacity: number;
     /**
-     * A shorthand to `Memory.spawns[spawn.name]`. You can use it for quick access
-     * the spawn’s specific memory data object.
+     * The spawn memory.
+     *
+     * A shorthand to `Memory.spawns[spawn.name]`. You can use it for quick access the spawn’s specific memory data object.
      *
      * @see http://docs.screeps.com/global-objects.html#Memory-object
      */
     memory: SpawnMemory;
     /**
-     * Spawn's name. You choose the name upon creating a new spawn, and it cannot
-     * be changed later. This name is a hash key to access the spawn via the
-     * `Game.spawns` object.
+     * The spawn name.
+     *
+     * You choose the name upon creating a new spawn, and it cannot be changed later.
+     * This name is a hash key to access the spawn via the {@link Game.spawns} object.
      */
     name: string;
     /**
@@ -4676,20 +5404,28 @@ interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
     /**
      * Check if a creep can be created.
      *
-     * @deprecated This method is deprecated and will be removed soon. Please use `StructureSpawn.spawnCreep` with `dryRun` flag instead.
-     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of these constants: WORK, MOVE, CARRY, ATTACK, RANGED_ATTACK, HEAL, TOUGH, CLAIM
+     * @deprecated This method is deprecated and will be removed soon. Please use {@link StructureSpawn.spawnCreep} with `dryRun` flag instead.
+     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of the {@link BodyPartConstant} constants.
      * @param name The name of a new creep.
      *
      * It should be unique creep name, i.e. the Game.creeps object should not contain another creep with the same name (hash key).
      *
      * If not defined, a random name will be generated.
+     * @returns One of the following codes:
+     * - OK: A creep with the given body and name can be created.
+     * - ERR_NOT_OWNER: You are not the owner of this spawn.
+     * - ERR_NAME_EXISTS: There is a creep with the same name already.
+     * - ERR_BUSY: The spawn is already in process of spawning another creep.
+     * - ERR_NOT_ENOUGH_ENERGY: The spawn and its extensions contain not enough energy to create a creep with the given body.
+     * - ERR_INVALID_ARGS: Body is not properly described.
+     * - ERR_RCL_NOT_ENOUGH: Your Room Controller level is insufficient to use this spawn.
      */
     canCreateCreep(body: BodyPartConstant[], name?: string): ScreepsReturnCode;
     /**
      * Start the creep spawning process.
      *
-     * @deprecated This method is deprecated and will be removed soon. Please use `StructureSpawn.spawnCreep` instead.
-     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of these constants: WORK, MOVE, CARRY, ATTACK, RANGED_ATTACK, HEAL, TOUGH, CLAIM
+     * @deprecated This method is deprecated and will be removed soon. Please use {@link StructureSpawn.spawnCreep} instead.
+     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of the {@link BodyPartConstant} constants.
      * @param name The name of a new creep.
      *
      * It should be unique creep name, i.e. the Game.creeps object should not contain another creep with the same name (hash key).
@@ -4697,41 +5433,29 @@ interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
      * If not defined, a random name will be generated.
      * @param memory The memory of a new creep. If provided, it will be immediately stored into Memory.creeps[name].
      * @returns The name of a new creep or one of these error codes:
-     * ```
-     * ERR_NOT_OWNER            -1  You are not the owner of this spawn.
-     * ERR_NAME_EXISTS          -3  There is a creep with the same name already.
-     * ERR_BUSY                 -4  The spawn is already in process of spawning another creep.
-     * ERR_NOT_ENOUGH_ENERGY    -6  The spawn and its extensions contain not enough energy to create a creep with the given body.
-     * ERR_INVALID_ARGS         -10 Body is not properly described.
-     * ERR_RCL_NOT_ENOUGH       -14 Your Room Controller level is not enough to use this spawn.
-     * ```
+     * - ERR_NOT_OWNER: You are not the owner of this spawn.
+     * - ERR_NAME_EXISTS: There is a creep with the same name already.
+     * - ERR_BUSY: The spawn is already in process of spawning another creep.
+     * - ERR_NOT_ENOUGH_ENERGY: The spawn and its extensions contain not enough energy to create a creep with the given body.
+     * - ERR_INVALID_ARGS: Body is not properly described.
+     * - ERR_RCL_NOT_ENOUGH: Your Room Controller level is not enough to use this spawn.
      */
     createCreep(body: BodyPartConstant[], name?: string, memory?: CreepMemory): ScreepsReturnCode | string;
 
     /**
      * Start the creep spawning process. The required energy amount can be withdrawn from all spawns and extensions in the room.
      *
-     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of these constants:
-     *  * WORK
-     *  * MOVE
-     *  * CARRY
-     *  * ATTACK
-     *  * RANGED_ATTACK
-     *  * HEAL
-     *  * TOUGH
-     *  * CLAIM
+     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of the {@link BodyPartConstant} constants.
      * @param name The name of a new creep. It must be a unique creep name, i.e. the Game.creeps object should not contain another creep with the same name (hash key).
      * @param opts An object with additional options for the spawning process.
      * @returns One of the following codes:
-     * ```
-     * OK                       0   The operation has been scheduled successfully.
-     * ERR_NOT_OWNER            -1  You are not the owner of this spawn.
-     * ERR_NAME_EXISTS          -3  There is a creep with the same name already.
-     * ERR_BUSY                 -4  The spawn is already in process of spawning another creep.
-     * ERR_NOT_ENOUGH_ENERGY    -6  The spawn and its extensions contain not enough energy to create a creep with the given body.
-     * ERR_INVALID_ARGS         -10 Body is not properly described or name was not provided.
-     * ERR_RCL_NOT_ENOUGH       -14 Your Room Controller level is insufficient to use this spawn.
-     * ```
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this spawn.
+     * - ERR_NAME_EXISTS: There is a creep with the same name already.
+     * - ERR_BUSY: The spawn is already in process of spawning another creep.
+     * - ERR_NOT_ENOUGH_ENERGY: The spawn and its extensions contain not enough energy to create a creep with the given body.
+     * - ERR_INVALID_ARGS: Body is not properly described or name was not provided.
+     * - ERR_RCL_NOT_ENOUGH: Your Room Controller level is insufficient to use this spawn.
      */
     spawnCreep(body: BodyPartConstant[], name: string, opts?: SpawnOptions): ScreepsReturnCode;
     /**
@@ -4741,15 +5465,33 @@ interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
      *
      * The spawn should not be busy with the spawning process.
      *
-     * Each execution increases the creep's timer by amount of ticks according to this formula: floor(600/body_size).
+     * Each execution increases the creep's timer by amount of ticks according to this formula: `floor(600/body_size)`.
      *
-     * Energy required for each execution is determined using this formula: ceil(creep_cost/2.5/body_size).
+     * Energy required for each execution is determined using this formula: `ceil(creep_cost/2.5/body_size)`.
      * @param target The target creep object.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of the spawn, or the creep.
+     * - ERR_BUSY: The spawn is spawning another creep.
+     * - ERR_NOT_ENOUGH_ENERGY: The spawn does not have enough energy.
+     * - ERR_INVALID_TARGET: The specified target object is not a creep, or the creep has CLAIM body part.
+     * - ERR_FULL: The target creep's time to live timer is full.
+     * - ERR_NOT_IN_RANGE: The target creep is too far away.
+     * - ERR_RCL_NOT_ENOUGH: Your Room Controller level is insufficient to use this spawn.
      */
     renewCreep(target: Creep): ScreepsReturnCode;
     /**
-     * Kill the creep and drop up to 100% of resources spent on its spawning and boosting depending on remaining life time. The target should be at adjacent square.
+     * Kill the creep and drop up to 100% of resources spent on its spawning and boosting depending on remaining life time.
+     *
+     * The target should be at adjacent square. Energy return is limited to 125 units per body part.
+     *
      * @param target The target creep object.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this spawn or the target creep.
+     * - ERR_INVALID_TARGET: The specified target object is not a creep.
+     * - ERR_NOT_IN_RANGE: The target creep is too far away.
+     * - ERR_RCL_NOT_ENOUGH: Your Room Controller level is insufficient to use this spawn.
      */
     recycleCreep(target: Creep): ScreepsReturnCode;
 }
@@ -4767,6 +5509,7 @@ interface Spawning {
 
     /**
      * An array with the spawn directions
+     *
      * @see http://docs.screeps.com/api/#StructureSpawn.Spawning.setDirections
      */
     directions?: DirectionConstant[];
@@ -4792,13 +5535,23 @@ interface Spawning {
     spawn: StructureSpawn;
 
     /**
-     * Cancel spawning immediately. Energy spent on spawning is not returned.
+     * Cancel spawning immediately.
+     *
+     * Energy spent on spawning is not returned.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this spawn.
      */
     cancel(): ScreepsReturnCode & (OK | ERR_NOT_OWNER);
 
     /**
-     * Set desired directions where the creep should move when spawned.
+     * Set allowed directions the creep can move when spawned.
+     *
      * @param directions An array with the spawn directions
+     * @return One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this spawn.
+     * - ERR_INVALID_ARGS: The directions is array is invalid.
      */
     setDirections(directions: DirectionConstant[]): ScreepsReturnCode & (OK | ERR_NOT_OWNER | ERR_INVALID_ARGS);
 }
@@ -4808,21 +5561,23 @@ interface Spawning {
  */
 interface SpawnOptions {
     /**
-     * Memory of the new creep. If provided, it will be immediately stored into Memory.creeps[name].
+     * Memory of the new creep.
+     *
+     * If provided, it will be immediately stored into Memory.creeps[name].
      */
     memory?: CreepMemory;
     /**
      * Array of spawns/extensions from which to draw energy for the spawning process.
+     *
      * Structures will be used according to the array order.
      */
     energyStructures?: Array<StructureSpawn | StructureExtension>;
     /**
-     * If dryRun is <code>true</code>, the operation will only check if it is possible to create a creep.
+     * If dryRun is `true`, the operation will only check if it is possible to create a creep.
      */
     dryRun?: boolean;
     /**
-     * Set desired directions where the creep should move when spawned.
-     * An array with the direction constants.
+     * Set allowed directions the creep can move when spawned.
      */
     directions?: DirectionConstant[];
 }
@@ -4833,7 +5588,9 @@ interface SpawningConstructor extends _Constructor<Spawning> {
 }
 interface StoreBase<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE extends boolean> {
     /**
-     * Returns capacity of this store for the specified resource. For a general purpose store, it returns total capacity if `resource` is undefined.
+     * Returns capacity of this store for the specified resource.
+     *
+     * For a general purpose store, it returns total capacity if `resource` is undefined.
      * @param resource The type of the resource.
      * @returns Returns capacity number, or `null` in case of an invalid `resource` for this store type.
      */
@@ -4857,7 +5614,9 @@ interface StoreBase<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE
         resource?: R,
     ): R extends undefined ? (ResourceConstant extends POSSIBLE_RESOURCES ? number : null) : R extends POSSIBLE_RESOURCES ? number : null;
     /**
-     * Returns free capacity for the store. For a limited store, it returns the capacity available for the specified resource if `resource` is defined and valid for this store.
+     * Returns free capacity for the store.
+     *
+     * For a limited store, it returns the capacity available for the specified resource if `resource` is defined and valid for this store.
      * @param resource The type of the resource.
      * @returns Returns available capacity number, or `null` in case of an invalid `resource` for this store type.
      */
@@ -4879,9 +5638,27 @@ type Store<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE extends 
     UNLIMITED_STORE
 > & { [P in POSSIBLE_RESOURCES]: number } & { [P in Exclude<ResourceConstant, POSSIBLE_RESOURCES>]: 0 };
 
+/**
+ * An object that can contain resources in its cargo.
+ *
+ * There are two types of stores in the game: general purpose stores and limited stores.
+ *
+ * General purpose stores can contain any resource within its capacity (e.g. creeps, containers, storages, terminals).
+ *
+ * Limited stores can contain only a few types of resources needed for that particular object (e.g. spawns, extensions, labs, nukers).
+ *
+ * The Store prototype is the same for both types of stores, but they have different behavior depending on the resource argument in its methods.
+ *
+ * You can get specific resources from the store by addressing them as object properties:
+ * ```
+ * console.log(creep.store[RESOURCE_ENERGY]);
+ * ```
+ */
 interface GenericStoreBase {
     /**
-     * Returns capacity of this store for the specified resource. For a general purpose store, it returns total capacity if `resource` is undefined.
+     * Returns capacity of this store for the specified resource.
+     *
+     * For a general purpose store, it returns total capacity if `resource` is undefined.
      * @param resource The type of the resource.
      * @returns Returns capacity number, or `null` in case of an invalid `resource` for this store type.
      */
@@ -4893,7 +5670,9 @@ interface GenericStoreBase {
      */
     getUsedCapacity(resource?: ResourceConstant): number | null;
     /**
-     * Returns free capacity for the store. For a limited store, it returns the capacity available for the specified resource if `resource` is defined and valid for this store.
+     * Returns free capacity for the store.
+     *
+     * For a limited store, it returns the capacity available for the specified resource if `resource` is defined and valid for this store.
      * @param resource The type of the resource.
      * @returns Returns available capacity number, or `null` in case of an invalid `resource` for this store type.
      */
@@ -4902,7 +5681,7 @@ interface GenericStoreBase {
 
 type GenericStore = GenericStoreBase & { [P in ResourceConstant]: number };
 /**
- * Parent object for structure classes
+ * The base prototype object of all structures.
  */
 interface Structure<T extends StructureConstant = StructureConstant> extends RoomObject {
     readonly prototype: Structure;
@@ -4916,20 +5695,28 @@ interface Structure<T extends StructureConstant = StructureConstant> extends Roo
      */
     hitsMax: number;
     /**
-     * A unique object identifier. You can use Game.getObjectById method to retrieve an object instance by its id.
+     * A unique object identifier.
+     *
+     * You can use {@link Game.getObjectById} to retrieve an object instance by its id.
      */
     id: Id<this>;
     /**
+     * The room the structure is in.
+     *
      * If you can get an instance of a Structure, you can see it.
      * If you can see the Structure, you can see the room it's in.
      */
     room: Room;
     /**
-     * One of the STRUCTURE_* constants.
+     * One of the {@link StructureConstant} constants.
      */
     structureType: T;
     /**
      * Destroy this structure immediately.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
+     * - ERR_BUSY: Hostile creeps are in the room.
      */
     destroy(): ScreepsReturnCode;
     /**
@@ -4939,6 +5726,10 @@ interface Structure<T extends StructureConstant = StructureConstant> extends Roo
     /**
      * Toggle auto notification when the structure is under attack. The notification will be sent to your account email. Turned on by default.
      * @param enabled Whether to enable notification or disable.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
+     * - ERR_INVALID_ARGS: enable argument is not a boolean value.
      */
     notifyWhenAttacked(enabled: boolean): ScreepsReturnCode;
 }
@@ -4948,22 +5739,27 @@ interface StructureConstructor extends _Constructor<Structure>, _ConstructorById
 declare const Structure: StructureConstructor;
 
 /**
- * The base prototype for a structure that has an owner. Such structures can be
- * found using `FIND_MY_STRUCTURES` and `FIND_HOSTILE_STRUCTURES` constants.
+ * The base prototype for a structure that has an owner.
+ *
+ * Such structures can be found using {@link Room.find} and the {@link FIND_MY_STRUCTURES} & {@link FIND_HOSTILE_STRUCTURES} constants.
  */
 interface OwnedStructure<T extends StructureConstant = StructureConstant> extends Structure<T> {
     readonly prototype: OwnedStructure;
 
     /**
-     * Whether this is your own structure. Walls and roads don't have this property as they are considered neutral structures.
+     * Whether this is your own structure.
+     *
+     * Walls and roads don't have this property as they are considered neutral structures.
      */
     my: boolean;
     /**
-     * An object with the structure’s owner info (if present) containing the following properties: username
+     * An object with the structure’s owner info (if present).
      */
     owner: T extends STRUCTURE_CONTROLLER ? Owner | undefined : Owner;
     /**
-     * The link to the Room object. Is always present because owned structures give visibility.
+     * The link to the Room object.
+     *
+     * Is always present because owned structures give visibility.
      */
     room: Room;
 }
@@ -4973,9 +5769,10 @@ interface OwnedStructureConstructor extends _Constructor<OwnedStructure>, _Const
 declare const OwnedStructure: OwnedStructureConstructor;
 
 /**
- * Claim this structure to take control over the room. The controller structure
- * cannot be damaged or destroyed. It can be addressed by `Room.controller`
- * property.
+ * Claim this structure to take control over the room.
+ *
+ * The controller structure cannot be damaged or destroyed.
+ * It can be addressed by {@link Room.controller} property.
  */
 interface StructureController extends OwnedStructure<STRUCTURE_CONTROLLER> {
     readonly prototype: StructureController;
@@ -4983,7 +5780,7 @@ interface StructureController extends OwnedStructure<STRUCTURE_CONTROLLER> {
     /**
      * Whether using power is enabled in this room.
      *
-     * Use `PowerCreep.enableRoom()` to turn powers on.
+     * Use {@link PowerCreep.enableRoom()} to turn powers on.
      */
     isPowerEnabled: boolean;
     /**
@@ -4999,7 +5796,9 @@ interface StructureController extends OwnedStructure<STRUCTURE_CONTROLLER> {
      */
     progressTotal: number;
     /**
-     * An object with the controller reservation info if present: username, ticksToEnd
+     * The reservation info for the controller.
+     *
+     * Can be undefined if the controller isn't reserved.
      */
     reservation: ReservationDefinition | undefined;
     /**
@@ -5019,7 +5818,9 @@ interface StructureController extends OwnedStructure<STRUCTURE_CONTROLLER> {
      */
     sign: SignDefinition | undefined;
     /**
-     * The amount of game ticks when this controller will lose one level. This timer can be reset by using Creep.upgradeController.
+     * The amount of game ticks when this controller will lose one level.
+     *
+     * This timer can be reset by using {@link Creep.upgradeController}
      */
     ticksToDowngrade: number;
     /**
@@ -5028,11 +5829,19 @@ interface StructureController extends OwnedStructure<STRUCTURE_CONTROLLER> {
     upgradeBlocked: number;
     /**
      * Activate safe mode if available.
-     * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_NOT_ENOUGH_RESOURCES, ERR_TIRED
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this controller.
+     * - ERR_BUSY: There is another room in safe mode already.
+     * - ERR_NOT_ENOUGH_RESOURCES: There is no safe mode activations available.
+     * - ERR_TIRED: The previous safe mode is still cooling down, or the controller is upgradeBlocked, or the controller is downgraded for 50% plus 5000 ticks or more.
      */
     activateSafeMode(): ScreepsReturnCode;
     /**
      * Make your claimed controller neutral again.
+     * @returnsOne of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this controller.
      */
     unclaim(): ScreepsReturnCode;
 }
@@ -5042,20 +5851,22 @@ interface StructureControllerConstructor extends _Constructor<StructureControlle
 declare const StructureController: StructureControllerConstructor;
 
 /**
- * Contains energy which can be spent on spawning bigger creeps. Extensions can
- * be placed anywhere in the room, any spawns will be able to use them regardless
- * of distance.
+ * Contains energy which can be spent on spawning bigger creeps.
+ *
+ * Extensions can be placed anywhere in the room, any spawns will be able to use them regardless of distance.
  */
 interface StructureExtension extends OwnedStructure<STRUCTURE_EXTENSION> {
     readonly prototype: StructureExtension;
 
     /**
      * The amount of energy containing in the extension.
+     *
      * @deprecated An alias for .store[RESOURCE_ENERGY].
      */
     energy: number;
     /**
      * The total amount of energy the extension can contain.
+     *
      * @deprecated An alias for .store.getCapacity(RESOURCE_ENERGY).
      */
     energyCapacity: number;
@@ -5102,6 +5913,16 @@ interface StructureLink extends OwnedStructure<STRUCTURE_LINK> {
      * Remote transfer process implies 3% energy loss and cooldown delay depending on the distance.
      * @param target The target object.
      * @param amount The amount of energy to be transferred. If omitted, all the available energy is used.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this link.
+     * - ERR_NOT_ENOUGH_RESOURCES: The structure does not have the given amount of energy.
+     * - ERR_INVALID_TARGET: The target is not a valid StructureLink object.
+     * - ERR_FULL: The target cannot receive any more energy.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_INVALID_ARGS: The energy amount is incorrect.
+     * - ERR_TIRED: The link is still cooling down.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this link.
      */
     transferEnergy(target: StructureLink, amount?: number): ScreepsReturnCode;
 }
@@ -5111,8 +5932,10 @@ interface StructureLinkConstructor extends _Constructor<StructureLink>, _Constru
 declare const StructureLink: StructureLinkConstructor;
 
 /**
- * Non-player structure. Spawns NPC Source Keepers that guards energy sources
- * and minerals in some rooms. This structure cannot be destroyed.
+ * Non-player structure.
+ *
+ * Spawns NPC Source Keepers that guards energy sources and minerals in some rooms.
+ * This structure cannot be destroyed.
  */
 interface StructureKeeperLair extends OwnedStructure<STRUCTURE_KEEPER_LAIR> {
     readonly prototype: StructureKeeperLair;
@@ -5134,8 +5957,16 @@ interface StructureObserver extends OwnedStructure<STRUCTURE_OBSERVER> {
     readonly prototype: StructureObserver;
 
     /**
-     * Provide visibility into a distant room from your script. The target room object will be available on the next tick. The maximum range is 5 rooms.
+     * Provide visibility into a distant room from your script.
+     *
+     * The target room object will be available on the next tick. The maximum range is 5 rooms.
      * @param roomName The room to observe.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
+     * - ERR_NOT_IN_RANGE: Room roomName is not in observing range.
+     * - ERR_INVALID_ARGS: roomName argument is not a valid room name value.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
     observeRoom(roomName: string): ScreepsReturnCode;
 }
@@ -5145,7 +5976,10 @@ interface StructureObserverConstructor extends _Constructor<StructureObserver>, 
 declare const StructureObserver: StructureObserverConstructor;
 
 /**
- * Non-player structure. Contains power resource which can be obtained by destroying the structure. Hits the attacker creep back on each attack.
+ * Non-player structure.
+ *
+ * Contains power resource which can be obtained by destroying the structure.
+ * Hits the attacker creep back on each attack.
  */
 interface StructurePowerBank extends OwnedStructure<STRUCTURE_POWER_BANK> {
     readonly prototype: StructurePowerBank;
@@ -5165,8 +5999,10 @@ interface StructurePowerBankConstructor extends _Constructor<StructurePowerBank>
 declare const StructurePowerBank: StructurePowerBankConstructor;
 
 /**
- * Non-player structure. Contains power resource which can be obtained by
- * destroying the structure. Hits the attacker creep back on each attack.
+ * Non-player structure.
+ *
+ * Contains power resource which can be obtained by destroying the structure.
+ * Hits the attacker creep back on each attack.
  */
 interface StructurePowerSpawn extends OwnedStructure<STRUCTURE_POWER_SPAWN> {
     readonly prototype: StructurePowerSpawn;
@@ -5191,12 +6027,19 @@ interface StructurePowerSpawn extends OwnedStructure<STRUCTURE_POWER_SPAWN> {
      */
     powerCapacity: number;
     /**
-     *
+     * A Store object that contains cargo of this structure.
      */
     store: Store<RESOURCE_ENERGY | RESOURCE_POWER, false>;
 
     /**
-     * Register power resource units into your account. Registered power allows to develop power creeps skills. Consumes 1 power resource unit and 50 energy resource units.
+     * Register power resource units into your account.
+     *
+     * Registered power allows to develop power creeps skills. Consumes 1 power resource unit and 50 energy resource units.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
+     * - ERR_NOT_ENOUGH_RESOURCES: The structure does not have enough energy or power resource units.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
     processPower(): ScreepsReturnCode;
 }
@@ -5206,6 +6049,8 @@ interface StructurePowerSpawnConstructor extends _Constructor<StructurePowerSpaw
 declare const StructurePowerSpawn: StructurePowerSpawnConstructor;
 
 /**
+ * A rampart structure.
+ *
  * Blocks movement of hostile creeps, and defends your creeps and structures on
  * the same tile. Can be used as a controllable gate.
  */
@@ -5218,13 +6063,19 @@ interface StructureRampart extends OwnedStructure<STRUCTURE_RAMPART> {
     ticksToDecay: number;
 
     /**
-     * If false (default), only your creeps can step on the same square. If true, any hostile creeps can pass through.
+     * Whether the rampart is open to the public or not.
+     *
+     * If false (default), only your creeps can step on the same square.
+     * If true, any hostile creeps can pass through.
      */
     isPublic: boolean;
 
     /**
      * Make this rampart public to allow other players' creeps to pass through.
      * @param isPublic Whether this rampart should be public or non-public
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
      */
     setPublic(isPublic: boolean): undefined;
 }
@@ -5234,8 +6085,9 @@ interface StructureRampartConstructor extends _Constructor<StructureRampart>, _C
 declare const StructureRampart: StructureRampartConstructor;
 
 /**
- * Decreases movement cost to 1. Using roads allows creating creeps with less
- * `MOVE` body parts.
+ * Decreases movement cost to 1.
+ *
+ * Using roads allows creating creeps with less `MOVE` body parts.
  */
 interface StructureRoad extends Structure<STRUCTURE_ROAD> {
     readonly prototype: StructureRoad;
@@ -5251,8 +6103,9 @@ interface StructureRoadConstructor extends _Constructor<StructureRoad>, _Constru
 declare const StructureRoad: StructureRoadConstructor;
 
 /**
- * A structure that can store huge amount of resource units. Only one structure
- * per room is allowed that can be addressed by `Room.storage` property.
+ * A structure that can store huge amount of resource units.
+ *
+ * Only one structure per room is allowed that can be addressed by {@link Room.storage} property.
  */
 interface StructureStorage extends OwnedStructure<STRUCTURE_STORAGE> {
     readonly prototype: StructureStorage;
@@ -5273,8 +6126,9 @@ interface StructureStorageConstructor extends _Constructor<StructureStorage>, _C
 declare const StructureStorage: StructureStorageConstructor;
 
 /**
- * Remotely attacks or heals creeps, or repairs structures. Can be targeted to
- * any object in the room. However, its effectiveness highly depends on the
+ * Remotely attacks or heals creeps, or repairs structures.
+ *
+ * Can be targeted to any object in the room. However, its effectiveness highly depends on the
  * distance. Each action consumes energy.
  */
 interface StructureTower extends OwnedStructure<STRUCTURE_TOWER> {
@@ -5296,18 +6150,42 @@ interface StructureTower extends OwnedStructure<STRUCTURE_TOWER> {
     store: Store<RESOURCE_ENERGY, false>;
 
     /**
-     * Remotely attack any creep or structure in the room. Consumes 10 energy units per tick. Attack power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
+     * Remotely attack any creep or structure in the room.
+     *
+     * Consumes 10 energy units per tick. Attack power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
      * @param target The target creep.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
+     * - ERR_NOT_ENOUGH_ENERGY: The tower does not have enough energy.
+     * - ERR_INVALID_TARGET: The target is not a valid attackable object.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
     attack(target: AnyCreep | Structure): ScreepsReturnCode;
     /**
-     * Remotely heal any creep in the room. Consumes 10 energy units per tick. Heal power depends on the distance to the target: from 400 hits at range 10 to 200 hits at range 40.
+     * Remotely heal any creep in the room.
+     *
+     * Consumes 10 energy units per tick. Heal power depends on the distance to the target: from 400 hits at range 10 to 200 hits at range 40.
      * @param target The target creep.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
+     * - ERR_NOT_ENOUGH_ENERGY: The tower does not have enough energy.
+     * - ERR_INVALID_TARGET: The target is not a valid attackable object.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
     heal(target: AnyCreep): ScreepsReturnCode;
     /**
-     * Remotely repair any structure in the room. Consumes 10 energy units per tick. Repair power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
+     * Remotely repair any structure in the room.
+     *
+     * Consumes 10 energy units per tick. Repair power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
      * @param target The target structure.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
+     * - ERR_NOT_ENOUGH_ENERGY: The tower does not have enough energy.
+     * - ERR_INVALID_TARGET: The target is not a valid attackable object.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
     repair(target: Structure): ScreepsReturnCode;
 }
@@ -5371,7 +6249,9 @@ interface StructureLab extends OwnedStructure<STRUCTURE_LAB> {
      */
     mineralAmount: number;
     /**
-     * The type of minerals containing in the lab. Labs can contain only one mineral type at the same time.
+     * The type of minerals containing in the lab.
+     *
+     * Labs can contain only one mineral type at the same time.
      * Null in case there is no mineral resource in the lab.
      */
     mineralType: MineralConstant | MineralCompoundConstant | null;
@@ -5385,32 +6265,74 @@ interface StructureLab extends OwnedStructure<STRUCTURE_LAB> {
      */
     store: Store<RESOURCE_ENERGY | MineralConstant | MineralCompoundConstant, false>;
     /**
-     * Boosts creep body part using the containing mineral compound. The creep has to be at adjacent square to the lab. Boosting one body part consumes 30 mineral units and 20 energy units.
+     * Boosts creep body part using the containing mineral compound.
+     *
+     * The creep has to be at adjacent square to the lab. Boosting one body part consumes 30 mineral units and 20 energy units.
      * @param creep The target creep.
      * @param bodyPartsCount The number of body parts of the corresponding type to be boosted.
-     *
      * Body parts are always counted left-to-right for TOUGH, and right-to-left for other types.
-     *
      * If undefined, all the eligible body parts are boosted.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this lab.
+     * - ERR_NOT_FOUND: The mineral containing in the lab cannot boost any of the creep's body parts.
+     * - ERR_NOT_ENOUGH_RESOURCES: The lab does not have enough energy or minerals.
+     * - ERR_INVALID_TARGET: The targets is not valid creep object.
+     * - ERR_NOT_IN_RANGE: The targets are too far away.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
     boostCreep(creep: Creep, bodyPartsCount?: number): ScreepsReturnCode;
     /**
+     * Unboost a creep.
+     *
      * Immediately remove boosts from the creep and drop 50% of the mineral compounds used to boost it onto the ground regardless of the creep's remaining time to live.
      * The creep has to be at adjacent square to the lab.
      * Unboosting requires cooldown time equal to the total sum of the reactions needed to produce all the compounds applied to the creep.
      * @param creep The target creep.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this lab, or the target creep.
+     * - ERR_NOT_FOUND: The target has no boosted parts.
+     * - ERR_INVALID_TARGET: The target is not a valid Creep object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_TIRED: The lab is still cooling down.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
     unboostCreep(creep: Creep): ScreepsReturnCode;
     /**
-     * Breaks mineral compounds back into reagents. The same output labs can be used by many source labs.
+     * Breaks mineral compounds back into reagents.
+     *
+     * The same output labs can be used by many source labs.
      * @param lab1 The first result lab.
      * @param lab2 The second result lab.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this lab.
+     * - ERR_NOT_ENOUGH_RESOURCES: The source lab do not have enough resources.
+     * - ERR_INVALID_TARGET: The targets are not valid lab objects.
+     * - ERR_FULL: One of targets cannot receive any more resource.
+     * - ERR_NOT_IN_RANGE: The targets are too far away.
+     * - ERR_INVALID_ARGS: The reaction cannot be reversed into this resources.
+     * - ERR_TIRED: The lab is still cooling down.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
     reverseReaction(lab1: StructureLab, lab2: StructureLab): ScreepsReturnCode;
     /**
-     * Produce mineral compounds using reagents from two another labs. Each lab has to be within 2 squares range. The same input labs can be used by many output labs
+     * Produce mineral compounds using reagents from two another labs.
+     *
+     * Each lab has to be within 2 squares range. The same input labs can be used by many output labs
      * @param lab1 The first source lab.
      * @param lab2 The second source lab.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this lab.
+     * - ERR_NOT_ENOUGH_RESOURCES: The source lab do not have enough resources.
+     * - ERR_INVALID_TARGET: The targets are not valid lab objects.
+     * - ERR_FULL: The target cannot receive any more resource.
+     * - ERR_NOT_IN_RANGE: The targets are too far away.
+     * - ERR_INVALID_ARGS: The reaction cannot be run using this resources.
+     * - ERR_TIRED: The lab is still cooling down.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
     runReaction(lab1: StructureLab, lab2: StructureLab): ScreepsReturnCode;
 }
@@ -5425,7 +6347,7 @@ declare const StructureLab: StructureLabConstructor;
 interface StructureTerminal extends OwnedStructure<STRUCTURE_TERMINAL> {
     readonly prototype: StructureTerminal;
     /**
-     * The remaining amount of ticks while this terminal cannot be used to make StructureTerminal.send or Game.market.deal calls.
+     * The remaining amount of ticks while this terminal cannot be used to make {@link StructureTerminal.send} or {@link Game.market.deal} calls.
      */
     cooldown: number;
     /**
@@ -5439,10 +6361,16 @@ interface StructureTerminal extends OwnedStructure<STRUCTURE_TERMINAL> {
     storeCapacity: number;
     /**
      * Sends resource to a Terminal in another room with the specified name.
-     * @param resourceType One of the RESOURCE_* constants.
+     * @param resourceType One of the {@link ResourceConstant} constants.
      * @param amount The amount of resources to be sent.
      * @param destination The name of the target room. You don't have to gain visibility in this room.
      * @param description The description of the transaction. It is visible to the recipient. The maximum length is 100 characters.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
+     * - ERR_NOT_ENOUGH_RESOURCES: The structure does not have the required amount of resources.
+     * - ERR_INVALID_ARGS: The arguments provided are incorrect.
+     * - ERR_TIRED: The terminal is still cooling down.
      */
     send(resourceType: ResourceConstant, amount: number, destination: string, description?: string): ScreepsReturnCode;
 }
@@ -5452,13 +6380,17 @@ interface StructureTerminalConstructor extends _Constructor<StructureTerminal>, 
 declare const StructureTerminal: StructureTerminalConstructor;
 
 /**
+ * A small resource store.
+ *
  * Contains up to 2,000 resource units. Can be constructed in neutral rooms. Decays for 5,000 hits per 100 ticks.
  */
 interface StructureContainer extends Structure<STRUCTURE_CONTAINER> {
     readonly prototype: StructureContainer;
     /**
-     * An object with the structure contents. Each object key is one of the RESOURCE_* constants, values are resources
-     * amounts. Use _.sum(structure.store) to get the total amount of contents
+     * An object with the structure contents.
+     *
+     * Each object key is one of the {@link ResourceConstant} constants, values are resources
+     * amounts. Use `_.sum(structure.store)` to get the total amount of contents.
      */
     store: StoreDefinition;
     /**
@@ -5478,6 +6410,7 @@ declare const StructureContainer: StructureContainerConstructor;
 
 /**
  * Launches a nuke to another room dealing huge damage to the landing area.
+ *
  * Each launch has a cooldown and requires energy and ghodium resources. Launching
  * creates a Nuke object at the target room position which is visible to any player
  * until it is landed. Incoming nuke cannot be moved or cancelled. Nukes cannot
@@ -5516,6 +6449,15 @@ interface StructureNuker extends OwnedStructure<STRUCTURE_NUKER> {
     /**
      * Launch a nuke to the specified position.
      * @param pos The target room position.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
+     * - ERR_NOT_ENOUGH_RESOURCES: The structure does not have enough energy and/or ghodium.
+     * - ERR_INVALID_TARGET: The nuke can't be launched to the specified RoomPosition (see Start Areas).
+     * - ERR_NOT_IN_RANGE: The target room is out of range.
+     * - ERR_INVALID_ARGS: The target is not a valid RoomPosition.
+     * - ERR_TIRED: This structure is still cooling down.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
     launchNuke(pos: RoomPosition): ScreepsReturnCode;
 }
@@ -5526,13 +6468,16 @@ declare const StructureNuker: StructureNukerConstructor;
 
 /**
  * A non-player structure.
+ *
  * Instantly teleports your creeps to a distant room acting as a room exit tile.
  * Portals appear randomly in the central room of each sector.
  */
 interface StructurePortal extends Structure<STRUCTURE_PORTAL> {
     readonly prototype: StructurePortal;
     /**
-     * If this is an inter-room portal, then this property contains a RoomPosition object leading to the point in the destination room.
+     * The portal's destination.
+     *
+     * If this is an inter-room portal, then this property contains a {@link RoomPosition} object leading to the point in the destination room.
      * If this is an inter-shard portal, then this property contains an object with shard and room string properties.
      * Exact coordinates are undetermined, the creep will appear at any free spot in the destination room.
      */
@@ -5558,7 +6503,8 @@ interface StructureFactory extends OwnedStructure<STRUCTURE_FACTORY> {
     cooldown: number;
     /**
      * The level of the factory.
-     * Can be set by applying the PWR_OPERATE_FACTORY power to a newly built factory.
+     *
+     * Can be set by applying the {@link PWR_OPERATE_FACTORY} power to a newly built factory.
      * Once set, the level cannot be changed.
      */
     level?: number;
@@ -5568,7 +6514,19 @@ interface StructureFactory extends OwnedStructure<STRUCTURE_FACTORY> {
     store: StoreDefinition;
     /**
      * Produces the specified commodity.
+     *
      * All ingredients should be available in the factory store.
+     * @param resource One of the {@link ResourceConstant} constants.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
+     * - ERR_BUSY: The factory is not operated by the PWR_OPERATE_FACTORY power.
+     * - ERR_NOT_ENOUGH_RESOURCES: The structure does not have the required amount of resources.
+     * - ERR_INVALID_TARGET: The factory cannot produce the commodity of this level.
+     * - ERR_FULL: The factory cannot contain the produce.
+     * - ERR_INVALID_ARGS: The arguments provided are incorrect.
+     * - ERR_TIRED: The factory is still cooling down.
+     * - ERR_RCL_NOT_ENOUGH: Your Room Controller level is insufficient to use the factory.
      */
     produce(resource: CommoditiesTypes): ScreepsReturnCode;
 }
@@ -5583,7 +6541,9 @@ declare const StructureFactory: StructureFactoryConstructor;
 interface StructureInvaderCore extends OwnedStructure<STRUCTURE_INVADER_CORE> {
     readonly prototype: StructureInvaderCore;
     /**
-     * The level of the stronghold. The amount and quality of the loot depends on the level.
+     * The level of the stronghold.
+     *
+     * The amount and quality of the loot depends on the level.
      */
     level: number;
     /**
@@ -5591,7 +6551,7 @@ interface StructureInvaderCore extends OwnedStructure<STRUCTURE_INVADER_CORE> {
      */
     ticksToDeploy: number;
     /**
-     * If the core is in process of spawning a new creep, this object will contain a `StructureSpawn.Spawning` object, or `null` otherwise.
+     * If the core is in process of spawning a new creep, this object will contain a {@link StructureSpawn.Spawning} object, or `null` otherwise.
      */
     spawning: Spawning | null;
 }
@@ -5636,7 +6596,7 @@ type AnyStoreStructure =
     | StructureContainer;
 
 /**
- * A discriminated union on Structure.type of all structure types
+ * A discriminated union on {@link Structure.structureType} of all structure types
  */
 type AnyStructure = AnyOwnedStructure | StructureContainer | StructurePortal | StructureRoad | StructureWall;
 
@@ -5669,19 +6629,21 @@ interface ConcreteStructureMap {
 
 /**
  * Conditional type for all concrete implementations of Structure.
- * Unlike Structure<T>, ConcreteStructure<T> gives you the actual concrete class that extends Structure<T>.
+ *
+ * Unlike {@link Structure<T>}, {@link ConcreteStructure<T>} gives you the actual concrete class that extends {@link Structure<T>}.
  */
 type ConcreteStructure<T extends StructureConstant> = ConcreteStructureMap[T];
 /**
- * A remnant of dead creeps. This is a walkable structure.
- * <ul>
- *     <li>Decay: 5 ticks per body part of the deceased creep</li>
- * </ul>
+ * A creep's final resting place.
+ *
+ * This is a walkable structure.
+ * Will decay 5 ticks per body part of the deceased creep.
  */
 interface Tombstone extends RoomObject {
     /**
-     * A unique object identificator.
-     * You can use {@link Game.getObjectById} method to retrieve an object instance by its id.
+     * A unique object identifier.
+     *
+     * You can use {@link Game.getObjectById} to retrieve an object instance by its id.
      */
     id: Id<this>;
     /**
@@ -5690,10 +6652,10 @@ interface Tombstone extends RoomObject {
     deathTime: number;
     /**
      * An object with the tombstone contents.
-     * Each object key is one of the RESOURCE_* constants, values are resources amounts.
-     * RESOURCE_ENERGY is always defined and equals to 0 when empty,
-     * other resources are undefined when empty.
-     * You can use lodash.sum to get the total amount of contents.
+     *
+     * Each object key is one of the {@link ResourceConstant} constants, values are resources amounts.
+     * {@link RESOURCE_ENERGY} is always defined and equals to 0 when empty, other resources are undefined when empty.
+     * You can use `_.sum(tombstone.store)` to get the total amount of contents.
      */
     store: StoreDefinitionUnlimited;
     /**

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1649,7 +1649,11 @@ interface Deposit extends RoomObject {
      */
     id: Id<this>;
     /**
-     * The deposit type, one of the {@link DepositConstant}.
+     * The deposit type, one of the {@link DepositConstant}:
+     * - `RESOURCE_MIST`
+     * - `RESOURCE_BIOMASS`
+     * - `RESOURCE_METAL`
+     * - `RESOURCE_SILICON`
      */
     depositType: DepositConstant;
     /**

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -5411,7 +5411,15 @@ interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
      * Check if a creep can be created.
      *
      * @deprecated This method is deprecated and will be removed soon. Please use {@link StructureSpawn.spawnCreep} with `dryRun` flag instead.
-     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of the {@link BodyPartConstant} constants.
+     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of the {@link BodyPartConstant} constants:
+     * - WORK
+     * - MOVE
+     * - CARRY
+     * - ATTACK
+     * - RANGED_ATTACK
+     * - HEAL
+     * - TOUGH
+     * - CLAIM
      * @param name The name of a new creep.
      *
      * It should be unique creep name, i.e. the Game.creeps object should not contain another creep with the same name (hash key).
@@ -5431,7 +5439,15 @@ interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
      * Start the creep spawning process.
      *
      * @deprecated This method is deprecated and will be removed soon. Please use {@link StructureSpawn.spawnCreep} instead.
-     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of the {@link BodyPartConstant} constants.
+     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of the {@link BodyPartConstant} constants:
+     * - WORK
+     * - MOVE
+     * - CARRY
+     * - ATTACK
+     * - RANGED_ATTACK
+     * - HEAL
+     * - TOUGH
+     * - CLAIM
      * @param name The name of a new creep.
      *
      * It should be unique creep name, i.e. the Game.creeps object should not contain another creep with the same name (hash key).
@@ -5447,11 +5463,18 @@ interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
      * - ERR_RCL_NOT_ENOUGH: Your Room Controller level is not enough to use this spawn.
      */
     createCreep(body: BodyPartConstant[], name?: string, memory?: CreepMemory): ScreepsReturnCode | string;
-
     /**
      * Start the creep spawning process. The required energy amount can be withdrawn from all spawns and extensions in the room.
      *
-     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of the {@link BodyPartConstant} constants.
+     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of the {@link BodyPartConstant} constants:
+     * - WORK
+     * - MOVE
+     * - CARRY
+     * - ATTACK
+     * - RANGED_ATTACK
+     * - HEAL
+     * - TOUGH
+     * - CLAIM
      * @param name The name of a new creep. It must be a unique creep name, i.e. the Game.creeps object should not contain another creep with the same name (hash key).
      * @param opts An object with additional options for the spawning process.
      * @returns One of the following codes:

--- a/src/construction-site.ts
+++ b/src/construction-site.ts
@@ -32,7 +32,7 @@ interface ConstructionSite<T extends BuildableStructureConstant = BuildableStruc
      */
     progressTotal: number;
     /**
-     * One of the {@link StructureConstant} constants.
+     * One of the {@link StructureConstant STRUCTURE_*} constants.
      */
     structureType: T;
     /**

--- a/src/construction-site.ts
+++ b/src/construction-site.ts
@@ -1,10 +1,18 @@
 /**
  * A site of a structure which is currently under construction.
+ *
+ * A construction site can be created using the 'Construct' button at the left of the game field or the {@link Room.createConstructionSite} method.
+ *
+ * To build a structure on the construction site, give a worker creep some amount of energy and perform {@link Creep.build} action.
+ *
+ * You can remove enemy construction sites by moving a creep on it.
  */
 interface ConstructionSite<T extends BuildableStructureConstant = BuildableStructureConstant> extends RoomObject {
     readonly prototype: ConstructionSite;
     /**
-     * A unique object identifier. You can use `Game.getObjectById` method to retrieve an object instance by its `id`.
+     * A unique object identifier.
+     *
+     * You can use {@link Game.getObjectById} to retrieve an object instance by its `id`.
      */
     id: Id<this>;
     /**
@@ -24,7 +32,7 @@ interface ConstructionSite<T extends BuildableStructureConstant = BuildableStruc
      */
     progressTotal: number;
     /**
-     * One of the `STRUCTURE_*` constants.
+     * One of the {@link StructureConstant} constants.
      */
     structureType: T;
     /**

--- a/src/creep.ts
+++ b/src/creep.ts
@@ -387,7 +387,7 @@ interface Creep extends RoomObject {
      * - ERR_NOT_IN_RANGE: The target is too far away.
      * - ERR_NO_BODYPART: There are no RANGED_ATTACK body parts in this creep’s body.
      */
-    rangedAttack(target: AnyCreep | Structure): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE | ERR_NO_BODYPART;
+    rangedAttack(target: AnyCreep | Structure): CreepActionReturnCode;
     /**
      * Heal another creep at a distance.
      *
@@ -403,7 +403,7 @@ interface Creep extends RoomObject {
      * - ERR_NOT_IN_RANGE: The target is too far away.
      * - ERR_NO_BODYPART: There are no HEAL body parts in this creep’s body.
      */
-    rangedHeal(target: AnyCreep): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE | ERR_NO_BODYPART;
+    rangedHeal(target: AnyCreep): CreepActionReturnCode;
     /**
      * A ranged attack against all hostile creeps or structures within 3 squares range.
      *
@@ -429,9 +429,7 @@ interface Creep extends RoomObject {
      * - ERR_NOT_IN_RANGE: The target is too far away.
      * - ERR_NO_BODYPART: There are no WORK body parts in this creep’s body.
      */
-    repair(
-        target: Structure,
-    ): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_ENOUGH_RESOURCES | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE | ERR_NO_BODYPART;
+    repair(target: Structure): CreepActionReturnCode | ERR_NOT_ENOUGH_RESOURCES;
     /**
      * Temporarily block a neutral controller from claiming by other players.
      *
@@ -449,7 +447,7 @@ interface Creep extends RoomObject {
      * - ERR_NOT_IN_RANGE: The target is too far away.
      * - ERR_NO_BODYPART: There are no CLAIM body parts in this creep’s body.
      */
-    reserveController(target: StructureController): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE | ERR_NO_BODYPART;
+    reserveController(target: StructureController): CreepActionReturnCode;
     /**
      * Display a visual speech balloon above the creep with the specified message.
      *

--- a/src/creep.ts
+++ b/src/creep.ts
@@ -208,7 +208,7 @@ interface Creep extends RoomObject {
     /**
      * Drop this resource on the ground.
      *
-     * @param resourceType One of the {@link ResourceConstant} constants.
+     * @param resourceType One of the {@link ResourceConstant RESOURCE_*} constants.
      * @param amount The amount of resource units to be dropped. If omitted, all the available carried amount is used.
      * @returns One of the following codes:
      * - OK: The operation has been scheduled successfully.
@@ -282,7 +282,7 @@ interface Creep extends RoomObject {
      * Move the creep one square in the specified direction or towards a creep that is pulling it.
      *
      * Requires the MOVE body part if not being pulled.
-     * @param direction The direction to move in (see {@link DirectionConstant}).
+     * @param direction The direction to move in ({@link DirectionConstant `TOP`, `TOP_LEFT`...}).
      * @param creep A creep nearby.
      * @return One of the following codes:
      * - OK: The operation has been scheduled successfully.
@@ -494,7 +494,7 @@ interface Creep extends RoomObject {
      *
      * The target has to be at adjacent square to the creep.
      * @param target The target object.
-     * @param resourceType One of the {@link ResourceConstant} constants
+     * @param resourceType One of the {@link ResourceConstant RESOURCE_*} constants
      * @param amount The amount of resources to be transferred. If omitted, all the available carried amount is used.
      * @returns One of the following codes:
      * - OK: The operation has been scheduled successfully.
@@ -504,7 +504,7 @@ interface Creep extends RoomObject {
      * - ERR_INVALID_TARGET: The target is not a valid object which can contain the specified resource.
      * - ERR_FULL: The target cannot receive any more resources.
      * - ERR_NOT_IN_RANGE: The target is too far away.
-     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant} constants, or the amount is incorrect.
+     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant RESOURCE_*} constants, or the amount is incorrect.
      */
     transfer(target: AnyCreep | Structure, resourceType: ResourceConstant, amount?: number): ScreepsReturnCode;
     /**
@@ -539,7 +539,7 @@ interface Creep extends RoomObject {
      * To transfer between creeps, use the {@link Creep.transfer} method on the original creep.
      *
      * @param target The target object.
-     * @param resourceType One of the {@link ResourceConstant} constants..
+     * @param resourceType One of the {@link ResourceConstant RESOURCE_*} constants.
      * @param amount The amount of resources to be transferred. If omitted, all the available amount is used.
      * @returns One of the following codes:
      * - OK: The operation has been scheduled successfully.
@@ -549,7 +549,7 @@ interface Creep extends RoomObject {
      * - ERR_INVALID_TARGET: The target is not a valid object which can contain the specified resource.
      * - ERR_FULL: The creep's carry is full.
      * - ERR_NOT_IN_RANGE: The target is too far away.
-     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant} constants, or the amount is incorrect.
+     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant RESOURCE_*} constants, or the amount is incorrect.
      */
     withdraw(target: Structure | Tombstone | Ruin, resourceType: ResourceConstant, amount?: number): ScreepsReturnCode;
 }

--- a/src/creep.ts
+++ b/src/creep.ts
@@ -1,7 +1,29 @@
 /**
  * Creeps are your units.
+ *
  * Creeps can move, harvest energy, construct structures, attack another creeps, and perform other actions.
- * Each creep consists of up to 50 body parts with the following possible types:
+ * Each creep consists of up to 50 body parts represented by {@link BodyPartConstant}:.
+ *
+ * | Body part       | Build cost | Effect per one body part
+ * | :-------------- | :--------: | :-----------------------
+ * | MOVE            | 50         | Decreases fatigue by 2 points per tick.
+ * | WORK            | 100        | Harvests 2 energy units from a source per tick.
+ * |                 |            | Harvests 1 resource unit from a mineral or a deposit per tick.
+ * |                 |            | Builds a structure for 5 energy units per tick.
+ * |                 |            | Repairs a structure for 100 hits per tick consuming 1 energy unit per tick.
+ * |                 |            | Dismantles a structure for 50 hits per tick returning 0.25 energy unit per tick.
+ * |                 |            | Upgrades a controller for 1 energy unit per tick.
+ * | CARRY           | 50         | Can contain up to 50 resource units.
+ * | ATTACK          | 80         | Attacks another creep/structure with 30 hits per tick in a short-ranged attack.
+ * | RANGED_ATTACK   | 150        | Attacks another single creep/structure with 10 hits per tick in a long-range attack up to 3 squares long.
+ * |                 |            | Attacks all hostile creeps/structures within 3 squares range with 1-4-10 hits (depending on the range).
+ * | HEAL            | 250        | Heals self or another creep restoring 12 hits per tick in short range or 4 hits per tick at a distance.
+ * | CLAIM           | 600        | Claims a neutral room controller.
+ * |                 |            | Reserves a neutral room controller for 1 tick per body part.
+ * |                 |            | Attacks a hostile room controller downgrading its timer by 300 ticks per body parts.
+ * |                 |            | Attacks a neutral room controller reservation timer by 1 tick per body parts.
+ * |                 |            | A creep with this body part will have a reduced life time of 600 ticks and cannot be renewed.
+ * | TOUGH           | 10         | No effect, just additional hit points to the creep's body. Can be boosted to resist damage.
  */
 interface Creep extends RoomObject {
     readonly prototype: Creep;
@@ -17,11 +39,13 @@ interface Creep extends RoomObject {
     carry: StoreDefinition;
     /**
      * The total amount of resources the creep can carry.
-     * @deprecated alias for Creep.store.getCapacity
+     * @deprecated alias for {@link Creep.store.getCapacity}
      */
     carryCapacity: number;
     /**
-     * The movement fatigue indicator. If it is greater than zero, the creep cannot move.
+     * The movement fatigue indicator.
+     *
+     * If it is greater than zero, the creep cannot move.
      */
     fatigue: number;
     /**
@@ -33,11 +57,15 @@ interface Creep extends RoomObject {
      */
     hitsMax: number;
     /**
-     * A unique object identifier. You can use `Game.getObjectById` method to retrieve an object instance by its `id`.
+     * A unique object identifier.
+     *
+     * You can use {@link Game.getObjectById} to retrieve an object instance by its `id`.
      */
     id: Id<this>;
     /**
-     * A shorthand to `Memory.creeps[creep.name]`. You can use it for quick access the creep’s specific memory data object.
+     * A shorthand to `Memory.creeps[creep.name]`.
+     *
+     * You can use it for quick access the creep’s specific memory data object.
      */
     memory: CreepMemory;
     /**
@@ -45,7 +73,10 @@ interface Creep extends RoomObject {
      */
     my: boolean;
     /**
-     * Creep’s name. You can choose the name while creating a new creep, and it cannot be changed later. This name is a hash key to access the creep via the `Game.creeps` object.
+     * The creep’s name.
+     *
+     * You can choose the name while creating a new creep, and it cannot be changed later.
+     * This name is a hash key to access the creep via the {@link Game.creeps} object.
      */
     name: string;
     /**
@@ -53,7 +84,9 @@ interface Creep extends RoomObject {
      */
     owner: Owner;
     /**
-     * The link to the Room object. Always defined because creeps give visibility into the room they're in.
+     * The {@link Room} the creep is in.
+     *
+     * Always defined because creeps give visibility into the room they're in.
      */
     room: Room;
     /**
@@ -75,78 +108,135 @@ interface Creep extends RoomObject {
      */
     ticksToLive: number | undefined;
     /**
-     * Attack another creep or structure in a short-ranged attack. Needs the
-     * ATTACK body part. If the target is inside a rampart, then the rampart is
-     * attacked instead.
+     * Attack another creep or structure in a short-ranged attack.
      *
-     * The target has to be at adjacent square to the creep. If the target is a
-     * creep with ATTACK body parts and is not inside a rampart, it will
+     * Needs the ATTACK body part.
+     * If the target is inside a rampart, then the rampart is attacked instead.
+     *
+     * The target has to be at adjacent square to the creep.
+     * If the target is a creep with ATTACK body parts and is not inside a rampart, it will
      * automatically hit back at the attacker.
      *
-     * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target is not a valid attackable object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no ATTACK body parts in this creep’s body.
      */
     attack(target: AnyCreep | Structure): CreepActionReturnCode;
     /**
-     * Decreases the controller's downgrade or reservation timer for 1 tick per
-     * every 5 `CLAIM` body parts (so the creep must have at least 5x`CLAIM`).
+     * Attack a controller.
+     *
+     * Decreases the controller's downgrade or reservation timer for 1 tick per every 5 `CLAIM` body parts (so the creep must have at least 5x`CLAIM`).
      *
      * The controller under attack cannot be upgraded for the next 1,000 ticks.
      * The target has to be at adjacent square to the creep.
      *
-     * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART, ERR_TIRED
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target is not a valid owned or reserved controller object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_TIRED: You have to wait until the next attack is possible.
+     * - ERR_NO_BODYPART: There are not enough CLAIM body parts in this creep’s body.
      */
     attackController(target: StructureController): CreepActionReturnCode;
     /**
      * Build a structure at the target construction site using carried energy.
-     * Needs WORK and CARRY body parts.
      *
+     * Needs WORK and CARRY body parts.
      * The target has to be within 3 squares range of the creep.
      *
      * @param target The target construction site to be built.
-     * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_NOT_ENOUGH_RESOURCES, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART, ERR_RCL_NOT_ENOUGH
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_NOT_ENOUGH_RESOURCES: The creep does not have any carried energy.
+     * - ERR_INVALID_TARGET: The target is not a valid construction site object or the structure cannot be built here (probably because of a creep at the same square).
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no WORK body parts in this creep’s body.
      */
     build(target: ConstructionSite): CreepActionReturnCode | ERR_NOT_ENOUGH_RESOURCES | ERR_RCL_NOT_ENOUGH;
     /**
      * Cancel the order given during the current game tick.
      * @param methodName The name of a creep's method to be cancelled.
-     * @returns Result Code: OK, ERR_NOT_FOUND
+     * @returns One of the following codes:
+     * - OK: The operation has been cancelled successfully.
+     * - ERR_NOT_FOUND: The order with the specified name is not found.
      */
     cancelOrder(methodName: string): OK | ERR_NOT_FOUND;
     /**
-     * Requires the CLAIM body part.
+     * Claim a controller.
      *
+     * Requires the CLAIM body part.
      * If applied to a neutral controller, claims it under your control.
      * If applied to a hostile controller, decreases its downgrade or reservation timer depending on the CLAIM body parts count.
      *
      * The target has to be at adjacent square to the creep.
      * @param target The target controller object.
-     * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_FULL, ERR_NOT_IN_RANGE, ERR_NO_BODYPART, ERR_GCL_NOT_ENOUGH
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target is not a valid neutral controller object.
+     * - ERR_FULL: You cannot claim more than 3 rooms in the Novice Area.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no CLAIM body parts in this creep’s body.
+     * - ERR_GCL_NOT_ENOUGH: Your Global Control Level is not enough.
      */
     claimController(target: StructureController): CreepActionReturnCode | ERR_FULL | ERR_GCL_NOT_ENOUGH;
     /**
-     * Dismantles any (even hostile) structure returning 50% of the energy spent on its repair.
+     * Dismantles any structure that can be constructed (even hostile) returning 50% of the energy spent on its repair.
      *
-     * Requires the WORK body part. If the creep has an empty CARRY body part, the energy is put into it; otherwise it is dropped on the ground.
-     *
+     * Requires the WORK body part.
+     * If the creep has an empty CARRY body part, the energy is put into it; otherwise it is dropped on the ground.
      * The target has to be at adjacent square to the creep.
      * @param target The target structure.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target is not a valid structure object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no WORK body parts in this creep’s body.
      */
     dismantle(target: Structure): CreepActionReturnCode;
     /**
      * Drop this resource on the ground.
-     * @param resourceType One of the RESOURCE_* constants.
+     *
+     * @param resourceType One of the {@link ResourceConstant} constants.
      * @param amount The amount of resource units to be dropped. If omitted, all the available carried amount is used.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_NOT_ENOUGH_RESOURCES: The creep does not have the given amount of resources.
+     * - ERR_INVALID_ARGS: The resourceType is not a valid RESOURCE_* constants.
      */
     drop(resourceType: ResourceConstant, amount?: number): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_ENOUGH_RESOURCES;
     /**
-     * Add one more available safe mode activation to a room controller. The creep has to be at adjacent square to the target room controller and have 1000 ghodium resource.
+     * Add one more available safe mode activation to a room controller.
+     *
+     * The creep has to be at adjacent square to the target room controller and have 1000 ghodium resource.
      * @param target The target room controller.
-     * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_NOT_ENOUGH_RESOURCES, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_NOT_ENOUGH_RESOURCES: The creep does not have enough ghodium.
+     * - ERR_INVALID_TARGET: The target is not a valid controller object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
      */
     generateSafeMode(target: StructureController): CreepActionReturnCode;
     /**
-     * Get the quantity of live body parts of the given type. Fully damaged parts do not count.
-     * @param type A body part type, one of the following body part constants: MOVE, WORK, CARRY, ATTACK, RANGED_ATTACK, HEAL, TOUGH, CLAIM
+     * Get the quantity of live body parts of the given type.
+     *
+     * Fully damaged parts do not count.
+     * @param type A body part type, one of the {@link BodyPartConstant} constants.
      */
     getActiveBodyparts(type: BodyPartConstant): number;
     /**
@@ -158,28 +248,58 @@ interface Creep extends RoomObject {
      *
      * The target has to be at an adjacent square to the creep.
      * @param target The source object to be harvested.
+     * @return One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep, or the room controller is owned or reserved by another player.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_NOT_FOUND: Extractor not found. You must build an extractor structure to harvest minerals. Learn more
+     * - ERR_NOT_ENOUGH_RESOURCES: The target does not contain any harvestable energy or mineral.
+     * - ERR_INVALID_TARGET: The target is not a valid source or mineral object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_TIRED: The extractor or the deposit is still cooling down.
+     * - ERR_NO_BODYPART: There are no WORK body parts in this creep’s body.
      */
     harvest(target: Source | Mineral | Deposit): CreepActionReturnCode | ERR_NOT_FOUND | ERR_NOT_ENOUGH_RESOURCES;
     /**
-     * Heal self or another creep. It will restore the target creep’s damaged body parts function and increase the hits counter.
+     * Heal self or another creep.
+     *
+     * It will restore the target creep’s damaged body parts function and increase the hits counter.
      *
      * Needs the HEAL body part.
      *
      * The target has to be at adjacent square to the creep.
      * @param target The target creep object.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target is not a valid creep object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no HEAL body parts in this creep’s body.
      */
     heal(target: AnyCreep): CreepActionReturnCode;
     /**
      * Move the creep one square in the specified direction or towards a creep that is pulling it.
      *
      * Requires the MOVE body part if not being pulled.
-     * @param direction The direction to move in (`TOP`, `TOP_LEFT`...)
+     * @param direction The direction to move in (see {@link DirectionConstant}).
+     * @param creep A creep nearby.
+     * @return One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_NOT_IN_RANGE: The target creep is too far away
+     * - ERR_INVALID_ARGS: The provided direction is incorrect.
+     * - ERR_TIRED: The fatigue indicator of the creep is non-zero.
+     * - ERR_NO_BODYPART: There are no MOVE body parts in this creep’s body.
      */
     move(direction: DirectionConstant): CreepMoveReturnCode;
     move(target: Creep): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_IN_RANGE | ERR_INVALID_ARGS;
     /**
-     * Move the creep using the specified predefined path. Needs the MOVE body part.
-     * @param path A path value as returned from Room.findPath or RoomPosition.findPathTo methods. Both array form and serialized string form are accepted.
+     * Move the creep using the specified predefined path.
+     *
+     * Needs the MOVE body part.
+     * @param path A path value as returned from {@link Room.findPath} or {@link RoomPosition.findPathTo} methods. Both array form and serialized string form are accepted.
      */
     moveByPath(path: PathStep[] | RoomPosition[] | string): CreepMoveReturnCode | ERR_NOT_FOUND | ERR_INVALID_ARGS;
     /**
@@ -207,31 +327,67 @@ interface Creep extends RoomObject {
         opts?: MoveToOpts,
     ): CreepMoveReturnCode | ERR_NO_PATH | ERR_INVALID_TARGET | ERR_NOT_FOUND;
     /**
-     * Toggle auto notification when the creep is under attack. The notification will be sent to your account email. Turned on by default.
+     * Toggle auto notification when the creep is under attack.
+     *
+     * The notification will be sent to your account email. Turned on by default.
      * @param enabled Whether to enable notification or disable.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_ARGS: enable argument is not a boolean value.
      */
     notifyWhenAttacked(enabled: boolean): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_ARGS;
     /**
-     * Pick up an item (a dropped piece of energy). Needs the CARRY body part. The target has to be at adjacent square to the creep or at the same square.
+     * Pick up an item (a dropped piece of energy).
+     *
+     * Needs the CARRY body part.
+     * The target has to be at adjacent square to the creep or at the same square.
      * @param target The target object to be picked up.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target is not a valid object to pick up.
+     * - ERR_FULL: The creep cannot receive any more resource.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no CARRY body parts in this creep’s body.
      */
     pickup(target: Resource): CreepActionReturnCode | ERR_FULL;
     /**
-     * Allow another creep to follow this creep. The fatigue generated for the target's move will be added to the creep instead of the target.
+     * Allow another creep to follow this creep.
      *
-     * Requires the MOVE body part. The target must be adjacent to the creep. The creep must move elsewhere, and the target must move towards the creep.
+     * Requires the MOVE body part.
+     *
+     * The fatigue generated for the target's move will be added to the creep instead of the target.
+     * The target must be adjacent to the creep. The creep must move elsewhere, and the target must move towards the creep.
      * @param target The target creep to be pulled.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target provided is invalid.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no MOVE body parts in this creep’s body.
      */
     pull(target: Creep): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE | ERR_NO_BODYPART;
     /**
      * A ranged attack against another creep or structure.
      *
-     * Needs the RANGED_ATTACK body part. If the target is inside a rampart, the rampart is attacked instead.
+     * Needs the RANGED_ATTACK body part.
      *
+     * If the target is inside a rampart, the rampart is attacked instead.
      * The target has to be within 3 squares range of the creep.
      * @param target The target object to be attacked.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target is not a valid attackable object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no RANGED_ATTACK body parts in this creep’s body.
      */
-    rangedAttack(target: AnyCreep | Structure): CreepActionReturnCode;
+    rangedAttack(target: AnyCreep | Structure): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE | ERR_NO_BODYPART;
     /**
      * Heal another creep at a distance.
      *
@@ -239,21 +395,43 @@ interface Creep extends RoomObject {
      *
      * Needs the HEAL body part. The target has to be within 3 squares range of the creep.
      * @param target The target creep object.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target is not a valid creep object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no HEAL body parts in this creep’s body.
      */
-    rangedHeal(target: AnyCreep): CreepActionReturnCode;
+    rangedHeal(target: AnyCreep): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE | ERR_NO_BODYPART;
     /**
      * A ranged attack against all hostile creeps or structures within 3 squares range.
      *
      * Needs the RANGED_ATTACK body part.
      *
      * The attack power depends on the range to each target. Friendly units are not affected.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_NO_BODYPART: There are no RANGED_ATTACK body parts in this creep’s body.
      */
     rangedMassAttack(): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NO_BODYPART;
     /**
      * Repair a damaged structure using carried energy. Needs the WORK and CARRY body parts. The target has to be within 3 squares range of the creep.
      * @param target The target structure to be repaired.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_NOT_ENOUGH_RESOURCES: The creep does not carry any energy.
+     * - ERR_INVALID_TARGET: The target is not a valid structure object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no WORK body parts in this creep’s body.
      */
-    repair(target: Structure): CreepActionReturnCode | ERR_NOT_ENOUGH_RESOURCES;
+    repair(
+        target: Structure,
+    ): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_ENOUGH_RESOURCES | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE | ERR_NO_BODYPART;
     /**
      * Temporarily block a neutral controller from claiming by other players.
      *
@@ -263,9 +441,15 @@ interface Creep extends RoomObject {
      *
      * The target has to be at adjacent square to the creep....
      * @param target The target controller object to be reserved.
-     * @return Result code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE, ERR_NO_BODYPART
+     * @return One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target is not a valid neutral controller object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no CLAIM body parts in this creep’s body.
      */
-    reserveController(target: StructureController): CreepActionReturnCode;
+    reserveController(target: StructureController): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE | ERR_NO_BODYPART;
     /**
      * Display a visual speech balloon above the creep with the specified message.
      *
@@ -274,53 +458,98 @@ interface Creep extends RoomObject {
      * Only the creep's owner can see the speech message unless toPublic is true.
      * @param message The message to be displayed. Maximum length is 10 characters.
      * @param set to 'true' to allow other players to see this message. Default is 'false'.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
      */
     say(message: string, toPublic?: boolean): OK | ERR_NOT_OWNER | ERR_BUSY;
     /**
-     * Sign a controller with a random text visible to all players. This text will appear in the room UI, in the world map, and can be accessed via the API.
-     * You can sign unowned and hostile controllers. The target has to be at adjacent square to the creep. Pass an empty string to remove the sign.
+     * Sign a controller with a random text visible to all players.
+     *
+     * This text will appear in the room UI, in the world map, and can be accessed via the API.
+     * You can sign unowned and hostile controllers.
+     *
+     * The target has to be at adjacent square to the creep. Pass an empty string to remove the sign.
      * @param target The target controller object to be signed.
      * @param text The sign text. The maximum text length is 100 characters.
-     * @returns Result Code: OK, ERR_BUSY, ERR_INVALID_TARGET, ERR_NOT_IN_RANGE
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_INVALID_TARGET: The target is not a valid controller object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
      */
     signController(target: StructureController, text: string): OK | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE;
     /**
      * Kill the creep immediately.
+     *
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
      */
     suicide(): OK | ERR_NOT_OWNER | ERR_BUSY;
     /**
-     * Transfer resource from the creep to another object. The target has to be at adjacent square to the creep.
+     * Transfer resource from the creep to another object.
+     *
+     * The target has to be at adjacent square to the creep.
      * @param target The target object.
-     * @param resourceType One of the RESOURCE_* constants
+     * @param resourceType One of the {@link ResourceConstant} constants
      * @param amount The amount of resources to be transferred. If omitted, all the available carried amount is used.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_NOT_ENOUGH_RESOURCES: The creep does not have the given amount of resources.
+     * - ERR_INVALID_TARGET: The target is not a valid object which can contain the specified resource.
+     * - ERR_FULL: The target cannot receive any more resources.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant} constants, or the amount is incorrect.
      */
     transfer(target: AnyCreep | Structure, resourceType: ResourceConstant, amount?: number): ScreepsReturnCode;
     /**
      * Upgrade your controller to the next level using carried energy.
      *
      * Upgrading controllers raises your Global Control Level in parallel.
+     * Requires WORK and CARRY body parts. The target has to be within 3 squares range of the creep.
      *
-     * Needs WORK and CARRY body parts.
-     *
-     * The target has to be at adjacent square to the creep.
-     *
-     * A fully upgraded level 8 controller can't be upgraded with the power over 15 energy units per tick regardless of creeps power.
-     *
+     * A fully upgraded level 8 controller can't be upgraded over 15 energy units per tick regardless of creeps abilities.
      * The cumulative effect of all the creeps performing upgradeController in the current tick is taken into account.
+     * This limit can be increased by using ghodium mineral boost.
+     *
+     * Upgrading the controller raises its ticksToDowngrade timer by 100. The timer must be full in order for controller to be levelled up.
      * @param target The target controller object to be upgraded.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep or the target controller.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_NOT_ENOUGH_RESOURCES: The creep does not have any carried energy.
+     * - ERR_INVALID_TARGET: The target is not a valid controller object, or the controller upgrading is blocked.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_NO_BODYPART: There are no WORK body parts in this creep’s body.
      */
     upgradeController(target: StructureController): ScreepsReturnCode;
     /**
      * Withdraw resources from a structure, a tombstone or a ruin.
      *
-     * The target has to be at adjacent square to the creep.
+     * The target has to be at adjacent square to the creep. Multiple creeps can withdraw from the same object in the same tick.
+     * Your creeps can withdraw resources from hostile structures/tombstones as well, in case if there is no hostile rampart on top of it.
      *
-     * Multiple creeps can withdraw from the same structure in the same tick.
+     * This method should not be used to transfer resources between creeps.
+     * To transfer between creeps, use the {@link Creep.transfer} method on the original creep.
      *
-     * Your creeps can withdraw resources from hostile structures as well, in case if there is no hostile rampart on top of it.
      * @param target The target object.
-     * @param resourceType The target One of the RESOURCE_* constants..
+     * @param resourceType One of the {@link ResourceConstant} constants..
      * @param amount The amount of resources to be transferred. If omitted, all the available amount is used.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep, or there is a hostile rampart on top of the target.
+     * - ERR_BUSY: The creep is still being spawned.
+     * - ERR_NOT_ENOUGH_RESOURCES: The target does not have the given amount of resources.
+     * - ERR_INVALID_TARGET: The target is not a valid object which can contain the specified resource.
+     * - ERR_FULL: The creep's carry is full.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant} constants, or the amount is incorrect.
      */
     withdraw(target: Structure | Tombstone | Ruin, resourceType: ResourceConstant, amount?: number): ScreepsReturnCode;
 }

--- a/src/deposit.ts
+++ b/src/deposit.ts
@@ -1,20 +1,24 @@
 /**
  * A rare resource deposit needed for producing commodities.
- * Can be harvested by creeps with a WORK body part.
- * Each harvest operation triggers a cooldown period, which becomes longer and longer over time.
+ *
+ * Can be harvested by creeps with a WORK body part. Each harvest operation triggers a cooldown period, which becomes longer and longer over time.
+ *
+ * Learn more about deposits from [this article](https://docs.screeps.com/resources.html).
+ *
+ * |              |             |
+ * | ------------ | ----------- |
+ * | **Cooldown** | 0.001 * totalHarvested ^ 1.2
+ * | **Decay**    | 50,000 ticks after appearing or last harvest operation
  */
 interface Deposit extends RoomObject {
     /**
-     * A unique object identificator.
-     * You can use {@link Game.getObjectById} method to retrieve an object instance by its id.
+     * A unique object identifier.
+     *
+     * You can use {@link Game.getObjectById} to retrieve an object instance by its id.
      */
     id: Id<this>;
     /**
-     * The deposit type, one of the following constants:
-     * * `RESOURCE_MIST`
-     * * `RESOURCE_BIOMASS`
-     * * `RESOURCE_METAL`
-     * * `RESOURCE_SILICON`
+     * The deposit type, one of the {@link DepositConstant}.
      */
     depositType: DepositConstant;
     /**

--- a/src/deposit.ts
+++ b/src/deposit.ts
@@ -18,7 +18,11 @@ interface Deposit extends RoomObject {
      */
     id: Id<this>;
     /**
-     * The deposit type, one of the {@link DepositConstant}.
+     * The deposit type, one of the {@link DepositConstant}:
+     * - `RESOURCE_MIST`
+     * - `RESOURCE_BIOMASS`
+     * - `RESOURCE_METAL`
+     * - `RESOURCE_SILICON`
      */
     depositType: DepositConstant;
     /**

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -1,27 +1,31 @@
 /**
- * A flag. Flags can be used to mark particular spots in a room. Flags are visible to their owners only.
+ * A flag.
+ *
+ * Flags can be used to mark particular spots in a room. Flags are visible to their owners only. You cannot have more than 10,000 flags.
  */
 interface Flag extends RoomObject {
     readonly prototype: Flag;
 
     /**
-     * Flag color. One of the `COLOR_*` constants.
+     * Flag color. One of the {@link ColorConstant} constants.
      */
     color: ColorConstant;
     /**
+     * The flag's memory.
+     *
      * A shorthand to Memory.flags[flag.name]. You can use it for quick access the flag's specific memory data object.
      */
     memory: FlagMemory;
     /**
-     * Flag’s name.
+     * The flag’s name.
      *
      * You can choose the name while creating a new flag, and it cannot be changed later.
      *
-     * This name is a hash key to access the flag via the `Game.flags` object. The maximum name length is 60 characters.
+     * This name is a hash key to access the flag via the {@link Game.flags} object. The maximum name length is 60 characters.
      */
     name: string;
     /**
-     * Flag secondary color. One of the `COLOR_*` constants.
+     * Flag secondary color. One of the {@link ColorConstant} constants.
      */
     secondaryColor: ColorConstant;
     /**
@@ -31,22 +35,28 @@ interface Flag extends RoomObject {
     remove(): OK;
     /**
      * Set new color of the flag.
-     * @param color One of the following constants: COLOR_WHITE, COLOR_GREY, COLOR_RED, COLOR_PURPLE, COLOR_BLUE, COLOR_CYAN, COLOR_GREEN, COLOR_YELLOW, COLOR_ORANGE, COLOR_BROWN
-     * @parma secondaryColor Secondary color of the flag. One of the COLOR_* constants.
-     * @returns Result Code: OK, ERR_INVALID_ARGS
+     * @param color One of the {@link ColorConstant} constants.
+     * @param secondaryColor Secondary color of the flag. One of the {@link ColorConstant} constants.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_INVALID_ARGS: color or secondaryColor is not a valid color constant.
      */
     setColor(color: ColorConstant, secondaryColor?: ColorConstant): OK | ERR_INVALID_ARGS;
     /**
      * Set new position of the flag.
      * @param x The X position in the room.
      * @param y The Y position in the room.
-     * @returns Result Code: OK, ERR_INVALID_TARGET
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_INVALID_TARGET: The target provided is invalid.
      */
     setPosition(x: number, y: number): OK | ERR_INVALID_ARGS;
     /**
      * Set new position of the flag.
-     * @param pos Can be a RoomPosition object or any object containing RoomPosition.
-     * @returns Result Code: OK, ERR_INVALID_TARGET
+     * @param pos Can be a {@link RoomPosition} object or any object containing RoomPosition.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_INVALID_TARGET: The target provided is invalid.
      */
     setPosition(pos: RoomPosition | { pos: RoomPosition }): OK | ERR_INVALID_ARGS;
 }

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -7,7 +7,7 @@ interface Flag extends RoomObject {
     readonly prototype: Flag;
 
     /**
-     * Flag color. One of the {@link ColorConstant} constants.
+     * Flag color. One of the {@link ColorConstant COLOR_*} constants.
      */
     color: ColorConstant;
     /**
@@ -25,7 +25,7 @@ interface Flag extends RoomObject {
      */
     name: string;
     /**
-     * Flag secondary color. One of the {@link ColorConstant} constants.
+     * Flag secondary color. One of the {@link ColorConstant COLOR_*} constants.
      */
     secondaryColor: ColorConstant;
     /**
@@ -35,8 +35,8 @@ interface Flag extends RoomObject {
     remove(): OK;
     /**
      * Set new color of the flag.
-     * @param color One of the {@link ColorConstant} constants.
-     * @param secondaryColor Secondary color of the flag. One of the {@link ColorConstant} constants.
+     * @param color One of the {@link ColorConstant COLOR_*} constants.
+     * @param secondaryColor Secondary color of the flag. One of the {@link ColorConstant COLOR_*} constants.
      * @returns One of the following codes:
      * - OK: The operation has been scheduled successfully.
      * - ERR_INVALID_ARGS: color or secondaryColor is not a valid color constant.

--- a/src/game.ts
+++ b/src/game.ts
@@ -31,15 +31,20 @@ interface Game {
      */
     market: Market;
     /**
-     * A hash containing all your power creeps with their names as hash keys. Even power creeps not spawned in the world can be accessed here.
+     * A hash containing all your power creeps with their names as hash keys.
+     *
+     * Even power creeps not spawned in the world can be accessed here.
      */
     powerCreeps: { [creepName: string]: PowerCreep };
     /**
-     * An object with your global resources that are bound to the account, like pixels or cpu unlocks. Each object key is a resource constant, values are resources amounts.
+     * An object with your global resources that are bound to the account, like pixels or cpu unlocks.
+     *
+     * Each object key is a resource constant, values are resources amounts.
      */
     resources: { [key: string]: any };
     /**
      * A hash containing all the rooms available to you with room names as hash keys.
+     *
      * A room is visible if you have a creep or an owned structure in it.
      */
     rooms: { [roomName: string]: Room };
@@ -63,12 +68,16 @@ interface Game {
     shard: Shard;
 
     /**
-     * System game tick counter. It is automatically incremented on every tick.
+     * System game tick counter.
+     *
+     * It is automatically incremented on every tick.
      */
     time: number;
 
     /**
-     * Get an object with the specified unique ID. It may be a game object of any type. Only objects from the rooms which are visible to you can be accessed.
+     * Get an object with the specified unique ID.
+     *
+     * It may be a game object of any type. Only objects from the rooms which are visible to you can be accessed.
      * @param id The unique identifier.
      * @returns an object instance or null if it cannot be found.
      */
@@ -80,12 +89,15 @@ interface Game {
      *
      * This way, you can set up notifications to yourself on any occasion within the game.
      *
-     * You can schedule up to 20 notifications during one game tick. Not available in the Simulation Room.
+     * You can schedule up to 20 notifications during one game tick. Not available in the Simulator.
      * @param message Custom text which will be sent in the message. Maximum length is 1000 characters.
      * @param groupInterval If set to 0 (default), the notification will be scheduled immediately.
      * Otherwise, it will be grouped with other notifications and mailed out later using the specified time in minutes.
+     * @returns One of the following codes:
+     * - OK: The message has been sent successfully.
+     * - ERR_FULL: More than 20 notifications sent this tick.
      */
-    notify(message: string, groupInterval?: number): undefined;
+    notify(message: string, groupInterval?: number): OK | ERR_FULL;
 }
 
 declare var Game: Game;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -166,7 +166,7 @@ interface HeapStatistics {
 type BodyPartDefinition<T extends BodyPartConstant = BodyPartConstant> = T extends any
     ? {
           /**
-           * One of the {@link ResourceConstant} constants.
+           * One of the {@link ResourceConstant RESOURCE_*} constants.
            *
            * If the body part is boosted, this property specifies the mineral type which is used for boosting.
            */

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -57,16 +57,21 @@ interface CPU {
      */
     limit: number;
     /**
-     * An amount of available CPU time at the current game tick. Usually it is higher than `Game.cpu.limit`.
+     * An amount of available CPU time at the current game tick.
+     *
+     * Usually it is higher than {@link Game.cpu.limit}.
      */
     tickLimit: number;
     /**
      * An amount of unused CPU accumulated in your bucket.
+     *
      * @see http://docs.screeps.com/cpu-limit.html#Bucket
      */
     bucket: number;
     /**
-     * An object with limits for each shard with shard names as keys. You can use `setShardLimits` method to re-assign them.
+     * An object with limits for each shard with shard names as keys.
+     *
+     * You can use {@link Game.cpu.setShardLimits} method to re-assign them.
      */
     shardLimits: CPUShardLimits;
     /**
@@ -75,20 +80,28 @@ interface CPU {
     unlocked: boolean;
     /**
      * The time in milliseconds since UNIX epoch time until full CPU is unlocked for your account.
+     *
      * This property is not defined when full CPU is not unlocked for your account or it's unlocked with a subscription.
      */
     unlockedTime: number | undefined;
 
     /**
-     * Get amount of CPU time used from the beginning of the current game tick. Always returns 0 in the Simulation mode.
+     * Get amount of CPU time used from the beginning of the current game tick.
+     *
+     * Always returns 0 in the simulator.
      */
     getUsed(): number;
     /**
-     * Allocate CPU limits to different shards. Total amount of CPU should remain equal to `Game.cpu.shardLimits`.
+     * Allocate CPU limits to different shards.
+     *
+     * Total amount of CPU should remain equal to {@link Game.cpu.shardLimits}.
      * This method can be used only once per 12 hours.
      *
-     * @param limits An object with CPU values for each shard in the same format as `Game.cpu.shardLimits`.
-     * @returns One of the following codes: `OK | ERR_BUSY | ERR_INVALID_ARGS`
+     * @param limits An object with CPU values for each shard in the same format as {@link Game.cpu.shardLimits}.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_BUSY: 12-hours cooldown period is not over yet.
+     * - ERR_INVALID_ARGS: The argument is not a valid shard limits object.
      */
     setShardLimits(limits: CPUShardLimits): OK | ERR_BUSY | ERR_INVALID_ARGS;
 
@@ -97,7 +110,8 @@ interface CPU {
      *
      * This method will be undefined if you are not using IVM.
      *
-     * The return value is almost identical to the Node.js function v8.getHeapStatistics().
+     * The return value is almost identical to Node's [v8.getHeapStatistics()](https://nodejs.org/docs/latest-v10.x/api/v8.html#v8_v8_getheapstatistics).
+     *
      * This function returns one additional property: externally_allocated_size which is the total amount of currently
      * allocated memory which is not included in the v8 heap but counts against this isolate's memory limit.
      * ArrayBuffer instances over a certain size are externally allocated and will be counted here.
@@ -113,13 +127,22 @@ interface CPU {
     halt?(): never;
     /**
      * Generate 1 pixel resource unit for 10000 CPU from your bucket.
+     *
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_ENOUGH_RESOURCES: Your bucket does not have enough CPU.
      */
     generatePixel(): OK | ERR_NOT_ENOUGH_RESOURCES;
 
     /**
      * Unlock full CPU for your account for additional 24 hours.
-     * This method will consume 1 CPU unlock bound to your account (See `Game.resources`).
+     *
+     * This method will consume 1 CPU unlock bound to your account (See {@link Game.resources}).
      * If full CPU is not currently unlocked for your account, it may take some time (up to 5 minutes) before unlock is applied to your account.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_ENOUGH_RESOURCES: Your account does not have enough cpuUnlock resource.
+     * - ERR_FULL: Your CPU is unlocked with a subscription.
      */
     unlock(): OK | ERR_NOT_ENOUGH_RESOURCES | ERR_FULL;
 }
@@ -143,7 +166,7 @@ interface HeapStatistics {
 type BodyPartDefinition<T extends BodyPartConstant = BodyPartConstant> = T extends any
     ? {
           /**
-           * One of the `RESOURCE_*` constants.
+           * One of the {@link ResourceConstant} constants.
            *
            * If the body part is boosted, this property specifies the mineral type which is used for boosting.
            */
@@ -287,28 +310,37 @@ interface FindTypes {
 
 interface FindPathOpts {
     /**
-     * Treat squares with creeps as walkable. Can be useful with too many moving creeps around or in some other cases. The default
-     * value is false.
+     * Treat squares with creeps as walkable.
+     *
+     * Can be useful with too many moving creeps around or in some other cases.
+     * @default false
      */
     ignoreCreeps?: boolean;
 
     /**
-     * Treat squares with destructible structures (constructed walls, ramparts, spawns, extensions) as walkable. Use this flag when
-     * you need to move through a territory blocked by hostile structures. If a creep with an ATTACK body part steps on such a square,
-     * it automatically attacks the structure. The default value is false.
+     * Treat squares with destructible structures (constructed walls, ramparts, spawns, extensions) as walkable.
+     *
+     * Use this flag when you need to move through a territory blocked by hostile structures.
+     * If a creep with an ATTACK body part steps on such a square, it automatically attacks the structure.
+     * @default false
      */
     ignoreDestructibleStructures?: boolean;
 
     /**
-     * Ignore road structures. Enabling this option can speed up the search. The default value is false. This is only used when the
-     * new PathFinder is enabled.
+     * Ignore road structures.
+     *
+     * Enabling this option can speed up the search. This is only used when the new PathFinder is enabled.
+     *
+     * @default false
      */
     ignoreRoads?: boolean;
 
     /**
-     * You can use this callback to modify a CostMatrix for any room during the search. The callback accepts two arguments, roomName
-     * and costMatrix. Use the costMatrix instance to make changes to the positions costs. If you return a new matrix from this callback,
-     * it will be used instead of the built-in cached one. This option is only used when the new PathFinder is enabled.
+     * You can use this callback to modify a CostMatrix for any room during the search.
+     *
+     * The callback accepts two arguments, roomName and costMatrix. Use the costMatrix instance to make changes to the positions costs.
+     * If you return a new matrix from this callback, it will be used instead of the built-in cached one.
+     * This option is only used when the new PathFinder is enabled.
      *
      * @param roomName The name of the room.
      * @param costMatrix The current CostMatrix
@@ -317,78 +349,103 @@ interface FindPathOpts {
     costCallback?: (roomName: string, costMatrix: CostMatrix) => void | CostMatrix;
 
     /**
-     * An array of the room's objects or RoomPosition objects which should be treated as walkable tiles during the search. This option
-     * cannot be used when the new PathFinder is enabled (use costCallback option instead).
+     * An array of the room's objects or RoomPosition objects which should be treated as walkable tiles during the search.
+     *
+     * This option cannot be used when the new PathFinder is enabled (use costCallback option instead).
      */
     ignore?: any[] | RoomPosition[];
 
     /**
-     * An array of the room's objects or RoomPosition objects which should be treated as obstacles during the search. This option cannot
-     * be used when the new PathFinder is enabled (use costCallback option instead).
+     * An array of the room's objects or RoomPosition objects which should be treated as obstacles during the search.
+     *
+     * This option cannot be used when the new PathFinder is enabled (use costCallback option instead).
      */
     avoid?: any[] | RoomPosition[];
 
     /**
-     * The maximum limit of possible pathfinding operations. You can limit CPU time used for the search based on ratio 1 op ~ 0.001 CPU.
-     * The default value is 2000.
+     * The maximum limit of possible pathfinding operations.
+     *
+     * You can limit CPU time used for the search based on ratio 1 op ~ 0.001 CPU.
+     * @default 2000
      */
     maxOps?: number;
 
     /**
-     * Weight to apply to the heuristic in the A* formula F = G + weight * H. Use this option only if you understand the underlying
-     * A* algorithm mechanics! The default value is 1.2.
+     * Weight to apply to the heuristic in the A* formula `F = G + weight * H`.
+     *
+     * Use this option only if you understand the underlying A* algorithm mechanics!
+     * @default 1.2
      */
     heuristicWeight?: number;
 
     /**
-     * If true, the result path will be serialized using Room.serializePath. The default is false.
+     * If true, the result path will be serialized using {@link Room.serializePath}.
+     * @default false
      */
     serialize?: boolean;
 
     /**
-     * The maximum allowed rooms to search. The default (and maximum) is 16. This is only used when the new PathFinder is enabled.
+     * The maximum allowed rooms to search.
+     *
+     * This is only used when the new PathFinder is enabled.
+     * @default 16 (also maximum)
      */
     maxRooms?: number;
 
     /**
-     * Path to within (range) tiles of target tile. The default is to path to the tile that the target is on (0).
+     * Path to within (range) tiles of target tile.
+     *
+     * The default is to path to the tile that the target is on.
+     *
+     * @default 0
      */
     range?: number;
 
     /**
-     * Cost for walking on plain positions. The default is 1.
+     * Cost for walking on plain positions.
+     * @default 1
      */
     plainCost?: number;
 
     /**
-     * Cost for walking on swamp positions. The default is 5.
+     * Cost for walking on swamp positions.
+     * @default 5
      */
     swampCost?: number;
 }
 
 interface MoveToOpts extends FindPathOpts {
     /**
-     * This option enables reusing the path found along multiple game ticks. It allows to save CPU time, but can result in a slightly
-     * slower creep reaction behavior. The path is stored into the creep's memory to the `_move` property. The `reusePath` value defines
-     * the amount of ticks which the path should be reused for. The default value is 5. Increase the amount to save more CPU, decrease
-     * to make the movement more consistent. Set to 0 if you want to disable path reusing.
+     * This option enables reusing the path found along multiple game ticks.
+     *
+     * It allows to save CPU time, but can result in a slightly slower creep reaction behavior.
+     * The path is stored into the creep's memory to the `_move` property.
+     * The `reusePath` value defines the amount of ticks which the path should be reused for.
+     * Increase the amount to save more CPU, decrease to make the movement more consistent.
+     * Set to 0 if you want to disable path reusing.
+     * @default 5
      */
     reusePath?: number;
 
     /**
-     * If `reusePath` is enabled and this option is set to true, the path will be stored in memory in the short serialized form using
-     * `Room.serializePath`. The default value is true.
+     * If `reusePath` is enabled and this option is set to true, the path will be stored in memory in the short serialized form using {@link Room.serializePath}.
+     * @default true
      */
     serializeMemory?: boolean;
 
     /**
-     * If this option is set to true, `moveTo` method will return `ERR_NOT_FOUND` if there is no memorized path to reuse. This can
-     * significantly save CPU time in some cases. The default value is false.
+     * Force the use of a cached path.
+     *
+     * If this option is set to true, `moveTo` method will return `ERR_NOT_FOUND` if there is no memorized path to reuse.
+     * This can significantly save CPU time in some cases.
+     * @default false
      */
     noPathFinding?: boolean;
 
     /**
-     * Draw a line along the creep’s path using `RoomVisual.poly`. You can provide either an empty object or custom style parameters.
+     * Draw a line along the creep’s path using {@link RoomVisual.poly}.
+     *
+     * You can provide either an empty object or custom style parameters.
      */
     visualizePathStyle?: PolyStyle;
 }

--- a/src/inter-shard-memory.ts
+++ b/src/inter-shard-memory.ts
@@ -1,7 +1,8 @@
 /**
  * `InterShardMemory` object provides an interface for communicating between shards.
- * Your script is executed separatedly on each shard, and their `Memory` objects are isolated from each other.
- * In order to pass messages and data between shards, you need to use `InterShardMemory` instead.
+ *
+ * Your script is executed separatedly on each shard, and their {@link Memory} objects are isolated from each other.
+ * In order to pass messages and data between shards, you need to use {@link InterShardMemory} instead.
  *
  * Every shard can have its own data string that can be accessed by all other shards.
  * A shard can write only to its own data, other shards' data is read-only.
@@ -14,15 +15,17 @@ interface InterShardMemory {
      */
     getLocal(): string;
     /**
-     * Replace the current shard's data with the new value
+     * Replace the current shard's data with the new value.
+     *
      * @param value New data value in string format.
+     * @throws if `value` isn't a string or contains more than `100 * 2014` characters.
      */
     setLocal(value: string): void;
     /**
      * Returns the string contents of another shard's data, null if shard exists but data is not set.
      *
      * @param shard Shard name.
-     * @throws Error if shard name is invalid
+     * @throws if shard name is invalid
      */
     getRemote(shard: string): string | null;
 }

--- a/src/map.ts
+++ b/src/map.ts
@@ -25,7 +25,9 @@ interface RoomStatusTemporary {
 type RoomStatus = RoomStatusPermanent | RoomStatusTemporary;
 
 /**
- * A global object representing world map. Use it to navigate between rooms. The object is accessible via Game.map property.
+ * A global object representing world map.
+ *
+ * Use it to navigate between rooms. The object is accessible via the {@link Game.map} property.
  */
 interface GameMap {
     /**
@@ -54,8 +56,9 @@ interface GameMap {
      */
     findRoute(fromRoom: string | Room, toRoom: string | Room, opts?: RouteOptions): { exit: ExitConstant; room: string }[] | ERR_NO_PATH;
     /**
-     * Get the linear distance (in rooms) between two rooms. You can use this function to estimate the energy cost of
-     * sending resources through terminals, or using observers and nukes.
+     * Get the linear distance (in rooms) between two rooms.
+     *
+     * You can use this function to estimate the energy cost of sending resources through terminals, or using observers and nukes.
      * @param roomName1 The name of the first room.
      * @param roomName2 The name of the second room.
      * @param continuous Whether to treat the world map continuous on borders. Set to true if you
@@ -63,26 +66,34 @@ interface GameMap {
      */
     getRoomLinearDistance(roomName1: string, roomName2: string, continuous?: boolean): number;
     /**
-     * Get terrain type at the specified room position. This method works for any room in the world even if you have no access to it.
+     * Get terrain type at the specified room position.
+     *
+     * This method works for any room in the world even if you have no access to it.
      * @param x X position in the room.
      * @param y Y position in the room.
      * @param roomName The room name.
-     * @deprecated use `Game.map.getRoomTerrain` instead
+     * @deprecated use {@link Game.map.getRoomTerrain} instead
      */
     getTerrainAt(x: number, y: number, roomName: string): Terrain;
     /**
-     * Get terrain type at the specified room position. This method works for any room in the world even if you have no access to it.
+     * Get terrain type at the specified room position.
+     *
+     * This method works for any room in the world even if you have no access to it.
      * @param pos The position object.
-     * @deprecated use `Game.map.getRoomTerrain` instead
+     * @deprecated use {@link Game.map.getRoomTerrain} instead
      */
     getTerrainAt(pos: RoomPosition): Terrain;
     /**
-     * Get room terrain for the specified room. This method works for any room in the world even if you have no access to it.
+     * Get room terrain for the specified room.
+     *
+     * This method works for any room in the world even if you have no access to it.
      * @param roomName String name of the room.
      */
     getRoomTerrain(roomName: string): RoomTerrain;
     /**
-     * Returns the world size as a number of rooms between world corners. For example, for a world with rooms from W50N50 to E50S50 this method will return 102.
+     * Returns the world size as a number of rooms between world corners.
+     *
+     * For example, for a world with rooms from W50N50 to E50S50 this method will return 102.
      */
     getWorldSize(): number;
 
@@ -97,13 +108,13 @@ interface GameMap {
     /**
      * Get the room status to determine if it's available, or in a reserved area.
      * @param roomName The room name.
-     * @returns An object with the following properties {status: "normal" | "closed" | "novice" | "respawn", timestamp: number}
+     * @returns A {@link RoomStatus} object.
      */
     getRoomStatus(roomName: string): RoomStatus;
 
     /**
      * Map visuals provide a way to show various visual debug info on the game map.
-     * You can use the `Game.map.visual` object to draw simple shapes that are visible only to you.
+     * You can use the {@link Game.map.visual} object to draw simple shapes that are visible only to you.
      *
      * Map visuals are not stored in the database, their only purpose is to display something in your browser.
      * All drawings will persist for one tick and will disappear if not updated.
@@ -115,8 +126,18 @@ interface GameMap {
     visual: MapVisual;
 }
 
-// No static is available
-
+/**
+ * Map visuals provide a way to show various visual debug info on the game map.
+ *
+ * You can use the {@link Game.map.visual} object to draw simple shapes that are visible only to you.
+ *
+ *  Map visuals are not stored in the database, their only purpose is to display something in your browser.
+ * All drawings will persist for one tick and will disappear if not updated.
+ * All `Game.map.visual` calls have no added CPU cost (their cost is natural and mostly related to simple `JSON.serialize` calls).
+ * However, there is a usage limit: you cannot post more than 1000 KB of serialized data.
+ *
+ * All draw coordinates are measured in global game coordinates ({@link RoomPosition}).
+ */
 interface MapVisual {
     /**
      * Draw a line.
@@ -169,7 +190,9 @@ interface MapVisual {
     clear(): MapVisual;
 
     /**
-     * Get the stored size of all visuals added on the map in the current tick. It must not exceed 1024,000 (1000 KB).
+     * Get the stored size of all visuals added on the map in the current tick.
+     *
+     * It must not exceed 1024,000 (1000 KB).
      * @returns The size of the visuals in bytes.
      */
     getSize(): number;
@@ -181,7 +204,7 @@ interface MapVisual {
     export(): string;
 
     /**
-     * Add previously exported (with `Game.map.visual.export`) map visuals to the map visual data of the current tick.
+     * Add previously exported (with {@link Game.map.visual.export}) map visuals to the map visual data of the current tick.
      * @param data The string returned from `Game.map.visual.export`.
      * @returns The MapVisual object itself, so that you can chain calls.
      */
@@ -190,64 +213,77 @@ interface MapVisual {
 
 interface MapLineStyle {
     /**
-     * Line width, default is 0.1.
+     * Line width.
+     * @default 0.1
      */
     width?: number;
     /**
-     * Line color in the following format: #ffffff (hex triplet). Default is #ffffff.
+     * Line color in the following format: #ffffff (hex triplet).
+     * @default #ffffff
      */
     color?: string;
     /**
-     * Opacity value, default is 0.5.
+     * Opacity value
+     * @default 0.5
      */
     opacity?: number;
     /**
-     * Either undefined (solid line), dashed, or dotted. Default is undefined.
+     * Either undefined (solid line), dashed, or dotted.
+     * @default undefined.
      */
     lineStyle?: "dashed" | "dotted" | "solid" | undefined;
 }
 
 interface MapPolyStyle {
     /**
-     * Fill color in the following format: #ffffff (hex triplet). Default is undefined (no fill).
+     * Fill color in the following format: #ffffff (hex triplet).
+     * @default undefined (no fill).
      */
     fill?: string | undefined;
     /**
-     * Opacity value, default is 0.5.
+     * Opacity value
+     * @default 0.5
      */
     opacity?: number;
     /**
-     * Stroke color in the following format: #ffffff (hex triplet). Default is #ffffff.
+     * Stroke color in the following format: #ffffff (hex triplet).
+     * @default #ffffff
      */
     stroke?: string;
     /**
-     * Stroke line width, default is 0.5.
+     * Stroke line width.
+     * @default 0.5
      */
     strokeWidth?: number;
     /**
-     * Either undefined (solid line), dashed, or dotted. Default is undefined.
+     * Either undefined (solid line), dashed, or dotted.
+     * @default is undefined
      */
     lineStyle?: "dashed" | "dotted" | "solid" | undefined;
 }
 
 interface MapCircleStyle extends MapPolyStyle {
     /**
-     * Circle radius, default is 10.
+     * Circle radius.
+     * @default 10
      */
     radius?: number;
 }
 
 interface MapTextStyle {
     /**
-     * Font color in the following format: #ffffff (hex triplet). Default is #ffffff.
+     * Font color in the following format: #ffffff (hex triplet).
+     * @default #ffffff
      */
     color?: string;
     /**
-     * The font family, default is sans-serif
+     * The font family.
+     * @default sans-serif
      */
     fontFamily?: string;
     /**
-     * The font size in game coordinates, default is 10
+     * The font size in game coordinates.
+     * @default 10
      */
     fontSize?: number;
     /**
@@ -259,27 +295,35 @@ interface MapTextStyle {
      */
     fontVariant?: string;
     /**
-     * Stroke color in the following format: #ffffff (hex triplet). Default is undefined (no stroke).
+     * Stroke color in the following format: #ffffff (hex triplet)
+     * @default undefined (no stroke).
      */
     stroke?: string | undefined;
     /**
-     * Stroke width, default is 0.15.
+     * Stroke width.
+     * @default 0.15
      */
     strokeWidth?: number;
     /**
-     * Background color in the following format: #ffffff (hex triplet). Default is undefined (no background). When background is enabled, text vertical align is set to middle (default is baseline).
+     * Background color in the following format: #ffffff (hex triplet).
+     *
+     * When background is enabled, text vertical align is set to middle (default is baseline).
+     * @default undefined (no background).
      */
     backgroundColor?: string | undefined;
     /**
-     * Background rectangle padding, default is 2.
+     * Background rectangle padding.
+     * @default 2
      */
     backgroundPadding?: number;
     /**
-     * Text align, either center, left, or right. Default is center.
+     * Text align, either center, left, or right.
+     * @default center
      */
     align?: "center" | "left" | "right";
     /**
-     * Opacity value, default is 0.5.
+     * Opacity value.
+     * @default 0.5
      */
     opacity?: number;
 }

--- a/src/market.ts
+++ b/src/market.ts
@@ -124,7 +124,7 @@ interface Market {
     getAllOrders(filter?: OrderFilter | ((o: Order) => boolean)): Order[];
     /**
      * Get daily price history of the specified resource on the market for the last 14 days.
-     * @param resource One of the {@link MarketResourceConstant} constants. If undefined, returns history data for all resources. Optional
+     * @param resource One of the {@link MarketResourceConstant RESOURCE_*} constants. If undefined, returns history data for all resources. Optional
      * @returns An array of objects with resource info.
      */
     getHistory(resource?: MarketResourceConstant): PriceHistory[];

--- a/src/market.ts
+++ b/src/market.ts
@@ -1,6 +1,10 @@
 /**
- * A global object representing the in-game market. You can use this object to track resource transactions to/from your
- * terminals, and your buy/sell orders. The object is accessible via the singleton Game.market property.
+ * A global object representing the in-game market.
+ *
+ * You can use this object to track resource transactions to/from your terminals, and your buy/sell orders.
+ * The object is accessible via the singleton {@link Game.market} property.
+ *
+ * Learn more about the market system from [this article](https://docs.screeps.com/market.html).
  */
 interface Market {
     /**
@@ -20,7 +24,9 @@ interface Market {
      */
     outgoingTransactions: Transaction[];
     /**
-     * Estimate the energy transaction cost of StructureTerminal.send and Market.deal methods. The formula:
+     * Estimate the energy transaction cost of {@link StructureTerminal.send} and {@link Market.deal} methods.
+     *
+     * The formula:
      *
      * ```
      * Math.ceil( amount * (Math.log(0.1*linearDistanceBetweenRooms + 0.9) + 0.1) )
@@ -33,20 +39,32 @@ interface Market {
      */
     calcTransactionCost(amount: number, roomName1: string, roomName2: string): number;
     /**
-     * Cancel a previously created order. The 5% fee is not returned.
+     * Cancel a previously created order.
+     *
+     * The 5% fee is not returned.
      * @param orderId The order ID as provided in Game.market.orders
-     * @returns Result Code: OK, ERR_INVALID_ARGS
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_INVALID_ARGS: The order ID is not valid.
      */
     cancelOrder(orderId: string): ScreepsReturnCode;
     /**
-     * Change the price of an existing order. If `newPrice` is greater than old price, you will be charged `(newPrice-oldPrice)*remainingAmount*0.05` credits.
+     * Change the price of an existing order.
+     *
+     * If `newPrice` is greater than old price, you will be charged `(newPrice-oldPrice)*remainingAmount*0.05` credits.
      * @param orderId The order ID as provided in Game.market.orders
      * @param newPrice The new order price.
-     * @returns Result Code: OK, ERR_NOT_OWNER, ERR_NOT_ENOUGH_RESOURCES, ERR_INVALID_ARGS
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of the room's terminal or there is no terminal.
+     * - ERR_NOT_ENOUGH_RESOURCES: You don't have enough credits to pay a fee.
+     * - ERR_INVALID_ARGS: The arguments provided are invalid.
      */
     changeOrderPrice(orderId: string, newPrice: number): ScreepsReturnCode;
     /**
-     * Create a market order in your terminal. You will be charged `price*amount*0.05` credits when the order is placed.
+     * Create a market order in your terminal.
+     *
+     * You will be charged `price*amount*0.05` credits when the order is placed.
      *
      * The maximum orders count is 300 per player. You can create an order at any time with any amount,
      * it will be automatically activated and deactivated depending on the resource/credits availability.
@@ -64,7 +82,7 @@ interface Market {
      * Execute a trade deal from your Terminal to another player's Terminal using the specified buy/sell order.
      *
      * Your Terminal will be charged energy units of transfer cost regardless of the order resource type.
-     * You can use Game.market.calcTransactionCost method to estimate it.
+     * You can use {@link Game.market.calcTransactionCost} method to estimate it.
      *
      * When multiple players try to execute the same deal, the one with the shortest distance takes precedence.
      *
@@ -75,15 +93,27 @@ interface Market {
      * @param yourRoomName The name of your room which has to contain an active Terminal with enough amount of energy.
      * This argument is not used when the order resource type is one of account-bound resources (@see {@link InterShardResourceConstant}).
      *
-     * @returns Result Code: OK, ERR_NOT_OWNER, ERR_NOT_ENOUGH_RESOURCES, ERR_FULL, ERR_INVALID_ARGS, ERR_TIRED
+     * @returns One of the following error codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You don't have a terminal in the target room.
+     * - ERR_NOT_ENOUGH_RESOURCES: You don't have enough credits or resource units.
+     * - ERR_FULL: You cannot execute more than 10 deals during one tick.
+     * - ERR_INVALID_ARGS: The arguments provided are invalid.
+     * - ERR_TIRED: The target terminal is still cooling down.
      */
     deal(orderId: string, amount: number, yourRoomName?: string): ScreepsReturnCode;
     /**
-     * Add more capacity to an existing order. It will affect `remainingAmount` and `totalAmount` properties. You will be charged `price*addAmount*0.05` credits.
+     * Add more capacity to an existing order.
+     *
+     * It will affect `remainingAmount` and `totalAmount` properties. You will be charged `price*addAmount*0.05` credits.
      * Extending the order doesn't update its expiration time.
+     *
      * @param orderId The order ID as provided in Game.market.orders
      * @param addAmount How much capacity to add. Cannot be a negative value.
-     * @returns One of the following codes: `OK`, `ERR_NOT_ENOUGH_RESOURCES`, `ERR_INVALID_ARGS`
+     * @returns One of the following error codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_ENOUGH_RESOURCES: You don't have enough credits to pay a fee.
+     * - ERR_INVALID_ARGS:  The arguments provided are invalid.
      */
     extendOrder(orderId: string, addAmount: number): ScreepsReturnCode;
     /**
@@ -94,14 +124,14 @@ interface Market {
     getAllOrders(filter?: OrderFilter | ((o: Order) => boolean)): Order[];
     /**
      * Get daily price history of the specified resource on the market for the last 14 days.
-     * @param resource One of the RESOURCE_* constants. If undefined, returns history data for all resources. Optional
+     * @param resource One of the {@link MarketResourceConstant} constants. If undefined, returns history data for all resources. Optional
      * @returns An array of objects with resource info.
      */
     getHistory(resource?: MarketResourceConstant): PriceHistory[];
     /**
      * Retrieve info for specific market order.
      * @param orderId The order ID.
-     * @returns An object with the order info. See `getAllOrders` for properties explanation.
+     * @returns An object with the order info. See {@link Order}.
      */
     getOrderById(id: string): Order | null;
 }
@@ -122,15 +152,33 @@ interface Transaction {
 }
 
 interface Order {
+    /** The unique order ID. */
     id: string;
+    /**
+     * The order creation time in milliseconds since UNIX epoch time.
+     *
+     * This property is absent for old orders.
+     */
     created: number;
+    /** Whether the order is active or not.
+     *
+     * Only exists for your own orders. */
     active?: boolean;
+    /** The order type. */
     type: ORDER_BUY | ORDER_SELL;
+    /**
+     * The type of resource requested by the order. See {@link MarketResourceConstant}.
+     */
     resourceType: MarketResourceConstant;
+    /** The room where this order is placed. */
     roomName?: string;
+    /** Currently available quantity of resource to trade. */
     amount: number;
+    /** Remaining quantity of resources to trade. */
     remainingAmount: number;
+    /** Total quantity of resources traded */
     totalAmount?: number;
+    /** The current price per unit. */
     price: number;
 }
 

--- a/src/mineral.ts
+++ b/src/mineral.ts
@@ -23,7 +23,7 @@ interface Mineral<T extends MineralConstant = MineralConstant> extends RoomObjec
      */
     readonly prototype: Mineral;
     /**
-     * The density of this mineral deposit, one of the {@link DensityConstant} constants.
+     * The density of this mineral deposit, one of the {@link DensityConstant DENSITY_*} constants.
      */
     density: number;
     /**
@@ -31,7 +31,7 @@ interface Mineral<T extends MineralConstant = MineralConstant> extends RoomObjec
      */
     mineralAmount: number;
     /**
-     * The resource type, one of the {@link MineralConstant} constants.
+     * The resource type, one of the {@link MineralConstant RESOURCE_*} constants.
      */
     mineralType: T;
     /**

--- a/src/mineral.ts
+++ b/src/mineral.ts
@@ -1,6 +1,21 @@
 /**
- * A mineral deposit object. Can be harvested by creeps with a WORK body part using the extractor structure.
- * @see http://docs.screeps.com/api/#Mineral
+ * A mineral deposit.
+ *
+ * Can be harvested by creeps with a WORK body part using the extractor structure.
+ * Learn more about minerals from [this article](http://docs.screeps.com/api/#Mineral).
+ *
+ *
+ * |                            |                              |
+ * | ---------------------------| ---------------------------- |
+ * | Regeneration amount        | DENSITY_LOW: 15,000
+ * |                            | DENSITY_MODERATE: 35,000
+ * |                            | DENSITY_HIGH: 70,000
+ * |                            | DENSITY_ULTRA: 100,000
+ * | Regeneration time          | 50,000 ticks
+ * | Density change probability | DENSITY_LOW: 100% chance
+ * |                            | DENSITY_MODERATE: 5% chance
+ * |                            | DENSITY_HIGH: 5% chance
+ * |                            | DENSITY_ULTRA: 100% chance*
  */
 interface Mineral<T extends MineralConstant = MineralConstant> extends RoomObject {
     /**
@@ -8,7 +23,7 @@ interface Mineral<T extends MineralConstant = MineralConstant> extends RoomObjec
      */
     readonly prototype: Mineral;
     /**
-     * The density of this mineral deposit, one of the `DENSITY_*` constants.
+     * The density of this mineral deposit, one of the {@link DensityConstant} constants.
      */
     density: number;
     /**
@@ -16,11 +31,13 @@ interface Mineral<T extends MineralConstant = MineralConstant> extends RoomObjec
      */
     mineralAmount: number;
     /**
-     * The resource type, one of the `RESOURCE_*` constants.
+     * The resource type, one of the {@link MineralConstant} constants.
      */
     mineralType: T;
     /**
-     * A unique object identifier. You can use `Game.getObjectById` method to retrieve an object instance by its `id`.
+     * A unique object identifier.
+     *
+     * You can use {@link Game.getObjectById} to retrieve an object instance by its `id`.
      */
     id: Id<this>;
     /**

--- a/src/nuke.ts
+++ b/src/nuke.ts
@@ -1,11 +1,30 @@
 /**
- * A nuke landing position. This object cannot be removed or modified. You can find incoming nukes in the room using the FIND_NUKES constant.
+ * A nuke landing position.
+ *
+ * This object cannot be removed or modified. You can find incoming nukes in the room using the {@link FIND_NUKES} constant.
+ *
+ * Landing time: 50,000 ticks
+ * All creeps, construction sites and dropped resources in the room are removed immediately, even inside ramparts.
+ *
+ * Damage to structures:
+ * - 10,000,000 hits at the landing position;
+ * - 5,000,000 hits to all structures in 5x5 area.
+ *
+ * Note that you can stack multiple nukes from different rooms at the same target position to increase damage.
+ *
+ * Nuke landing does not generate tombstones and ruins, and destroys all existing tombstones and ruins in the room.
+ *
+ * If the room is in safe mode, then the safe mode is cancelled immediately, and the safe mode cooldown is reset to 0.
+ *
+ * The room controller is hit by triggering {@link StructureController.upgradeBlocked} period, which means it is unavailable to activate safe mode again within the next 200 ticks.
  */
 interface Nuke extends RoomObject {
     readonly prototype: Nuke;
 
     /**
-     * A unique object identifier. You can use Game.getObjectById method to retrieve an object instance by its id.
+     * A unique object identifier.
+     *
+     * You can use {@link Game.getObjectById} to retrieve an object instance by its id.
      */
     id: Id<this>;
     /**

--- a/src/path-finder.ts
+++ b/src/path-finder.ts
@@ -1,10 +1,13 @@
 /**
- * Contains powerful methods for pathfinding in the game world. Support exists for custom navigation costs and paths which span multiple rooms.
+ * Contains powerful methods for pathfinding in the game world.
+ *
+ * This module is written in fast native C++ code and supports custom navigation costs and paths which span multiple rooms.
+ *
  * Additionally PathFinder can search for paths through rooms you can't see, although you won't be able to detect any dynamic obstacles like creeps or buildings.
  */
 interface PathFinder {
     /**
-     * Creates a new CostMatrix containing 0's for all positions.
+     * Creates a new {@link CostMatrix} containing 0's for all positions.
      */
     CostMatrix: CostMatrixConstructor;
 
@@ -23,10 +26,10 @@ interface PathFinder {
     /**
      * Specify whether to use this new experimental pathfinder in game objects methods.
      * This method should be invoked every tick. It affects the following methods behavior:
-     * * `Room.findPath`
-     * * `RoomPosition.findPathTo`
-     * * `RoomPosition.findClosestByPath`
-     * * `Creep.moveTo`
+     * - {@link Room.findPath}
+     * - {@link RoomPosition.findPathTo}
+     * - {@link RoomPosition.findClosestByPath}
+     * - {@link Creep.moveTo}
      *
      * @deprecated This method is deprecated and will be removed soon.
      * @param isEnabled Whether to activate the new pathfinder or deactivate.
@@ -44,7 +47,7 @@ interface PathFinder {
  */
 interface PathFinderPath {
     /**
-     * An array of RoomPosition objects.
+     * An array of {@link RoomPosition} objects.
      */
     path: RoomPosition[];
     /**
@@ -52,7 +55,7 @@ interface PathFinderPath {
      */
     ops: number;
     /**
-     * The total cost of the path as derived from `plainCost`, `swampCost` and any given CostMatrix instances.
+     * The total cost of the path as derived from `plainCost`, `swampCost` and any given {@link CostMatrix} instances.
      */
     cost: number;
     /**
@@ -68,42 +71,56 @@ interface PathFinderPath {
  */
 interface PathFinderOpts {
     /**
-     * Cost for walking on plain positions. The default is 1.
+     * Cost for walking on plain positions.
+     * @default 1
      */
     plainCost?: number;
     /**
-     * Cost for walking on swamp positions. The default is 5.
+     * Cost for walking on swamp positions.
+     * @default 5
      */
     swampCost?: number;
     /**
      * Instead of searching for a path to the goals this will search for a path away from the goals.
-     * The cheapest path that is out of range of every goal will be returned. The default is false.
+     *
+     * The cheapest path that is out of range of every goal will be returned.
+     * @default false
      */
     flee?: boolean;
     /**
-     * The maximum allowed pathfinding operations. You can limit CPU time used for the search based on ratio 1 op ~ 0.001 CPU. The default value is 2000.
+     * The maximum allowed pathfinding operations.
+     *
+     * You can limit CPU time used for the search based on ratio 1 op ~ 0.001 CPU.
+     * @default 2000
      */
     maxOps?: number;
     /**
-     * The maximum allowed rooms to search. The default (and maximum) is 16.
+     * The maximum allowed rooms to search.
+     * @default 16 (also maximum)
      */
     maxRooms?: number;
     /**
-     * The maximum allowed cost of the path returned. If at any point the pathfinder detects that it is impossible to find
-     * a path with a cost less than or equal to maxCost it will immediately halt the search. The default is Infinity.
+     * The maximum allowed cost of the path returned.
+     *
+     * If at any point the pathfinder detects that it is impossible to find a path with a cost less than or equal to maxCost it will immediately halt the search.
+     * @default Infinity
      */
     maxCost?: number;
     /**
-     * Weight to apply to the heuristic in the A* formula F = G + weight * H. Use this option only if you understand
-     * the underlying A* algorithm mechanics! The default value is 1.
+     * Weight to apply to the heuristic in the A* formula `F = G + weight * H`.
+     *
+     * Use this option only if you understand the underlying A* algorithm mechanics!
+     * @default 1
      */
     heuristicWeight?: number;
 
     /**
-     * Request from the pathfinder to generate a CostMatrix for a certain room. The callback accepts one argument, roomName.
+     * Request from the pathfinder to generate a CostMatrix for a certain room.
+     *
+     * The callback accepts one argument, roomName.
      * This callback will only be called once per room per search. If you are running multiple pathfinding operations in a
-     * single room and in a single tick you may consider caching your CostMatrix to speed up your code. Please read the
-     * CostMatrix documentation below for more information on CostMatrix.
+     * single room and in a single tick you may consider caching your {@link CostMatrix} to speed up your code.
+     * Please read the {@link CostMatrix} documentation below for more information on CostMatrix.
      *
      * @param roomName The name of the room the pathfinder needs a cost matrix for.
      */
@@ -122,6 +139,14 @@ interface CostMatrixConstructor extends _Constructor<CostMatrix> {
 
 /**
  * Container for custom navigation cost data.
+ *
+ * By default PathFinder will only consider terrain data (plain, swamp, wall) — if you need to route around obstacles such as buildings or creeps you must put them into a CostMatrix.
+ *
+ * Generally you will create your CostMatrix from within {@link PathFinderOpts.roomCallback}.
+ * If a non-0 value is found in a room's CostMatrix then that value will be used instead of the default terrain cost.
+ *
+ * You should avoid using large values in your CostMatrix and terrain cost flags.
+ * For example, running {@link PathFinder.search} with `{ plainCost: 1, swampCost: 5 }` is faster than running it with `{plainCost: 2, swampCost: 10 }` even though your paths will be the same.
  */
 interface CostMatrix {
     /**

--- a/src/power-creep.ts
+++ b/src/power-creep.ts
@@ -23,7 +23,7 @@ interface PowerCreep extends RoomObject {
      */
     carryCapacity: number;
     /**
-     * The power creep's class, one of the {@link PowerClassConstant} constants.
+     * The power creep's class, one of the {@link PowerClassConstant POWER_CLASS} constants.
      */
     className: PowerClassConstant;
     /**
@@ -125,14 +125,14 @@ interface PowerCreep extends RoomObject {
     delete(cancel?: boolean): OK | ERR_NOT_OWNER | ERR_BUSY;
     /**
      * Drop this resource on the ground.
-     * @param resourceType One of the {@link ResourceConstant} constants.
+     * @param resourceType One of the {@link ResourceConstant RESOURCE_*} constants.
      * @param amount The amount of resource units to be dropped. If omitted, all the available carried amount is used.
      * @returns One of the following codes:
      * - OK: The operation has been scheduled successfully.
      * - ERR_NOT_OWNER: You are not the owner of this creep.
      * - ERR_BUSY: The power creep is not spawned in the world.
      * - ERR_NOT_ENOUGH_RESOURCES: The creep does not have the given amount of energy.
-     * - ERR_INVALID_ARGS: The resourceType is not a valid {@link ResourceConstant} constants.
+     * - ERR_INVALID_ARGS: The resourceType is not a valid {@link ResourceConstant RESOURCE_*} constants.
      */
     drop(resourceType: ResourceConstant, amount?: number): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_ENOUGH_RESOURCES;
     /**
@@ -151,7 +151,7 @@ interface PowerCreep extends RoomObject {
      * Move the creep one square in the specified direction or towards a creep that is pulling it.
      *
      * Requires the MOVE body part if not being pulled.
-     * @param direction The direction to move in (see {@link DirectionConstant})
+     * @param direction The direction to move in ({@link DirectionConstant `TOP`, `TOP_LEFT`...})
      * @returns One of the following codes:
      * - OK: The operation has been scheduled successfully.
      * - ERR_NOT_OWNER: You are not the owner of this creep.
@@ -288,7 +288,7 @@ interface PowerCreep extends RoomObject {
      *
      * The target has to be at adjacent square to the creep.
      * @param target The target object.
-     * @param resourceType One of the {@link ResourceConstant} constants
+     * @param resourceType One of the {@link ResourceConstant RESOURCE_*} constants
      * @param amount The amount of resources to be transferred. If omitted, all the available carried amount is used.
      * @returns
      * - OK: The operation has been scheduled successfully.
@@ -298,14 +298,14 @@ interface PowerCreep extends RoomObject {
      * - ERR_INVALID_TARGET: The target is not a valid object which can contain the specified resource.
      * - ERR_FULL: The target cannot receive any more resources.
      * - ERR_NOT_IN_RANGE: The target is too far away.
-     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant} constants, or the amount is incorrect.
+     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant RESOURCE_*} constants, or the amount is incorrect.
      */
     transfer(target: AnyCreep | Structure, resourceType: ResourceConstant, amount?: number): ScreepsReturnCode;
     /**
      * Upgrade the creep, adding a new power ability to it or increasing the level of the existing power.
      *
      * You need one free Power Level in your account to perform this action.
-     * @param power	The power ability to upgrade, one of the {@link PowerConstant} constants.
+     * @param power	The power ability to upgrade, one of the {@link PowerConstant PWR_*} constants.
      * @returns
      * - OK: The operation has been scheduled successfully.
      * - ERR_NOT_OWNER: You are not the owner of the creep.
@@ -317,7 +317,7 @@ interface PowerCreep extends RoomObject {
     /**
      * Apply one of the creep's powers on the specified target.
      *
-     * @param power The power ability to use, one of the {@link PowerConstant} constants.
+     * @param power The power ability to use, one of the {@link PowerConstant PWR_*} constants.
      * @param target A target object in the room.
      * @returns
      * - OK: The operation has been scheduled successfully.
@@ -341,7 +341,7 @@ interface PowerCreep extends RoomObject {
      *
      * Your creeps can withdraw resources from hostile structures as well, in case if there is no hostile rampart on top of it.
      * @param target The target object.
-     * @param resourceType The target One of the {@link ResourceConstant} constants..
+     * @param resourceType The target One of the {@link ResourceConstant RESOURCE_*} constants.
      * @param amount The amount of resources to be transferred. If omitted, all the available amount is used.
      * @returns
      * - OK: The operation has been scheduled successfully.
@@ -351,7 +351,7 @@ interface PowerCreep extends RoomObject {
      * - ERR_INVALID_TARGET: The target is not a valid object which can contain the specified resource.
      * - ERR_FULL: The creep's carry is full.
      * - ERR_NOT_IN_RANGE: The target is too far away.
-     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant} constants, or the amount is incorrect.
+     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant RESOURCE_*} constants, or the amount is incorrect.
      */
     withdraw(target: Structure | Tombstone | Ruin, resourceType: ResourceConstant, amount?: number): ScreepsReturnCode;
 }
@@ -365,7 +365,7 @@ interface PowerCreepConstructor extends _Constructor<PowerCreep>, _ConstructorBy
      * You need one free Power Level in your account to perform this action.
      *
      * @param name The name of the power creep.
-     * @param className The class of the new power creep, one of the {@link PowerClassConstant} constants
+     * @param className The class of the new power creep, one of the {@link PowerClassConstant POWER_CLASS} constants
      */
     create(name: string, className: PowerClassConstant): OK | ERR_NAME_EXISTS | ERR_NOT_ENOUGH_RESOURCES;
 }

--- a/src/power-creep.ts
+++ b/src/power-creep.ts
@@ -173,7 +173,7 @@ interface PowerCreep extends RoomObject {
      * - ERR_NOT_FOUND: The specified path doesn't match the creep's location.
      * - ERR_INVALID_ARGS: path is not a valid path array.
      */
-    moveByPath(path: PathStep[] | RoomPosition[] | string): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_FOUND | ERR_INVALID_ARGS;
+    moveByPath(path: PathStep[] | RoomPosition[] | string): CreepMoveReturnCode | ERR_NOT_FOUND | ERR_INVALID_ARGS;
     /**
      * Find the optimal path to the target within the same room and move to it.
      *
@@ -222,7 +222,7 @@ interface PowerCreep extends RoomObject {
      * - ERR_FULL: The creep cannot receive any more resource.
      * - ERR_NOT_IN_RANGE: The target is too far away.
      */
-    pickup(target: Resource): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_FULL | ERR_NOT_IN_RANGE;
+    pickup(target: Resource): CreepActionReturnCode | ERR_FULL;
     /**
      * Rename the power creep.
      *

--- a/src/power-creep.ts
+++ b/src/power-creep.ts
@@ -1,6 +1,15 @@
 /**
  * Power Creeps are immortal "heroes" that are tied to your account and can be respawned in any PowerSpawn after death.
- * You can upgrade their abilities ("powers") up to your account Global Power Level (see `Game.gpl`).
+ *
+ * You can upgrade their abilities ("powers") up to your account Global Power Level (see {@link Game.gpl}).
+ *
+ * |                   |                  |
+ * | ----------------- | ---------------- |
+ * | **Time to live**  | 5,000
+ * | **Hits**          | 1,000 per level
+ * | **Capacity**      | 100 per level
+ *
+ * [Full list of available powers](https://docs.screeps.com/power.html#Powers)
  */
 interface PowerCreep extends RoomObject {
     /**
@@ -14,7 +23,7 @@ interface PowerCreep extends RoomObject {
      */
     carryCapacity: number;
     /**
-     * The power creep's class, one of the `POWER_CLASS` constants.
+     * The power creep's class, one of the {@link PowerClassConstant} constants.
      */
     className: PowerClassConstant;
     /**
@@ -30,7 +39,9 @@ interface PowerCreep extends RoomObject {
      */
     hitsMax: number;
     /**
-     * A unique identifier. You can use `Game.getObjectById` method to retrieve an object instance by its id.
+     * A unique identifier.
+     *
+     * You can use the {@link Game.getObjectById} to retrieve an object instance by its id.
      */
     id: Id<this>;
     /**
@@ -38,7 +49,11 @@ interface PowerCreep extends RoomObject {
      */
     level: number;
     /**
-     * A shorthand to `Memory.powerCreeps[creep.name]`. You can use it for quick access to the creep's specific memory data object.
+     * The power creep's memory.
+     *
+     * A shorthand to `Memory.powerCreeps[creep.name]`.
+     *
+     * You can use it for quick access to the creep's specific memory data object.
      */
     memory: PowerCreepMemory;
     /**
@@ -46,7 +61,10 @@ interface PowerCreep extends RoomObject {
      */
     my: boolean;
     /**
-     * Power creep name. You can choose the name while creating a new power creep, and `rename` it while unspawned. This name is a hash key to access the creep via the `Game.powerCreeps` object.
+     * The power creep name.
+     *
+     * You can choose the name while creating a new power creep, and `rename` it while unspawned.
+     * This name is a hash key to access the creep via the {@link Game.powerCreeps} object.
      */
     name: string;
     /**
@@ -70,90 +88,163 @@ interface PowerCreep extends RoomObject {
      */
     shard: string | undefined;
     /**
-     * The timestamp when spawning or deleting this creep will become available. Undefined if the power creep is spawned in the world.
+     * The timestamp when spawning or deleting this creep will become available.
+     *
+     * Undefined if the power creep is spawned in the world.
+     *
      * Note: This is a timestamp, not ticks as powerCreeps are not shard dependent.
      */
     spawnCooldownTime: number | undefined;
     /**
-     * The remaining amount of game ticks after which the creep will die and become unspawned. Undefined if the creep is not spawned in the world.
+     * The remaining amount of game ticks after which the creep will die and become unspawned.
+     *
+     * Undefined if the creep is not spawned in the world.
      */
     ticksToLive: number | undefined;
     /**
-     *
+     * Cancel the order given during the current game tick.
      * @param methodName Cancel the order given during the current game tick.
+     * @returns One of the following codes:
+     * - OK: The operation has been cancelled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of the creep.
+     * - ERR_BUSY: The power creep is not spawned in the world.
+     * - ERR_NOT_FOUND: The order with the specified name is not found.
      */
     cancelOrder(methodName: string): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_FOUND;
     /**
      * Delete the power creep permanently from your account.
-     * It should NOT be spawned in the world. The creep is not deleted immediately, but a 24-hour delete time is started (see `deleteTime`).
+     *
+     * It should NOT be spawned in the world.
+     * The creep is not deleted immediately, but a 24-hour delete time is started (see {@link PowerCreep.deleteTime}).
      * You can cancel deletion by calling `delete(true)`.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of the creep.
+     * - ERR_BUSY: The power creep is spawned in the world.
      */
     delete(cancel?: boolean): OK | ERR_NOT_OWNER | ERR_BUSY;
     /**
      * Drop this resource on the ground.
-     * @param resourceType One of the RESOURCE_* constants.
+     * @param resourceType One of the {@link ResourceConstant} constants.
      * @param amount The amount of resource units to be dropped. If omitted, all the available carried amount is used.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The power creep is not spawned in the world.
+     * - ERR_NOT_ENOUGH_RESOURCES: The creep does not have the given amount of energy.
+     * - ERR_INVALID_ARGS: The resourceType is not a valid {@link ResourceConstant} constants.
      */
     drop(resourceType: ResourceConstant, amount?: number): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_ENOUGH_RESOURCES;
     /**
-     * Enable power usage in this room. The room controller should be at adjacent tile.
+     * Enable power usage in this room.
+     *
+     * The room controller should be at adjacent tile.
      * @param controller The room controller
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_INVALID_TARGET: The target is not a controller structure.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
      */
     enableRoom(controller: StructureController): OK | ERR_NOT_OWNER | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE;
     /**
      * Move the creep one square in the specified direction or towards a creep that is pulling it.
      *
      * Requires the MOVE body part if not being pulled.
-     * @param direction The direction to move in (`TOP`, `TOP_LEFT`...)
+     * @param direction The direction to move in (see {@link DirectionConstant})
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The power creep is not spawned in the world.
+     * - ERR_NOT_IN_RANGE: The target creep is too far away
+     * - ERR_INVALID_ARGS: The provided direction is incorrect.
      */
     move(direction: DirectionConstant): CreepMoveReturnCode;
     move(target: Creep): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_IN_RANGE | ERR_INVALID_ARGS;
     /**
-     * Move the creep using the specified predefined path. Needs the MOVE body part.
-     * @param path A path value as returned from Room.findPath or RoomPosition.findPathTo methods. Both array form and serialized string form are accepted.
+     * Move the creep using the specified predefined path.
+     *
+     * @param path A path value as returned from {@link Room.findPath} or {@link RoomPosition.findPathTo} methods.
+     * Both array form and serialized string form are accepted.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The power creep is not spawned in the world.
+     * - ERR_NOT_FOUND: The specified path doesn't match the creep's location.
+     * - ERR_INVALID_ARGS: path is not a valid path array.
      */
-    moveByPath(path: PathStep[] | RoomPosition[] | string): CreepMoveReturnCode | ERR_NOT_FOUND | ERR_INVALID_ARGS;
+    moveByPath(path: PathStep[] | RoomPosition[] | string): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_FOUND | ERR_INVALID_ARGS;
     /**
      * Find the optimal path to the target within the same room and move to it.
-     * A shorthand to consequent calls of pos.findPathTo() and move() methods.
+     *
+     * A shorthand to consequent calls of {@link RoomPosition.findPathTo()} and {@link Creep.move()} methods.
      * If the target is in another room, then the corresponding exit will be used as a target.
      *
-     * Needs the MOVE body part.
      * @param x X position of the target in the room.
      * @param y Y position of the target in the room.
-     * @param opts An object containing pathfinding options flags (see Room.findPath for more info) or one of the following: reusePath, serializeMemory, noPathFinding
-     */
-    moveTo(x: number, y: number, opts?: MoveToOpts): CreepMoveReturnCode | ERR_NO_PATH | ERR_INVALID_TARGET;
-    /**
-     * Find the optimal path to the target within the same room and move to it.
-     * A shorthand to consequent calls of pos.findPathTo() and move() methods.
-     * If the target is in another room, then the corresponding exit will be used as a target.
-     *
-     * Needs the MOVE body part.
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
-     * @param opts An object containing pathfinding options flags (see Room.findPath for more info) or one of the following: reusePath, serializeMemory, noPathFinding
+     * @param opts An object containing pathfinding options flags (see {@link Room.findPath} for more info) or one of the following: reusePath, serializeMemory, noPathFinding
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_NO_PATH: No path to the target could be found.
+     * - ERR_BUSY: The power creep is not spawned in the world.
+     * - ERR_NOT_FOUND: The creep has no memorized path to reuse.
+     * - ERR_INVALID_TARGET: The target provided is invalid.
      */
+    moveTo(x: number, y: number, opts?: MoveToOpts): OK | ERR_NOT_OWNER | ERR_NO_PATH | ERR_BUSY | ERR_NOT_FOUND | ERR_INVALID_TARGET;
     moveTo(
         target: RoomPosition | { pos: RoomPosition },
         opts?: MoveToOpts,
     ): CreepMoveReturnCode | ERR_NO_PATH | ERR_INVALID_TARGET | ERR_NOT_FOUND;
     /**
-     * Toggle auto notification when the creep is under attack. The notification will be sent to your account email. Turned on by default.
+     * Toggle auto notification when the creep is under attack.
+     *
+     * The notification will be sent to your account email. Turned on by default.
      * @param enabled Whether to enable notification or disable.
+     * * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The power creep is not spawned in the world.
+     * - ERR_INVALID_ARGS: enable argument is not a boolean value.
      */
     notifyWhenAttacked(enabled: boolean): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_ARGS;
     /**
-     * Pick up an item (a dropped piece of energy). Needs the CARRY body part. The target has to be at adjacent square to the creep or at the same square.
+     * Pick up an item (a dropped piece of energy).
+     *
+     * The target has to be at adjacent square to the creep or at the same square.
      * @param target The target object to be picked up.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The power creep is not spawned in the world.
+     * - ERR_INVALID_TARGET: The target is not a valid object to pick up.
+     * - ERR_FULL: The creep cannot receive any more resource.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
      */
-    pickup(target: Resource): CreepActionReturnCode | ERR_FULL;
+    pickup(target: Resource): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_FULL | ERR_NOT_IN_RANGE;
     /**
-     * Rename the power creep. It must not be spawned in the world.
+     * Rename the power creep.
+     *
+     * It must not be spawned in the world.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of the creep.
+     * - ERR_NAME_EXISTS: A power creep with the specified name already exists.
+     * - ERR_BUSY: The power creep is spawned in the world.
      */
     rename(name: string): OK | ERR_NOT_OWNER | ERR_NAME_EXISTS | ERR_BUSY;
     /**
-     * Instantly restore time to live to the maximum using a Power Spawn or a Power Bank nearby. It has to be at adjacent tile.
+     * Instantly restore time to live to the maximum using a Power Spawn or a Power Bank nearby.
+     *
+     * It has to be at adjacent tile.
      * @param target The target structure
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The power creep is not spawned in the world.
+     * - ERR_INVALID_TARGET: The target is not a valid power bank or power spawn.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
      */
     renew(target: StructurePowerBank | StructurePowerSpawn): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_NOT_IN_RANGE;
     /**
@@ -164,30 +255,81 @@ interface PowerCreep extends RoomObject {
      * Only the creep's owner can see the speech message unless toPublic is true.
      * @param message The message to be displayed. Maximum length is 10 characters.
      * @param set to 'true' to allow other players to see this message. Default is 'false'.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The power creep is not spawned in the world.
      */
     say(message: string, toPublic?: boolean): OK | ERR_NOT_OWNER | ERR_BUSY;
     /**
      * Spawn this power creep in the specified Power Spawn.
      * @param powerSpawn Your Power Spawn structure
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of the creep or the spawn.
+     * - ERR_BUSY: The power creep is already spawned in the world.
+     * - ERR_INVALID_TARGET: The specified object is not a Power Spawn.
+     * - ERR_TIRED: The power creep cannot be spawned because of the cooldown.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use the spawn.
      */
     spawn(powerSpawn: StructurePowerSpawn): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_INVALID_TARGET | ERR_TIRED | ERR_RCL_NOT_ENOUGH;
     /**
-     * Kill the power creep immediately. It will not be destroyed permanently, but will become unspawned, so that you can `spawn` it again.
+     * Kill the power creep immediately.
+     *
+     * It will not be destroyed permanently, but will become unspawned, so that you can `spawn` it again.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The power creep is not spawned in the world.
      */
     suicide(): OK | ERR_NOT_OWNER | ERR_BUSY;
     /**
-     * Transfer resource from the creep to another object. The target has to be at adjacent square to the creep.
+     * Transfer resource from the creep to another object.
+     *
+     * The target has to be at adjacent square to the creep.
      * @param target The target object.
-     * @param resourceType One of the RESOURCE_* constants
+     * @param resourceType One of the {@link ResourceConstant} constants
      * @param amount The amount of resources to be transferred. If omitted, all the available carried amount is used.
+     * @returns
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep.
+     * - ERR_BUSY: The power creep is not spawned in the world.
+     * - ERR_NOT_ENOUGH_RESOURCES: The creep does not have the given amount of resources.
+     * - ERR_INVALID_TARGET: The target is not a valid object which can contain the specified resource.
+     * - ERR_FULL: The target cannot receive any more resources.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant} constants, or the amount is incorrect.
      */
     transfer(target: AnyCreep | Structure, resourceType: ResourceConstant, amount?: number): ScreepsReturnCode;
     /**
-     * Upgrade the creep, adding a new power ability to it or increasing the level of the existing power. You need one free Power Level in your account to perform this action.
+     * Upgrade the creep, adding a new power ability to it or increasing the level of the existing power.
+     *
+     * You need one free Power Level in your account to perform this action.
+     * @param power	The power ability to upgrade, one of the {@link PowerConstant} constants.
+     * @returns
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of the creep.
+     * - ERR_NOT_ENOUGH_RESOURCES: You account Power Level is not enough.
+     * - ERR_FULL: The specified power cannot be upgraded on this creep's level, or the creep reached the maximum level.
+     * - ERR_INVALID_ARGS: The specified power ID is not valid.
      */
     upgrade(power: PowerConstant): OK | ERR_NOT_OWNER | ERR_NOT_ENOUGH_RESOURCES | ERR_FULL | ERR_INVALID_ARGS;
     /**
      * Apply one of the creep's powers on the specified target.
+     *
+     * @param power The power ability to use, one of the {@link PowerConstant} constants.
+     * @param target A target object in the room.
+     * @returns
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of the creep.
+     * - ERR_BUSY: The creep is not spawned in the world.
+     * - ERR_NOT_ENOUGH_RESOURCES: The creep doesn't have enough resources to use the power.
+     * - ERR_INVALID_TARGET: The specified target is not valid.
+     * - ERR_FULL: The target has the same active effect of a higher level.
+     * - ERR_NOT_IN_RANGE: The specified target is too far away.
+     * - ERR_INVALID_ARGS: Using powers is not enabled on the Room Controller.
+     * - ERR_TIRED: The power ability is still on cooldown.
+     * - ERR_NO_BODYPART: The creep doesn't have the specified power ability.
      */
     usePower(power: PowerConstant, target?: RoomObject): ScreepsReturnCode;
     /**
@@ -199,21 +341,31 @@ interface PowerCreep extends RoomObject {
      *
      * Your creeps can withdraw resources from hostile structures as well, in case if there is no hostile rampart on top of it.
      * @param target The target object.
-     * @param resourceType The target One of the RESOURCE_* constants..
+     * @param resourceType The target One of the {@link ResourceConstant} constants..
      * @param amount The amount of resources to be transferred. If omitted, all the available amount is used.
+     * @returns
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this creep, or there is a hostile rampart on top of the target.
+     * - ERR_BUSY: The power creep is not spawned in the world.
+     * - ERR_NOT_ENOUGH_RESOURCES: The target does not have the given amount of resources.
+     * - ERR_INVALID_TARGET: The target is not a valid object which can contain the specified resource.
+     * - ERR_FULL: The creep's carry is full.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_INVALID_ARGS: The resourceType is not one of the {@link ResourceConstant} constants, or the amount is incorrect.
      */
     withdraw(target: Structure | Tombstone | Ruin, resourceType: ResourceConstant, amount?: number): ScreepsReturnCode;
 }
 
 interface PowerCreepConstructor extends _Constructor<PowerCreep>, _ConstructorById<PowerCreep> {
     /**
-     * A static method to create new Power Creep instance in your account. It will be added in an unspawned state,
-     * use spawn method to spawn it in the world.
+     * A static method to create new Power Creep instance in your account.
+     *
+     * It will be added in an unspawned state, use the {@link PowerCreep.spawn} method to spawn it in the world.
      *
      * You need one free Power Level in your account to perform this action.
      *
      * @param name The name of the power creep.
-     * @param className The class of the new power creep, one of the `POWER_CLASS` constants
+     * @param className The class of the new power creep, one of the {@link PowerClassConstant} constants
      */
     create(name: string, className: PowerClassConstant): OK | ERR_NAME_EXISTS | ERR_NOT_ENOUGH_RESOURCES;
 }
@@ -230,7 +382,9 @@ interface PowerCreepPowers {
          */
         level: number;
         /**
-         * Cooldown ticks remaining, or undefined if the power creep is not spawned in the world.
+         * Cooldown ticks remaining
+         *
+         * Will be undefined if the power creep is not spawned in the world.
          */
         cooldown: number | undefined;
     };

--- a/src/raw-memory.ts
+++ b/src/raw-memory.ts
@@ -1,15 +1,21 @@
 /**
  * RawMemory object allows to implement your own memory stringifier instead of built-in serializer based on JSON.stringify.
+ *
+ * It also allows to request up to 10 MB of additional memory using asynchronous memory segments feature.
+ *
+ * You can also access memory segments of other players using methods below.
  */
 interface RawMemory {
     /**
-     * An object with asynchronous memory segments available on this tick. Each object key is the segment ID with data in string values.
-     * Use RawMemory.setActiveSegments to fetch segments on the next tick. Segments data is saved automatically in the end of the tick.
+     * An object with asynchronous memory segments available on this tick.
+     *
+     * Each object key is the segment ID with data in string values.
+     * Use {@link RawMemory.setActiveSegments} to fetch segments on the next tick. Segments data is saved automatically in the end of the tick.
      */
     segments: { [segmentId: number]: string };
 
     /**
-     * An object with a memory segment of another player available on this tick. Use `setActiveForeignSegment` to fetch segments on the next tick.
+     * An object with a memory segment of another player available on this tick. Use {@link RawMemory.setActiveForeignSegment} to fetch segments on the next tick.
      */
     foreignSegment: {
         username: string;
@@ -37,36 +43,50 @@ interface RawMemory {
     /**
      * Set new memory value.
      * @param value New memory value as a string.
+     * @throws if the new value is not a string or contains more than `2 * 1024 * 1024` characters.
      */
     set(value: string): undefined;
     /**
-     * Request memory segments using the list of their IDs. Memory segments will become available on the next tick in RawMemory.segments object.
-     * @param ids An array of segment IDs. Each ID should be a number from 0 to 99. Maximum 10 segments can be active at the same time. Subsequent calls of setActiveSegments override previous ones.
+     * Request memory segments using the list of their IDs.
+     *
+     * Memory segments will become available on the next tick in {@link RawMemory.segments} object.
+     * Segment IDs are a number from 0 to 99. A maximum of 10 segments can be active at the same time.
+     * Subsequent calls to {@link RawMemory.setActiveSegments} overrides previous ones.
+     *
+     * @param ids An array of segment IDs.
+     * @throws if `ids` isn't an array, more than 10 segments are active, or the ids aren't all integers.
      */
     setActiveSegments(ids: number[]): undefined;
     /**
      * Request a memory segment of another user.
      *
-     * The segment should be marked by its owner as public using `setPublicSegments`.
+     * The segment should be marked by its owner as public using {@link RawMemory.setPublicSegments}.
      *
-     * The segment data will become available on the next tick in `foreignSegment` object.
+     * The segment data will become available on the next tick in {@link foreignSegment} object.
      *
      * You can only have access to one foreign segment at the same time.
      *
      * @param username The name of another user. Pass `null` to clear the foreign segment.
-     * @param id The ID of the requested segment from 0 to 99. If undefined, the user's default public segment is requested as set by `setDefaultPublicSegment`.
+     * @param id The ID of the requested segment from 0 to 99. If undefined, the user's default public segment is requested as set by {@link RawMemory.setDefaultPublicSegment}.
+     * @throws if `id` is passed and isn't an integer.
      */
     setActiveForeignSegment(username: string | null, id?: number): undefined;
     /**
-     * Set the specified segment as your default public segment. It will be returned if no id parameter is passed to `setActiveForeignSegment` by another user.
+     * Set the specified segment as your default public segment.
+     *
+     * It will be returned if no id parameter is passed to {@link RawMemory.setActiveForeignSegment} by another user.
      *
      * @param id The ID of the requested segment from 0 to 99. Pass `null` to clear the foreign segment.
+     * @throws if `id` is passed and isn't an integer.
      */
     setDefaultPublicSegment(id: number | null): undefined;
     /**
-     * Set specified segments as public. Other users will be able to request access to them using `setActiveForeignSegment`.
+     * Set specified segments as public.
      *
-     * @param ids An array of segment IDs. Each ID should be a number from 0 to 99. Subsequent calls of `setPublicSegments` override previous ones.
+     * Other users will be able to request access to them using {@link setActiveForeignSegment}.
+     *
+     * @param ids An array of segment IDs. Each ID should be a number from 0 to 99. Subsequent calls of {@link RawMemory.setPublicSegments} override previous ones.
+     * @throws if `ids` isn't an array or the ids aren't all integers.
      */
     setPublicSegments(ids: number[]): undefined;
 }

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -19,7 +19,7 @@ interface Resource<T extends ResourceConstant = ResourceConstant> extends RoomOb
      */
     id: Id<this>;
     /**
-     * One of the {@link ResourceConstant} constants.
+     * One of the {@link ResourceConstant RESOURCE_*} constants.
      */
     resourceType: T;
 }

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -1,5 +1,8 @@
 /**
- * A dropped piece of resource. It will decay after a while if not picked up. Dropped resource pile decays for ceil(amount/1000) units per tick.
+ * A dropped piece of resource.
+ *
+ * It will decay after a while if not picked up.
+ * Dropped resource pile decays for `ceil(amount/1000)` units per tick.
  */
 
 interface Resource<T extends ResourceConstant = ResourceConstant> extends RoomObject {
@@ -10,11 +13,13 @@ interface Resource<T extends ResourceConstant = ResourceConstant> extends RoomOb
      */
     amount: number;
     /**
-     * A unique object identifier. You can use `Game.getObjectById` method to retrieve an object instance by its `id`.
+     * A unique object identifier.
+     *
+     * You can use {@link Game.getObjectById} to retrieve an object instance by its `id`.
      */
     id: Id<this>;
     /**
-     * One of the `RESOURCE_*` constants.
+     * One of the {@link ResourceConstant} constants.
      */
     resourceType: T;
 }

--- a/src/room-object.ts
+++ b/src/room-object.ts
@@ -1,12 +1,13 @@
 /**
- * Any object with a position in a room. Almost all game objects prototypes
- * are derived from RoomObject.
+ * Any object with a position in a room.
+ *
+ * Almost all game objects prototypes are derived from RoomObject.
  */
 
 interface RoomObject {
     readonly prototype: RoomObject;
     /**
-     * Applied effects, an array of objects with the following properties:
+     * Effects currently being applied to the object.
      */
     effects?: RoomObjectEffect[];
     /**
@@ -14,8 +15,9 @@ interface RoomObject {
      */
     pos: RoomPosition;
     /**
-     * The link to the Room object. May be undefined in case if an object is a
-     * flag or a construction site and is placed in a room that is not visible
+     * The link to the {@link Room} object.
+     *
+     * May be `undefined` if the object is a {@link Flag} or a {@link ConstructionSite} and is placed in a room that is not visible
      * to you.
      */
     room: Room | undefined;
@@ -38,7 +40,9 @@ type RoomObjectEffect = NaturalEffect | PowerEffect;
  */
 interface NaturalEffect {
     /**
-     * Effect ID of the applied effect. `EFFECT_*` constant.
+     * Effect ID of the applied effect.
+     *
+     * One of the {@link EffectConstant} constants.
      */
     effect: EffectConstant;
     /**
@@ -48,7 +52,7 @@ interface NaturalEffect {
 }
 
 /**
- * Effect applied to room object as result of a `PowerCreep.usePower`.
+ * Effect applied to room object as result of a {@link PowerCreep.usePower}.
  */
 interface PowerEffect {
     /**
@@ -56,11 +60,17 @@ interface PowerEffect {
      */
     level: number;
     /**
-     * Effect ID of the applied effect. `PWR_*` constant.
+     * Effect ID of the applied effect.
+     *
+     * One of the {@link PowerConstant} constants.
      */
     effect: PowerConstant;
     /**
-     * @deprecated Power ID of the applied effect. `PWR_*` constant. No longer documented, will be removed.
+     * Power ID of the applied effect.
+     *
+     * @deprecated Use {@link PowerEffect.effect} instead.
+     *
+     * One of the {@link PowerConstant} constants.
      */
     power: PowerConstant;
     /**

--- a/src/room-object.ts
+++ b/src/room-object.ts
@@ -42,7 +42,7 @@ interface NaturalEffect {
     /**
      * Effect ID of the applied effect.
      *
-     * One of the {@link EffectConstant} constants.
+     * One of the {@link EffectConstant EFFECT_*} constants.
      */
     effect: EffectConstant;
     /**
@@ -62,7 +62,7 @@ interface PowerEffect {
     /**
      * Effect ID of the applied effect.
      *
-     * One of the {@link PowerConstant} constants.
+     * One of the {@link PowerConstant PWR_*} constants.
      */
     effect: PowerConstant;
     /**
@@ -70,7 +70,7 @@ interface PowerEffect {
      *
      * @deprecated Use {@link PowerEffect.effect} instead.
      *
-     * One of the {@link PowerConstant} constants.
+     * One of the {@link PowerConstant PWR_*} constants.
      */
     power: PowerConstant;
     /**

--- a/src/room-position.ts
+++ b/src/room-position.ts
@@ -22,7 +22,7 @@ interface RoomPosition {
     y: number;
     /**
      * Create a new {@link ConstructionSite} at the specified location.
-     * @param structureType One of {@link BuildableStructureConstant}.
+     * @param structureType One of {@link BuildableStructureConstant Buildable STRUCTURE_*}.
      * @returns
      * - OK: The operation has been scheduled successfully.
      * - ERR_NOT_OWNER: You don't have ownership of the targetted room.
@@ -34,7 +34,7 @@ interface RoomPosition {
     createConstructionSite(structureType: BuildableStructureConstant): ScreepsReturnCode;
     /**
      * Create a new {@link ConstructionSite} at the specified location.
-     * @param structureType One of {@link BuildableStructureConstant}.
+     * @param structureType One of {@link BuildableStructureConstant Buildable STRUCTURE_*}.
      * @param name The name of the structure, for structures that support it (currently only spawns). The name length limit is 100 characters.
      * @returns
      * - OK: The operation has been scheduled successfully.
@@ -50,8 +50,8 @@ interface RoomPosition {
      * @param name The name of a new flag.
      * It should be unique, i.e. the Game.flags object should not contain another flag with the same name (hash key).
      * If not defined, a random name will be generated.
-     * @param color The color of a new flag. Should be one of the {@link ColorConstant} constants
-     * @param secondaryColor The secondary color of a new flag. Should be one of the {@link ColorConstant} constants. The default value is equal to color.
+     * @param color The color of a new flag. Should be one of the {@link ColorConstant COLOR_*} constants
+     * @param secondaryColor The secondary color of a new flag. Should be one of the {@link ColorConstant COLOR_*} constants. The default value is equal to color.
      * @returns The name of the flag if created, or one of the following error codes: ERR_NAME_EXISTS, ERR_INVALID_ARGS
      */
     createFlag(name?: string, color?: ColorConstant, secondaryColor?: ColorConstant): ERR_NAME_EXISTS | ERR_INVALID_ARGS | string;
@@ -59,7 +59,7 @@ interface RoomPosition {
      * Find the object with the shortest path from the given position.
      *
      * Uses A* search algorithm and Dijkstra's algorithm.
-     * @param type Any of the {@link FindConstant} constants.
+     * @param type Any of the {@link FindConstant FIND_*} constants.
      * @param opts An object containing pathfinding options (see {@link Room.findPath}), or one of the following: filter, algorithm
      * @returns An instance of a RoomObject.
      */
@@ -88,7 +88,7 @@ interface RoomPosition {
     ): S | null;
     /**
      * Find the object with the shortest linear distance from the given position.
-     * @param type Any of the {@link FindConstant} constants.
+     * @param type Any of the {@link FindConstant FIND_*} constants.
      * @param opts An object containing pathfinding options (see {@link Room.findPath}), or one of the following: filter, algorithm
      */
     findClosestByRange<K extends FindConstant, S extends FindTypes[K]>(type: K, opts?: FilterOptions<FindTypes[K], S>): S | null;
@@ -104,7 +104,7 @@ interface RoomPosition {
     findClosestByRange<T extends _HasRoomPosition | RoomPosition, S extends T = T>(objects: T[], opts?: FilterOptions<T, S>): S | null;
     /**
      * Find all objects in the specified linear range.
-     * @param type Any of the {@link FindConstant} constants.
+     * @param type Any of the {@link FindConstant FIND_*} constants.
      * @param range The range distance.
      * @param opts See Room.find.
      */

--- a/src/room-position.ts
+++ b/src/room-position.ts
@@ -1,9 +1,9 @@
 /**
  * An object representing the specified position in the room.
  *
- * Every object in the room contains RoomPosition as the pos property.
+ * Every object in the room contains one of these as its `pos` property.
  *
- * The position object of a custom location can be obtained using the Room.getPositionAt() method or using the constructor.
+ * The position object of a custom location can be obtained using the {@link Room.getPositionAt()} method or using the constructor.
  */
 interface RoomPosition {
     readonly prototype: RoomPosition;
@@ -21,42 +21,46 @@ interface RoomPosition {
      */
     y: number;
     /**
-     * Create new ConstructionSite at the specified location.
-     * @param structureType One of the following constants:
-     *  * STRUCTURE_EXTENSION
-     *  * STRUCTURE_RAMPART
-     *  * STRUCTURE_ROAD
-     *  * STRUCTURE_SPAWN
-     *  * STRUCTURE_WALL
-     *  * STRUCTURE_LINK
+     * Create a new {@link ConstructionSite} at the specified location.
+     * @param structureType One of {@link BuildableStructureConstant}.
+     * @returns
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You don't have ownership of the targetted room.
+     * - ERR_INVALID_TARGET: The structure cannot be placed at the specified location.
+     * - ERR_FULL: You have too many construction sites. The maximum number of construction sites per player is 100.
+     * - ERR_INVALID_ARGS: The location is incorrect.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient.
      */
     createConstructionSite(structureType: BuildableStructureConstant): ScreepsReturnCode;
     /**
-     * Create new ConstructionSite at the specified location.
-     * @param structureType One of the following constants:
-     *  * STRUCTURE_EXTENSION
-     *  * STRUCTURE_RAMPART
-     *  * STRUCTURE_ROAD
-     *  * STRUCTURE_SPAWN
-     *  * STRUCTURE_WALL
-     *  * STRUCTURE_LINK
-     * @param name The name of the structure, for structures that support it (currently only spawns).
+     * Create a new {@link ConstructionSite} at the specified location.
+     * @param structureType One of {@link BuildableStructureConstant}.
+     * @param name The name of the structure, for structures that support it (currently only spawns). The name length limit is 100 characters.
+     * @returns
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You don't have ownership of the targetted room.
+     * - ERR_INVALID_TARGET: The structure cannot be placed at the specified location.
+     * - ERR_FULL: You have too many construction sites. The maximum number of construction sites per player is 100.
+     * - ERR_INVALID_ARGS: The location is incorrect.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient.
      */
     createConstructionSite(structureType: STRUCTURE_SPAWN, name?: string): ScreepsReturnCode;
     /**
-     * Create new Flag at the specified location.
+     * Create a new {@link Flag} at the specified location.
      * @param name The name of a new flag.
      * It should be unique, i.e. the Game.flags object should not contain another flag with the same name (hash key).
      * If not defined, a random name will be generated.
-     * @param color The color of a new flag. Should be one of the COLOR_* constants
-     * @param secondaryColor The secondary color of a new flag. Should be one of the COLOR_* constants. The default value is equal to color.
+     * @param color The color of a new flag. Should be one of the {@link ColorConstant} constants
+     * @param secondaryColor The secondary color of a new flag. Should be one of the {@link ColorConstant} constants. The default value is equal to color.
      * @returns The name of the flag if created, or one of the following error codes: ERR_NAME_EXISTS, ERR_INVALID_ARGS
      */
     createFlag(name?: string, color?: ColorConstant, secondaryColor?: ColorConstant): ERR_NAME_EXISTS | ERR_INVALID_ARGS | string;
     /**
-     * Find the object with the shortest path from the given position. Uses A* search algorithm and Dijkstra's algorithm.
-     * @param type Any of the FIND_* constants.
-     * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
+     * Find the object with the shortest path from the given position.
+     *
+     * Uses A* search algorithm and Dijkstra's algorithm.
+     * @param type Any of the {@link FindConstant} constants.
+     * @param opts An object containing pathfinding options (see {@link Room.findPath}), or one of the following: filter, algorithm
      * @returns An instance of a RoomObject.
      */
     findClosestByPath<K extends FindConstant, S extends FindTypes[K]>(
@@ -68,9 +72,11 @@ interface RoomPosition {
         opts?: FindPathOpts & FilterOptions<FindTypes[FIND_STRUCTURES], S> & { algorithm?: FindClosestByPathAlgorithm },
     ): S | null;
     /**
-     * Find the object with the shortest path from the given position. Uses A* search algorithm and Dijkstra's algorithm.
+     * Find the object with the shortest path from the given position.
+     *
+     * Uses A* search algorithm and Dijkstra's algorithm.
      * @param objects An array of RoomPositions or objects with a RoomPosition
-     * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
+     * @param opts An object containing pathfinding options (see {@link Room.findPath}), or one of the following: filter, algorithm
      * @returns One of the supplied objects
      */
     findClosestByPath<T extends _HasRoomPosition | RoomPosition, S extends T = T>(
@@ -82,8 +88,8 @@ interface RoomPosition {
     ): S | null;
     /**
      * Find the object with the shortest linear distance from the given position.
-     * @param type Any of the FIND_* constants.
-     * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
+     * @param type Any of the {@link FindConstant} constants.
+     * @param opts An object containing pathfinding options (see {@link Room.findPath}), or one of the following: filter, algorithm
      */
     findClosestByRange<K extends FindConstant, S extends FindTypes[K]>(type: K, opts?: FilterOptions<FindTypes[K], S>): S | null;
     findClosestByRange<S extends AnyStructure>(
@@ -93,12 +99,12 @@ interface RoomPosition {
     /**
      * Find the object with the shortest linear distance from the given position.
      * @param objects An array of RoomPositions or objects with a RoomPosition.
-     * @param opts An object containing pathfinding options (see Room.findPath), or one of the following: filter, algorithm
+     * @param opts An object containing pathfinding options (see {@link Room.findPath}), or one of the following: filter, algorithm
      */
     findClosestByRange<T extends _HasRoomPosition | RoomPosition, S extends T = T>(objects: T[], opts?: FilterOptions<T, S>): S | null;
     /**
      * Find all objects in the specified linear range.
-     * @param type Any of the FIND_* constants.
+     * @param type Any of the {@link FindConstant} constants.
      * @param range The range distance.
      * @param opts See Room.find.
      */
@@ -112,24 +118,24 @@ interface RoomPosition {
      * Find all objects in the specified linear range.
      * @param objects An array of room's objects or RoomPosition objects that the search should be executed against.
      * @param range The range distance.
-     * @param opts See Room.find.
+     * @param opts See {@link Room.find}.
      */
     findInRange<T extends _HasRoomPosition | RoomPosition, S extends T = T>(objects: T[], range: number, opts?: FilterOptions<T, S>): S[];
     /**
      * Find an optimal path to the specified position using A* search algorithm.
      *
-     * This method is a shorthand for Room.findPath. If the target is in another room, then the corresponding exit will be used as a target.
+     * This method is a shorthand for {@link Room.findPath}. If the target is in another room, then the corresponding exit will be used as a target.
      * @param x X position in the room.
      * @param y Y position in the room.
-     * @param opts An object containing pathfinding options flags (see Room.findPath for more details).
+     * @param opts An object containing pathfinding options flags (see {@link Room.findPath} for more details).
      */
     findPathTo(x: number, y: number, opts?: FindPathOpts): PathStep[];
     /**
      * Find an optimal path to the specified position using A* search algorithm.
      *
-     * This method is a shorthand for Room.findPath. If the target is in another room, then the corresponding exit will be used as a target.
+     * This method is a shorthand for {@link Room.findPath}. If the target is in another room, then the corresponding exit will be used as a target.
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
-     * @param opts An object containing pathfinding options flags (see Room.findPath for more details).
+     * @param opts An object containing pathfinding options flags (see {@link Room.findPath} for more details).
      */
     findPathTo(target: RoomPosition | _HasRoomPosition, opts?: FindPathOpts): PathStep[];
     /**
@@ -179,13 +185,17 @@ interface RoomPosition {
      */
     isEqualTo(target: RoomPosition | { pos: RoomPosition }): boolean;
     /**
-     * Check whether this position is on the adjacent square to the specified position. The same as inRangeTo(target, 1).
+     * Check whether this position is on the adjacent square to the specified position.
+     *
+     * Equivalent to `inRangeTo(target, 1)`.
      * @param x X position in the room.
      * @param y Y position in the room.
      */
     isNearTo(x: number, y: number): boolean;
     /**
-     * Check whether this position is on the adjacent square to the specified position. The same as inRangeTo(target, 1).
+     * Check whether this position is on the adjacent square to the specified position.
+     *
+     * Equivalent to inRangeTo(target, 1).
      * @param target Can be a RoomPosition object or any object containing RoomPosition.
      */
     isNearTo(target: RoomPosition | { pos: RoomPosition }): boolean;
@@ -206,6 +216,7 @@ interface RoomPositionConstructor extends _Constructor<RoomPosition> {
      * @param x X position in the room.
      * @param y Y position in the room.
      * @param roomName The room name.
+     * @throws if `x` or `y` are out of bounds, or `roomName` isn't a valid room name.
      */
     new (x: number, y: number, roomName: string): RoomPosition;
     (x: number, y: number, roomName: string): RoomPosition;

--- a/src/room-terrain.ts
+++ b/src/room-terrain.ts
@@ -1,16 +1,22 @@
 /**
- * Result of Object that contains all terrain for a room
+ * An object which provides fast access to room terrain data.
+ *
+ * These objects can be constructed for any room in the world even if you have no access to it.
+ *
+ * Technically every Room.Terrain object is a very lightweight adapter to underlying static terrain buffers with corresponding minimal accessors.
  */
 interface RoomTerrain {
     /**
-     * Get terrain type at the specified room position. This method works for any room in the world even if you have no access to it.
+     * Get terrain type at the specified room position.
+     *
+     * This method works for any room in the world even if you have no access to it.
      * @param x X position in the room.
      * @param y Y position in the room.
-     * @return number Number of terrain mask like: TERRAIN_MASK_SWAMP | TERRAIN_MASK_WALL
+     * @return A bitmask of {@link TERRAIN_MASK_WALL}, {@link TERRAIN_MASK_SWAMP}.
      */
     get(x: number, y: number): 0 | TERRAIN_MASK_WALL | TERRAIN_MASK_SWAMP;
     /**
-     * Get copy of underlying static terrain buffer.
+     * Get a copy of the underlying static terrain buffer.
      * @param destinationArray (optional) A typed array view in which terrain will be copied to.
      * @throws {RangeError} if `destinationArray` is provided, it must have a length of at least 2500 (`50*50`).
      * @return Copy of underlying room terrain as a new typed array of size 2500.
@@ -34,7 +40,9 @@ interface RoomTerrain {
 
 interface RoomTerrainConstructor extends _Constructor<RoomTerrain> {
     /**
-     * Get room terrain for the specified room. This method works for any room in the world even if you have no access to it.
+     * Get room terrain for the specified room.
+     *
+     * This method works for any room in the world even if you have no access to it.
      * @param roomName String name of the room.
      */
     new (roomName: string): RoomTerrain;

--- a/src/room-visual.ts
+++ b/src/room-visual.ts
@@ -1,3 +1,16 @@
+/**
+ * Room visuals provide a way to show various visual debug info in game rooms.
+ *
+ * You can use the RoomVisual object to draw simple shapes that are visible only to you.
+ * Every existing Room object already contains the visual property, but you also can create new RoomVisual objects for any room (even without visibility) using the constructor.
+ *
+ * Room visuals are not stored in the database, their only purpose is to display something in your browser.
+ * All drawings will persist for one tick and will disappear if not updated. All RoomVisual API calls have no added CPU cost (their cost is natural and mostly related to simple `JSON.serialize` calls).
+ * However, there is a usage limit: you cannot post more than 500 KB of serialized data per one room (see {@link RoomVisual.getSize} method).
+ *
+ * All draw coordinates are measured in game coordinates and centered to tile centers, i.e. (10,10) will point to the center of the creep at x:10; y:10 position.
+ * Fractional coordinates are allowed.
+ */
 declare class RoomVisual {
     /**
      * You can create new RoomVisual object using its constructor.
@@ -86,7 +99,9 @@ declare class RoomVisual {
     text(text: string, x: number, y: number, style?: TextStyle): RoomVisual;
 
     /**
-     * Draw a text label. You can use any valid Unicode characters, including emoji.
+     * Draw a text label.
+     *
+     * You can use any valid Unicode characters, including emoji.
      * @param text The text message.
      * @param pos The position object of the center.
      * @param style An object describing the style.
@@ -114,7 +129,7 @@ declare class RoomVisual {
     export(): string;
 
     /**
-     * Add previously exported (with `RoomVisual.export`) room visuals to the room visual data of the current tick.
+     * Add previously exported (with {@link RoomVisual.export}) room visuals to the room visual data of the current tick.
      * @param data The string returned from `RoomVisual.export`.
      * @returns The RoomVisual object itself, so that you can chain calls.
      */
@@ -123,26 +138,31 @@ declare class RoomVisual {
 
 interface LineStyle {
     /**
-     * Line width, default is 0.1.
+     * Line width.
+     * @default 0.1
      */
     width?: number;
     /**
-     * Line color in any web format, default is #ffffff(white).
+     * Line color in any web format.
+     * @default #ffffff (white)
      */
     color?: string;
     /**
-     * Opacity value, default is 0.5.
+     * Opacity value.
+     * @default 0.5
      */
     opacity?: number;
     /**
-     * Either undefined (solid line), dashed, or dotted.Default is undefined.
+     * Either undefined (solid line), dashed, or dotted.
+     * @default undefined
      */
     lineStyle?: "dashed" | "dotted" | "solid" | undefined;
 }
 
 interface PolyStyle {
     /**
-     * Fill color in any web format, default is undefined (no fill).
+     * Fill color in any web format.
+     * @default undefined (no fill).
      */
     fill?: string | undefined;
     /**
@@ -150,59 +170,70 @@ interface PolyStyle {
      */
     opacity?: number;
     /**
-     * Stroke color in any web format, default is #ffffff (white).
+     * Stroke color in any web format.
+     * @default #ffffff (white)
      */
     stroke?: string;
     /**
-     * Stroke line width, default is 0.1.
+     * Stroke line width.
+     * @default 0.1
      */
     strokeWidth?: number;
     /**
-     * Either undefined (solid line), dashed, or dotted. Default is undefined.
+     * Either undefined (solid line), dashed, or dotted.
+     * @default undefined
      */
     lineStyle?: "dashed" | "dotted" | "solid" | undefined;
 }
 
 interface CircleStyle extends PolyStyle {
     /**
-     * Circle radius, default is 0.15.
+     * Circle radius.
+     * @default 0.15
      */
     radius?: number;
 }
 
 interface TextStyle {
     /**
-     * Font color in any web format, default is #ffffff(white).
+     * Font color in any web format.
+     * @default #ffffff (white)
      */
     color?: string;
     /**
      * Either a number or a string in one of the following forms:
-     * 0.7 - relative size in game coordinates
-     * 20px - absolute size in pixels
-     * 0.7 serif
-     * bold italic 1.5 Times New Roman
+     * - 0.7 - relative size in game coordinates
+     * - 20px - absolute size in pixels
+     * - 0.7 serif
+     * - bold italic 1.5 Times New Roman
      */
     font?: number | string;
     /**
-     * Stroke color in any web format, default is undefined (no stroke).
+     * Stroke color in any web format.
+     * @default undefined (no stroke)
      */
     stroke?: string | undefined;
     /**
-     * Stroke width, default is 0.15.
+     * Stroke width.
+     * @default 0.15
      */
     strokeWidth?: number;
     /**
-     * Background color in any web format, default is undefined (no background).When background is enabled, text vertical align is set to middle (default is baseline).
+     * Background color in any web format.
+     * When background is enabled, text vertical align is set to middle (default is baseline).
+     * @default undefined (no background)
      */
     backgroundColor?: string | undefined;
 
     /**
-     * Background rectangle padding, default is 0.3.
+     * Background rectangle padding
+     * @default 0.3
      */
     backgroundPadding?: number;
     align?: "center" | "left" | "right";
     /**
-     * Opacity value, default is 1.0.
+     * Opacity value.
+     * @default 1.0
      */
     opacity?: number;
 }

--- a/src/room.ts
+++ b/src/room.ts
@@ -56,7 +56,7 @@ interface Room {
      * Create new {@link ConstructionSite} at the specified location.
      * @param x The X position
      * @param y The Y position
-     * @param structureType One of {@link BuildableStructureConstant}.
+     * @param structureType One of {@link BuildableStructureConstant Buildable STRUCTURE_*}.
      * @returns
      * - OK: The operation has been scheduled successfully.
      * - ERR_NOT_OWNER: The room is claimed or reserved by a hostile player.
@@ -69,7 +69,7 @@ interface Room {
     /**
      * Create new {@link ConstructionSite} at the specified location.
      * @param pos Can be a {@link RoomPosition} object or any object containing RoomPosition.
-     * @param structureType One of {@link BuildableStructureConstant}.
+     * @param structureType One of {@link BuildableStructureConstant Buildable STRUCTURE_*}.
      * @returns
      * - OK: The operation has been scheduled successfully.
      * - ERR_NOT_OWNER: The room is claimed or reserved by a hostile player.
@@ -83,7 +83,7 @@ interface Room {
      * Create new {@link ConstructionSite} at the specified location.
      * @param x The X position
      * @param y The Y position
-     * @param structureType One of {@link BuildableStructureConstant}.
+     * @param structureType One of {@link BuildableStructureConstant Buildable STRUCTURE_*}.
      * @returns
      * - OK: The operation has been scheduled successfully.
      * - ERR_NOT_OWNER: The room is claimed or reserved by a hostile player.
@@ -96,7 +96,7 @@ interface Room {
     /**
      * Create new {@link ConstructionSite} at the specified location.
      * @param pos Can be a {@link RoomPosition} object or any object containing RoomPosition.
-     * @param structureType One of {@link BuildableStructureConstant}.
+     * @param structureType One of {@link BuildableStructureConstant Buildable STRUCTURE_*}.
      * @returns
      * - OK: The operation has been scheduled successfully.
      * - ERR_NOT_OWNER: The room is claimed or reserved by a hostile player.
@@ -156,7 +156,7 @@ interface Room {
     ): ERR_NAME_EXISTS | ERR_INVALID_ARGS | string;
     /**
      * Find all objects of the specified type in the room.
-     * @param type One of the {@link FindConstant} constants.
+     * @param type One of the {@link FindConstant FIND_*} constants.
      * @param opts An object with additional options
      * @returns An array with the objects found.
      */
@@ -223,17 +223,23 @@ interface Room {
     /**
      * Get the objects at the given position.
      *
-     * @param type One of the {@link LookConstant} constants.
+     * @param type One of the {@link LookConstant LOOK_*} constants.
      * @param x The X position.
      * @param y The Y position.
-     * @param target A RoomPosition. Its room name will be ignored.
      * @returns An array of objects of the requested type at the given position, or ERR_INVALID_ARGS.
      */
     lookForAt<T extends keyof AllLookAtTypes>(type: T, x: number, y: number): Array<AllLookAtTypes[T]>;
+    /**
+     * Get the objects at the given position.
+     *
+     * @param type One of the {@link LookConstant LOOK_*} constants.
+     * @param target A RoomPosition. Its room name will be ignored.
+     * @returns An array of objects of the requested type at the given position, or ERR_INVALID_ARGS.
+     */
     lookForAt<T extends keyof AllLookAtTypes>(type: T, target: RoomPosition | _HasRoomPosition): Array<AllLookAtTypes[T]>;
     /**
      * Get the given objects in the supplied area.
-     * @param type One of the {@link LookConstant} constants
+     * @param type One of the {@link LookConstant LOOK_*} constants
      * @param top The top (Y) boundary of the area.
      * @param left The left (X) boundary of the area.
      * @param bottom The bottom (Y) boundary of the area.

--- a/src/room.ts
+++ b/src/room.ts
@@ -3,7 +3,7 @@
  *
  * It can be used to look around, find paths, etc.
  *
- * Every object in the room contains its linked Room instance in the room property.
+ * Every object in the room contains its linked Room instance in the {@link RoomObject.room} property.
  */
 interface Room {
     readonly prototype: Room;
@@ -29,6 +29,8 @@ interface Room {
      */
     getEventLog(raw: true): string;
     /**
+     * The room's memory.
+     *
      * A shorthand to `Memory.rooms[room.name]`. You can use it for quick access the room’s specific memory data object.
      */
     memory: RoomMemory;
@@ -37,51 +39,75 @@ interface Room {
      */
     readonly name: string;
     /**
-     * The Storage structure of this room, if present, otherwise undefined.
+     * The {@link StructureStorage} of this room, if present, otherwise undefined.
      */
     storage?: StructureStorage;
     /**
-     * The Terminal structure of this room, if present, otherwise undefined.
+     * The {@link StructureTerminal} of this room, if present, otherwise undefined.
      */
     terminal?: StructureTerminal;
     /**
-     * A RoomVisual object for this room. You can use this object to draw simple shapes (lines, circles, text labels) in the room.
+     * A {@link RoomVisual} object for this room.
+     *
+     * You can use this object to draw simple shapes (lines, circles, text labels) in the room.
      */
     visual: RoomVisual;
     /**
-     * Create new ConstructionSite at the specified location.
-     * @param x The X position.
-     * @param y The Y position.
-     * @param structureType One of the following constants: STRUCTURE_EXTENSION, STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_SPAWN, STRUCTURE_WALL, STRUCTURE_LINK
-     * @returns Result Code: OK, ERR_INVALID_TARGET, ERR_INVALID_ARGS, ERR_RCL_NOT_ENOUGH
+     * Create new {@link ConstructionSite} at the specified location.
+     * @param x The X position
+     * @param y The Y position
+     * @param structureType One of {@link BuildableStructureConstant}.
+     * @returns
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: The room is claimed or reserved by a hostile player.
+     * - ERR_INVALID_TARGET: The structure cannot be placed at the specified location.
+     * - ERR_FULL: You have too many construction sites. The maximum number of construction sites per player is 100.
+     * - ERR_INVALID_ARGS: The location is incorrect.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient.
      */
     createConstructionSite(x: number, y: number, structureType: BuildableStructureConstant): ScreepsReturnCode;
     /**
-     * Create new ConstructionSite at the specified location.
-     * @param pos Can be a RoomPosition object or any object containing RoomPosition.
-     * @param structureType One of the following constants: STRUCTURE_EXTENSION, STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_SPAWN, STRUCTURE_WALL, STRUCTURE_LINK
-     * @returns Result Code: OK, ERR_INVALID_TARGET, ERR_INVALID_ARGS, ERR_RCL_NOT_ENOUGH
+     * Create new {@link ConstructionSite} at the specified location.
+     * @param pos Can be a {@link RoomPosition} object or any object containing RoomPosition.
+     * @param structureType One of {@link BuildableStructureConstant}.
+     * @returns
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: The room is claimed or reserved by a hostile player.
+     * - ERR_INVALID_TARGET: The structure cannot be placed at the specified location.
+     * - ERR_FULL: You have too many construction sites. The maximum number of construction sites per player is 100.
+     * - ERR_INVALID_ARGS: The location is incorrect.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient.
      */
     createConstructionSite(pos: RoomPosition | _HasRoomPosition, structureType: StructureConstant): ScreepsReturnCode;
     /**
-     * Create new ConstructionSite at the specified location.
-     * @param x The X position.
-     * @param y The Y position.
-     * @param structureType One of the following constants: STRUCTURE_EXTENSION, STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_SPAWN, STRUCTURE_WALL, STRUCTURE_LINK
-     * @param name The name of the structure, for structures that support it (currently only spawns).
-     * @returns Result Code: OK, ERR_INVALID_TARGET, ERR_INVALID_ARGS, ERR_RCL_NOT_ENOUGH
+     * Create new {@link ConstructionSite} at the specified location.
+     * @param x The X position
+     * @param y The Y position
+     * @param structureType One of {@link BuildableStructureConstant}.
+     * @returns
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: The room is claimed or reserved by a hostile player.
+     * - ERR_INVALID_TARGET: The structure cannot be placed at the specified location.
+     * - ERR_FULL: You have too many construction sites. The maximum number of construction sites per player is 100.
+     * - ERR_INVALID_ARGS: The location is incorrect.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient.
      */
     createConstructionSite(x: number, y: number, structureType: STRUCTURE_SPAWN, name?: string): ScreepsReturnCode;
     /**
-     * Create new ConstructionSite at the specified location.
-     * @param pos Can be a RoomPosition object or any object containing RoomPosition.
-     * @param structureType One of the following constants: STRUCTURE_EXTENSION, STRUCTURE_RAMPART, STRUCTURE_ROAD, STRUCTURE_SPAWN, STRUCTURE_WALL, STRUCTURE_LINK
-     * @param name The name of the structure, for structures that support it (currently only spawns).
-     * @returns Result Code: OK, ERR_INVALID_TARGET, ERR_INVALID_ARGS, ERR_RCL_NOT_ENOUGH
+     * Create new {@link ConstructionSite} at the specified location.
+     * @param pos Can be a {@link RoomPosition} object or any object containing RoomPosition.
+     * @param structureType One of {@link BuildableStructureConstant}.
+     * @returns
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: The room is claimed or reserved by a hostile player.
+     * - ERR_INVALID_TARGET: The structure cannot be placed at the specified location.
+     * - ERR_FULL: You have too many construction sites. The maximum number of construction sites per player is 100.
+     * - ERR_INVALID_ARGS: The location is incorrect.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient.
      */
     createConstructionSite(pos: RoomPosition | _HasRoomPosition, structureType: STRUCTURE_SPAWN, name?: string): ScreepsReturnCode;
     /**
-     * Create new Flag at the specified location.
+     * Create new {@link Flag} at the specified location.
      * @param x The X position.
      * @param y The Y position.
      * @param name (optional) The name of a new flag.
@@ -93,7 +119,10 @@ interface Room {
      * The maximum length is 60 characters.
      * @param color The color of a new flag. Should be one of the COLOR_* constants. The default value is COLOR_WHITE.
      * @param secondaryColor The secondary color of a new flag. Should be one of the COLOR_* constants. The default value is equal to color.
-     * @returns The name of a new flag, or one of the following error codes: ERR_NAME_EXISTS, ERR_INVALID_ARGS
+     * @returns The name of a new flag, or one of the following error codes:
+     * - ERR_NAME_EXISTS: There is a flag with the same name already.
+     * - ERR_FULL: You have too many flags. The maximum number of flags per player is 10000.
+     * - ERR_INVALID_ARGS: The location or the name or the color constant is incorrect.
      */
     createFlag(
         x: number,
@@ -103,8 +132,8 @@ interface Room {
         secondaryColor?: ColorConstant,
     ): ERR_NAME_EXISTS | ERR_INVALID_ARGS | string;
     /**
-     * Create new Flag at the specified location.
-     * @param pos Can be a RoomPosition object or any object containing RoomPosition.
+     * Create new {@link Flag} at the specified location.
+     * @param pos Can be a {@link RoomPosition} object or any object containing RoomPosition.
      * @param name (optional) The name of a new flag.
      *
      * It should be unique, i.e. the Game.flags object should not contain another flag with the same name (hash key).
@@ -114,7 +143,10 @@ interface Room {
      * The maximum length is 60 characters.
      * @param color The color of a new flag. Should be one of the COLOR_* constants. The default value is COLOR_WHITE.
      * @param secondaryColor The secondary color of a new flag. Should be one of the COLOR_* constants. The default value is equal to color.
-     * @returns The name of a new flag, or one of the following error codes: ERR_NAME_EXISTS, ERR_INVALID_ARGS
+     * @returns The name of a new flag, or one of the following error codes:
+     * - ERR_NAME_EXISTS: There is a flag with the same name already.
+     * - ERR_FULL: You have too many flags. The maximum number of flags per player is 10000.
+     * - ERR_INVALID_ARGS: The location or the name or the color constant is incorrect.
      */
     createFlag(
         pos: RoomPosition | { pos: RoomPosition },
@@ -124,25 +156,7 @@ interface Room {
     ): ERR_NAME_EXISTS | ERR_INVALID_ARGS | string;
     /**
      * Find all objects of the specified type in the room.
-     * @param type One of the following constants:
-     *  * FIND_CREEPS
-     *  * FIND_MY_CREEPS
-     *  * FIND_HOSTILE_CREEPS
-     *  * FIND_MY_SPAWNS
-     *  * FIND_HOSTILE_SPAWNS
-     *  * FIND_SOURCES
-     *  * FIND_SOURCES_ACTIVE
-     *  * FIND_DROPPED_RESOURCES
-     *  * FIND_STRUCTURES
-     *  * FIND_MY_STRUCTURES
-     *  * FIND_HOSTILE_STRUCTURES
-     *  * FIND_FLAGS
-     *  * FIND_CONSTRUCTION_SITES
-     *  * FIND_EXIT_TOP
-     *  * FIND_EXIT_RIGHT
-     *  * FIND_EXIT_BOTTOM
-     *  * FIND_EXIT_LEFT
-     *  * FIND_EXIT
+     * @param type One of the {@link FindConstant} constants.
      * @param opts An object with additional options
      * @returns An array with the objects found.
      */
@@ -162,19 +176,20 @@ interface Room {
      * Find an optimal path inside the room between fromPos and toPos using A* search algorithm.
      * @param fromPos The start position.
      * @param toPos The end position.
-     * @param opts (optional) An object containing additonal pathfinding flags
+     * @param opts (optional) An object containing additional pathfinding flags
      * @returns An array with path steps
      */
     findPath(fromPos: RoomPosition, toPos: RoomPosition, opts?: FindPathOpts): PathStep[];
     /**
-     * Creates a RoomPosition object at the specified location.
+     * Creates a {@link RoomPosition} object at the specified location.
      * @param x The X position.
      * @param y The Y position.
      * @returns A RoomPosition object or null if it cannot be obtained.
      */
     getPositionAt(x: number, y: number): RoomPosition | null;
     /**
-     * Get a Room.Terrain object which provides fast access to static terrain data.
+     * Get a {@link RoomTerrain} object which provides fast access to static terrain data.
+     *
      * This method works for any room in the world even if you have no access to it.
      */
     getTerrain(): RoomTerrain;
@@ -183,6 +198,7 @@ interface Room {
      * @param x The X position.
      * @param y The Y position.
      * @returns An array with objects at the specified position
+     * @throws if `x` or `y` are out of bounds.
      */
     lookAt(x: number, y: number): LookAtResult[];
     /**
@@ -192,7 +208,9 @@ interface Room {
      */
     lookAt(target: RoomPosition | { pos: RoomPosition }): LookAtResult[];
     /**
-     * Get the list of objects at the specified room area. This method is more CPU efficient in comparison to multiple lookAt calls.
+     * Get the list of objects at the specified room area.
+     *
+     * This method is more CPU efficient in comparison to multiple {@link Room.lookAt} calls.
      * @param top The top Y boundary of the area.
      * @param left The left X boundary of the area.
      * @param bottom The bottom Y boundary of the area.
@@ -201,40 +219,27 @@ interface Room {
      * @returns An object with all the objects in the specified area
      */
     lookAtArea(top: number, left: number, bottom: number, right: number, asArray?: false): LookAtResultMatrix;
-    /**
-     * Get the list of objects at the specified room area. This method is more CPU efficient in comparison to multiple lookAt calls.
-     * @param top The top Y boundary of the area.
-     * @param left The left X boundary of the area.
-     * @param bottom The bottom Y boundary of the area.
-     * @param right The right X boundary of the area.
-     * @param asArray Set to true if you want to get the result as a plain array.
-     * @returns An object with all the objects in the specified area
-     */
     lookAtArea(top: number, left: number, bottom: number, right: number, asArray: true): LookAtResultWithPos[];
     /**
      * Get the objects at the given position.
-     * @param type One of the LOOK_* constants.
+     *
+     * @param type One of the {@link LookConstant} constants.
      * @param x The X position.
      * @param y The Y position.
-     * @returns An array of Creep at the given position.
+     * @param target A RoomPosition. Its room name will be ignored.
+     * @returns An array of objects of the requested type at the given position, or ERR_INVALID_ARGS.
      */
     lookForAt<T extends keyof AllLookAtTypes>(type: T, x: number, y: number): Array<AllLookAtTypes[T]>;
-    /**
-     * Get the objects at the given RoomPosition.
-     * @param type One of the LOOK_* constants.
-     * @param target Can be a RoomPosition object or any object containing RoomPosition.
-     * @returns An array of Creeps at the specified position if found.
-     */
     lookForAt<T extends keyof AllLookAtTypes>(type: T, target: RoomPosition | _HasRoomPosition): Array<AllLookAtTypes[T]>;
     /**
-     * Get the given objets in the supplied area.
-     * @param type One of the LOOK_* constants
-     * @param top The top (Y) boundry of the area.
-     * @param left The left (X) boundry of the area.
-     * @param bottom The bottom (Y) boundry of the area.
-     * @param right The right(X) boundry of the area.
+     * Get the given objects in the supplied area.
+     * @param type One of the {@link LookConstant} constants
+     * @param top The top (Y) boundary of the area.
+     * @param left The left (X) boundary of the area.
+     * @param bottom The bottom (Y) boundary of the area.
+     * @param right The right(X) boundary of the area.
      * @param asArray Flatten the results into an array?
-     * @returns An object with the sstructure object[X coord][y coord] as an array of found objects.
+     * @returns Either an array of found objects with an x & y property or a nested object keyed by x, then y coordinate.
      */
     lookForAtArea<T extends keyof AllLookAtTypes>(
         type: T,
@@ -244,16 +249,6 @@ interface Room {
         right: number,
         asArray?: false,
     ): LookForAtAreaResultMatrix<AllLookAtTypes[T]>;
-    /**
-     * Get the given objets in the supplied area.
-     * @param type One of the LOOK_* constants
-     * @param top The top (Y) boundry of the area.
-     * @param left The left (X) boundry of the area.
-     * @param bottom The bottom (Y) boundry of the area.
-     * @param right The right(X) boundry of the area.
-     * @param asArray Flatten the results into an array?
-     * @returns An array of found objects with an x & y property for their position
-     */
     lookForAtArea<T extends keyof AllLookAtTypes>(
         type: T,
         top: number,
@@ -262,18 +257,6 @@ interface Room {
         right: number,
         asArray: true,
     ): LookForAtAreaResultArray<AllLookAtTypes[T], T>;
-
-    /**
-     * Serialize a path array into a short string representation, which is suitable to store in memory.
-     * @param path A path array retrieved from Room.findPath.
-     * @returns A serialized string form of the given path.
-     */
-
-    /**
-     * Deserialize a short string path representation into an array form.
-     * @param path A serialized path string.
-     * @returns A path array.
-     */
 }
 
 interface RoomConstructor extends _Constructor<Room> {
@@ -283,7 +266,7 @@ interface RoomConstructor extends _Constructor<Room> {
 
     /**
      * Serialize a path array into a short string representation, which is suitable to store in memory.
-     * @param path A path array retrieved from `Room.findPath`.
+     * @param path A path array retrieved from {@link Room.findPath}.
      * @returns A serialized string form of the given path.
      */
     serializePath(path: PathStep[]): string;

--- a/src/ruin.ts
+++ b/src/ruin.ts
@@ -1,13 +1,14 @@
 /**
- * A destroyed structure. This is a walkable object.
- * <ul>
- *     <li>Decay: 500 ticks except some special cases</li>
- * </ul>
+ * A destroyed structure.
+ *
+ * This is a walkable object.
+ *
+ * Usually decays in 500 ticks except some special cases.
  */
 interface Ruin extends RoomObject {
     /**
-     * A unique object identificator.
-     * You can use {@link Game.getObjectById} method to retrieve an object instance by its id.
+     * A unique object identifier.
+     * You can use {@link Game.getObjectById} to retrieve an object instance by its id.
      */
     id: Id<this>;
     /**

--- a/src/source.ts
+++ b/src/source.ts
@@ -1,5 +1,14 @@
 /**
- * An energy source object. Can be harvested by creeps with a WORK body part.
+ * An energy source object.
+ *
+ * Can be harvested by creeps with a WORK body part.
+ *
+ * |                     |                                    |
+ * | ------------------- | ---------------------------------- |
+ * | Energy amount       | 4000 in center rooms
+ * |                     | 3000 in an owned or reserved room
+ * |                     | 1500 in an unreserved room
+ * | Energy regeneration | Every 300 game ticks
  */
 interface Source extends RoomObject {
     /**
@@ -11,16 +20,19 @@ interface Source extends RoomObject {
      */
     energy: number;
     /**
-     * The total amount of energy in the source. Equals to 3000 in most cases.
+     * The total amount of energy in the source.
+     *
+     * Equals to 3000 in most cases.
      */
     energyCapacity: number;
     /**
-     * A unique object identifier. You can use Game.getObjectById method to retrieve an object instance by its id.
+     * A unique object identifier.
+     *
+     * You can use {@link Game.getObjectById} to retrieve an object instance by its id.
      */
     id: Id<this>;
     /**
-     * If you can get an instance of Source, you can see it.
-     * If you can see a Source, you can see the room it's in.
+     * The room the source is in.
      */
     room: Room;
     /**

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -58,7 +58,15 @@ interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
      * Check if a creep can be created.
      *
      * @deprecated This method is deprecated and will be removed soon. Please use {@link StructureSpawn.spawnCreep} with `dryRun` flag instead.
-     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of the {@link BodyPartConstant} constants.
+     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of the {@link BodyPartConstant} constants:
+     * - WORK
+     * - MOVE
+     * - CARRY
+     * - ATTACK
+     * - RANGED_ATTACK
+     * - HEAL
+     * - TOUGH
+     * - CLAIM
      * @param name The name of a new creep.
      *
      * It should be unique creep name, i.e. the Game.creeps object should not contain another creep with the same name (hash key).
@@ -78,7 +86,15 @@ interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
      * Start the creep spawning process.
      *
      * @deprecated This method is deprecated and will be removed soon. Please use {@link StructureSpawn.spawnCreep} instead.
-     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of the {@link BodyPartConstant} constants.
+     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of the {@link BodyPartConstant} constants:
+     * - WORK
+     * - MOVE
+     * - CARRY
+     * - ATTACK
+     * - RANGED_ATTACK
+     * - HEAL
+     * - TOUGH
+     * - CLAIM
      * @param name The name of a new creep.
      *
      * It should be unique creep name, i.e. the Game.creeps object should not contain another creep with the same name (hash key).
@@ -94,11 +110,18 @@ interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
      * - ERR_RCL_NOT_ENOUGH: Your Room Controller level is not enough to use this spawn.
      */
     createCreep(body: BodyPartConstant[], name?: string, memory?: CreepMemory): ScreepsReturnCode | string;
-
     /**
      * Start the creep spawning process. The required energy amount can be withdrawn from all spawns and extensions in the room.
      *
-     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of the {@link BodyPartConstant} constants.
+     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of the {@link BodyPartConstant} constants:
+     * - WORK
+     * - MOVE
+     * - CARRY
+     * - ATTACK
+     * - RANGED_ATTACK
+     * - HEAL
+     * - TOUGH
+     * - CLAIM
      * @param name The name of a new creep. It must be a unique creep name, i.e. the Game.creeps object should not contain another creep with the same name (hash key).
      * @param opts An object with additional options for the spawning process.
      * @returns One of the following codes:

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -1,8 +1,23 @@
 /**
- * Spawns are your colony centers. This structure can create, renew, and recycle
- * creeps. All your spawns are accessible through `Game.spawns` hash list.
- * Spawns auto-regenerate a little amount of energy each tick, so that you can
- * easily recover even if all your creeps died.
+ * Spawns are your colony centers.
+ *
+ * This structure can create, renew, and recycle creeps.
+ * All your spawns are accessible through {@link Game.spawns} hash list.
+ * Spawns auto-regenerate a little amount of energy each tick, so that you can easily recover even if all your creeps died.
+ *
+ * | Controller level |          |
+ * | ---------------- | -------- |
+ * |  1-6             | 1 spawn  |
+ * |  7               | 2 spawns |
+ * |  8               | 3 spawns |
+ *
+ * |                               |               |
+ * | ----------------------------- | ------------- |
+ * | **Cost**                      | 15,000
+ * | **Hits**                      | 5,000
+ * | **Capacity**                  | 300
+ * | **Spawn time**                | 3 ticks per each body part
+ * | **Energy auto-regeneration**  | 1 energy unit per tick while energy available | in the room (in all spawns and extensions) is less than 300
  */
 interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
     readonly prototype: StructureSpawn;
@@ -12,21 +27,23 @@ interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
      */
     energy: number;
     /**
-     * The total amount of energy the spawn can contain
+     * The total amount of energy the spawn can contain.
      * @deprecated An alias for .store.getCapacity(RESOURCE_ENERGY).
      */
     energyCapacity: number;
     /**
-     * A shorthand to `Memory.spawns[spawn.name]`. You can use it for quick access
-     * the spawn’s specific memory data object.
+     * The spawn memory.
+     *
+     * A shorthand to `Memory.spawns[spawn.name]`. You can use it for quick access the spawn’s specific memory data object.
      *
      * @see http://docs.screeps.com/global-objects.html#Memory-object
      */
     memory: SpawnMemory;
     /**
-     * Spawn's name. You choose the name upon creating a new spawn, and it cannot
-     * be changed later. This name is a hash key to access the spawn via the
-     * `Game.spawns` object.
+     * The spawn name.
+     *
+     * You choose the name upon creating a new spawn, and it cannot be changed later.
+     * This name is a hash key to access the spawn via the {@link Game.spawns} object.
      */
     name: string;
     /**
@@ -40,20 +57,28 @@ interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
     /**
      * Check if a creep can be created.
      *
-     * @deprecated This method is deprecated and will be removed soon. Please use `StructureSpawn.spawnCreep` with `dryRun` flag instead.
-     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of these constants: WORK, MOVE, CARRY, ATTACK, RANGED_ATTACK, HEAL, TOUGH, CLAIM
+     * @deprecated This method is deprecated and will be removed soon. Please use {@link StructureSpawn.spawnCreep} with `dryRun` flag instead.
+     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of the {@link BodyPartConstant} constants.
      * @param name The name of a new creep.
      *
      * It should be unique creep name, i.e. the Game.creeps object should not contain another creep with the same name (hash key).
      *
      * If not defined, a random name will be generated.
+     * @returns One of the following codes:
+     * - OK: A creep with the given body and name can be created.
+     * - ERR_NOT_OWNER: You are not the owner of this spawn.
+     * - ERR_NAME_EXISTS: There is a creep with the same name already.
+     * - ERR_BUSY: The spawn is already in process of spawning another creep.
+     * - ERR_NOT_ENOUGH_ENERGY: The spawn and its extensions contain not enough energy to create a creep with the given body.
+     * - ERR_INVALID_ARGS: Body is not properly described.
+     * - ERR_RCL_NOT_ENOUGH: Your Room Controller level is insufficient to use this spawn.
      */
     canCreateCreep(body: BodyPartConstant[], name?: string): ScreepsReturnCode;
     /**
      * Start the creep spawning process.
      *
-     * @deprecated This method is deprecated and will be removed soon. Please use `StructureSpawn.spawnCreep` instead.
-     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of these constants: WORK, MOVE, CARRY, ATTACK, RANGED_ATTACK, HEAL, TOUGH, CLAIM
+     * @deprecated This method is deprecated and will be removed soon. Please use {@link StructureSpawn.spawnCreep} instead.
+     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of the {@link BodyPartConstant} constants.
      * @param name The name of a new creep.
      *
      * It should be unique creep name, i.e. the Game.creeps object should not contain another creep with the same name (hash key).
@@ -61,41 +86,29 @@ interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
      * If not defined, a random name will be generated.
      * @param memory The memory of a new creep. If provided, it will be immediately stored into Memory.creeps[name].
      * @returns The name of a new creep or one of these error codes:
-     * ```
-     * ERR_NOT_OWNER            -1  You are not the owner of this spawn.
-     * ERR_NAME_EXISTS          -3  There is a creep with the same name already.
-     * ERR_BUSY                 -4  The spawn is already in process of spawning another creep.
-     * ERR_NOT_ENOUGH_ENERGY    -6  The spawn and its extensions contain not enough energy to create a creep with the given body.
-     * ERR_INVALID_ARGS         -10 Body is not properly described.
-     * ERR_RCL_NOT_ENOUGH       -14 Your Room Controller level is not enough to use this spawn.
-     * ```
+     * - ERR_NOT_OWNER: You are not the owner of this spawn.
+     * - ERR_NAME_EXISTS: There is a creep with the same name already.
+     * - ERR_BUSY: The spawn is already in process of spawning another creep.
+     * - ERR_NOT_ENOUGH_ENERGY: The spawn and its extensions contain not enough energy to create a creep with the given body.
+     * - ERR_INVALID_ARGS: Body is not properly described.
+     * - ERR_RCL_NOT_ENOUGH: Your Room Controller level is not enough to use this spawn.
      */
     createCreep(body: BodyPartConstant[], name?: string, memory?: CreepMemory): ScreepsReturnCode | string;
 
     /**
      * Start the creep spawning process. The required energy amount can be withdrawn from all spawns and extensions in the room.
      *
-     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of these constants:
-     *  * WORK
-     *  * MOVE
-     *  * CARRY
-     *  * ATTACK
-     *  * RANGED_ATTACK
-     *  * HEAL
-     *  * TOUGH
-     *  * CLAIM
+     * @param body An array describing the new creep’s body. Should contain 1 to 50 elements with one of the {@link BodyPartConstant} constants.
      * @param name The name of a new creep. It must be a unique creep name, i.e. the Game.creeps object should not contain another creep with the same name (hash key).
      * @param opts An object with additional options for the spawning process.
      * @returns One of the following codes:
-     * ```
-     * OK                       0   The operation has been scheduled successfully.
-     * ERR_NOT_OWNER            -1  You are not the owner of this spawn.
-     * ERR_NAME_EXISTS          -3  There is a creep with the same name already.
-     * ERR_BUSY                 -4  The spawn is already in process of spawning another creep.
-     * ERR_NOT_ENOUGH_ENERGY    -6  The spawn and its extensions contain not enough energy to create a creep with the given body.
-     * ERR_INVALID_ARGS         -10 Body is not properly described or name was not provided.
-     * ERR_RCL_NOT_ENOUGH       -14 Your Room Controller level is insufficient to use this spawn.
-     * ```
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this spawn.
+     * - ERR_NAME_EXISTS: There is a creep with the same name already.
+     * - ERR_BUSY: The spawn is already in process of spawning another creep.
+     * - ERR_NOT_ENOUGH_ENERGY: The spawn and its extensions contain not enough energy to create a creep with the given body.
+     * - ERR_INVALID_ARGS: Body is not properly described or name was not provided.
+     * - ERR_RCL_NOT_ENOUGH: Your Room Controller level is insufficient to use this spawn.
      */
     spawnCreep(body: BodyPartConstant[], name: string, opts?: SpawnOptions): ScreepsReturnCode;
     /**
@@ -105,15 +118,33 @@ interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
      *
      * The spawn should not be busy with the spawning process.
      *
-     * Each execution increases the creep's timer by amount of ticks according to this formula: floor(600/body_size).
+     * Each execution increases the creep's timer by amount of ticks according to this formula: `floor(600/body_size)`.
      *
-     * Energy required for each execution is determined using this formula: ceil(creep_cost/2.5/body_size).
+     * Energy required for each execution is determined using this formula: `ceil(creep_cost/2.5/body_size)`.
      * @param target The target creep object.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of the spawn, or the creep.
+     * - ERR_BUSY: The spawn is spawning another creep.
+     * - ERR_NOT_ENOUGH_ENERGY: The spawn does not have enough energy.
+     * - ERR_INVALID_TARGET: The specified target object is not a creep, or the creep has CLAIM body part.
+     * - ERR_FULL: The target creep's time to live timer is full.
+     * - ERR_NOT_IN_RANGE: The target creep is too far away.
+     * - ERR_RCL_NOT_ENOUGH: Your Room Controller level is insufficient to use this spawn.
      */
     renewCreep(target: Creep): ScreepsReturnCode;
     /**
-     * Kill the creep and drop up to 100% of resources spent on its spawning and boosting depending on remaining life time. The target should be at adjacent square.
+     * Kill the creep and drop up to 100% of resources spent on its spawning and boosting depending on remaining life time.
+     *
+     * The target should be at adjacent square. Energy return is limited to 125 units per body part.
+     *
      * @param target The target creep object.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this spawn or the target creep.
+     * - ERR_INVALID_TARGET: The specified target object is not a creep.
+     * - ERR_NOT_IN_RANGE: The target creep is too far away.
+     * - ERR_RCL_NOT_ENOUGH: Your Room Controller level is insufficient to use this spawn.
      */
     recycleCreep(target: Creep): ScreepsReturnCode;
 }
@@ -131,6 +162,7 @@ interface Spawning {
 
     /**
      * An array with the spawn directions
+     *
      * @see http://docs.screeps.com/api/#StructureSpawn.Spawning.setDirections
      */
     directions?: DirectionConstant[];
@@ -156,13 +188,23 @@ interface Spawning {
     spawn: StructureSpawn;
 
     /**
-     * Cancel spawning immediately. Energy spent on spawning is not returned.
+     * Cancel spawning immediately.
+     *
+     * Energy spent on spawning is not returned.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this spawn.
      */
     cancel(): ScreepsReturnCode & (OK | ERR_NOT_OWNER);
 
     /**
-     * Set desired directions where the creep should move when spawned.
+     * Set allowed directions the creep can move when spawned.
+     *
      * @param directions An array with the spawn directions
+     * @return One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this spawn.
+     * - ERR_INVALID_ARGS: The directions is array is invalid.
      */
     setDirections(directions: DirectionConstant[]): ScreepsReturnCode & (OK | ERR_NOT_OWNER | ERR_INVALID_ARGS);
 }
@@ -172,21 +214,23 @@ interface Spawning {
  */
 interface SpawnOptions {
     /**
-     * Memory of the new creep. If provided, it will be immediately stored into Memory.creeps[name].
+     * Memory of the new creep.
+     *
+     * If provided, it will be immediately stored into Memory.creeps[name].
      */
     memory?: CreepMemory;
     /**
      * Array of spawns/extensions from which to draw energy for the spawning process.
+     *
      * Structures will be used according to the array order.
      */
     energyStructures?: Array<StructureSpawn | StructureExtension>;
     /**
-     * If dryRun is <code>true</code>, the operation will only check if it is possible to create a creep.
+     * If dryRun is `true`, the operation will only check if it is possible to create a creep.
      */
     dryRun?: boolean;
     /**
-     * Set desired directions where the creep should move when spawned.
-     * An array with the direction constants.
+     * Set allowed directions the creep can move when spawned.
      */
     directions?: DirectionConstant[];
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,6 +1,8 @@
 interface StoreBase<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE extends boolean> {
     /**
-     * Returns capacity of this store for the specified resource. For a general purpose store, it returns total capacity if `resource` is undefined.
+     * Returns capacity of this store for the specified resource.
+     *
+     * For a general purpose store, it returns total capacity if `resource` is undefined.
      * @param resource The type of the resource.
      * @returns Returns capacity number, or `null` in case of an invalid `resource` for this store type.
      */
@@ -24,7 +26,9 @@ interface StoreBase<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE
         resource?: R,
     ): R extends undefined ? (ResourceConstant extends POSSIBLE_RESOURCES ? number : null) : R extends POSSIBLE_RESOURCES ? number : null;
     /**
-     * Returns free capacity for the store. For a limited store, it returns the capacity available for the specified resource if `resource` is defined and valid for this store.
+     * Returns free capacity for the store.
+     *
+     * For a limited store, it returns the capacity available for the specified resource if `resource` is defined and valid for this store.
      * @param resource The type of the resource.
      * @returns Returns available capacity number, or `null` in case of an invalid `resource` for this store type.
      */
@@ -46,9 +50,27 @@ type Store<POSSIBLE_RESOURCES extends ResourceConstant, UNLIMITED_STORE extends 
     UNLIMITED_STORE
 > & { [P in POSSIBLE_RESOURCES]: number } & { [P in Exclude<ResourceConstant, POSSIBLE_RESOURCES>]: 0 };
 
+/**
+ * An object that can contain resources in its cargo.
+ *
+ * There are two types of stores in the game: general purpose stores and limited stores.
+ *
+ * General purpose stores can contain any resource within its capacity (e.g. creeps, containers, storages, terminals).
+ *
+ * Limited stores can contain only a few types of resources needed for that particular object (e.g. spawns, extensions, labs, nukers).
+ *
+ * The Store prototype is the same for both types of stores, but they have different behavior depending on the resource argument in its methods.
+ *
+ * You can get specific resources from the store by addressing them as object properties:
+ * ```
+ * console.log(creep.store[RESOURCE_ENERGY]);
+ * ```
+ */
 interface GenericStoreBase {
     /**
-     * Returns capacity of this store for the specified resource. For a general purpose store, it returns total capacity if `resource` is undefined.
+     * Returns capacity of this store for the specified resource.
+     *
+     * For a general purpose store, it returns total capacity if `resource` is undefined.
      * @param resource The type of the resource.
      * @returns Returns capacity number, or `null` in case of an invalid `resource` for this store type.
      */
@@ -60,7 +82,9 @@ interface GenericStoreBase {
      */
     getUsedCapacity(resource?: ResourceConstant): number | null;
     /**
-     * Returns free capacity for the store. For a limited store, it returns the capacity available for the specified resource if `resource` is defined and valid for this store.
+     * Returns free capacity for the store.
+     *
+     * For a limited store, it returns the capacity available for the specified resource if `resource` is defined and valid for this store.
      * @param resource The type of the resource.
      * @returns Returns available capacity number, or `null` in case of an invalid `resource` for this store type.
      */

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -1,5 +1,5 @@
 /**
- * Parent object for structure classes
+ * The base prototype object of all structures.
  */
 interface Structure<T extends StructureConstant = StructureConstant> extends RoomObject {
     readonly prototype: Structure;
@@ -13,20 +13,28 @@ interface Structure<T extends StructureConstant = StructureConstant> extends Roo
      */
     hitsMax: number;
     /**
-     * A unique object identifier. You can use Game.getObjectById method to retrieve an object instance by its id.
+     * A unique object identifier.
+     *
+     * You can use {@link Game.getObjectById} to retrieve an object instance by its id.
      */
     id: Id<this>;
     /**
+     * The room the structure is in.
+     *
      * If you can get an instance of a Structure, you can see it.
      * If you can see the Structure, you can see the room it's in.
      */
     room: Room;
     /**
-     * One of the STRUCTURE_* constants.
+     * One of the {@link StructureConstant} constants.
      */
     structureType: T;
     /**
      * Destroy this structure immediately.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
+     * - ERR_BUSY: Hostile creeps are in the room.
      */
     destroy(): ScreepsReturnCode;
     /**
@@ -36,6 +44,10 @@ interface Structure<T extends StructureConstant = StructureConstant> extends Roo
     /**
      * Toggle auto notification when the structure is under attack. The notification will be sent to your account email. Turned on by default.
      * @param enabled Whether to enable notification or disable.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
+     * - ERR_INVALID_ARGS: enable argument is not a boolean value.
      */
     notifyWhenAttacked(enabled: boolean): ScreepsReturnCode;
 }
@@ -45,22 +57,27 @@ interface StructureConstructor extends _Constructor<Structure>, _ConstructorById
 declare const Structure: StructureConstructor;
 
 /**
- * The base prototype for a structure that has an owner. Such structures can be
- * found using `FIND_MY_STRUCTURES` and `FIND_HOSTILE_STRUCTURES` constants.
+ * The base prototype for a structure that has an owner.
+ *
+ * Such structures can be found using {@link Room.find} and the {@link FIND_MY_STRUCTURES} & {@link FIND_HOSTILE_STRUCTURES} constants.
  */
 interface OwnedStructure<T extends StructureConstant = StructureConstant> extends Structure<T> {
     readonly prototype: OwnedStructure;
 
     /**
-     * Whether this is your own structure. Walls and roads don't have this property as they are considered neutral structures.
+     * Whether this is your own structure.
+     *
+     * Walls and roads don't have this property as they are considered neutral structures.
      */
     my: boolean;
     /**
-     * An object with the structure’s owner info (if present) containing the following properties: username
+     * An object with the structure’s owner info (if present).
      */
     owner: T extends STRUCTURE_CONTROLLER ? Owner | undefined : Owner;
     /**
-     * The link to the Room object. Is always present because owned structures give visibility.
+     * The link to the Room object.
+     *
+     * Is always present because owned structures give visibility.
      */
     room: Room;
 }
@@ -70,9 +87,10 @@ interface OwnedStructureConstructor extends _Constructor<OwnedStructure>, _Const
 declare const OwnedStructure: OwnedStructureConstructor;
 
 /**
- * Claim this structure to take control over the room. The controller structure
- * cannot be damaged or destroyed. It can be addressed by `Room.controller`
- * property.
+ * Claim this structure to take control over the room.
+ *
+ * The controller structure cannot be damaged or destroyed.
+ * It can be addressed by {@link Room.controller} property.
  */
 interface StructureController extends OwnedStructure<STRUCTURE_CONTROLLER> {
     readonly prototype: StructureController;
@@ -80,7 +98,7 @@ interface StructureController extends OwnedStructure<STRUCTURE_CONTROLLER> {
     /**
      * Whether using power is enabled in this room.
      *
-     * Use `PowerCreep.enableRoom()` to turn powers on.
+     * Use {@link PowerCreep.enableRoom()} to turn powers on.
      */
     isPowerEnabled: boolean;
     /**
@@ -96,7 +114,9 @@ interface StructureController extends OwnedStructure<STRUCTURE_CONTROLLER> {
      */
     progressTotal: number;
     /**
-     * An object with the controller reservation info if present: username, ticksToEnd
+     * The reservation info for the controller.
+     *
+     * Can be undefined if the controller isn't reserved.
      */
     reservation: ReservationDefinition | undefined;
     /**
@@ -116,7 +136,9 @@ interface StructureController extends OwnedStructure<STRUCTURE_CONTROLLER> {
      */
     sign: SignDefinition | undefined;
     /**
-     * The amount of game ticks when this controller will lose one level. This timer can be reset by using Creep.upgradeController.
+     * The amount of game ticks when this controller will lose one level.
+     *
+     * This timer can be reset by using {@link Creep.upgradeController}
      */
     ticksToDowngrade: number;
     /**
@@ -125,11 +147,19 @@ interface StructureController extends OwnedStructure<STRUCTURE_CONTROLLER> {
     upgradeBlocked: number;
     /**
      * Activate safe mode if available.
-     * @returns Result Code: OK, ERR_NOT_OWNER, ERR_BUSY, ERR_NOT_ENOUGH_RESOURCES, ERR_TIRED
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this controller.
+     * - ERR_BUSY: There is another room in safe mode already.
+     * - ERR_NOT_ENOUGH_RESOURCES: There is no safe mode activations available.
+     * - ERR_TIRED: The previous safe mode is still cooling down, or the controller is upgradeBlocked, or the controller is downgraded for 50% plus 5000 ticks or more.
      */
     activateSafeMode(): ScreepsReturnCode;
     /**
      * Make your claimed controller neutral again.
+     * @returnsOne of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this controller.
      */
     unclaim(): ScreepsReturnCode;
 }
@@ -139,20 +169,22 @@ interface StructureControllerConstructor extends _Constructor<StructureControlle
 declare const StructureController: StructureControllerConstructor;
 
 /**
- * Contains energy which can be spent on spawning bigger creeps. Extensions can
- * be placed anywhere in the room, any spawns will be able to use them regardless
- * of distance.
+ * Contains energy which can be spent on spawning bigger creeps.
+ *
+ * Extensions can be placed anywhere in the room, any spawns will be able to use them regardless of distance.
  */
 interface StructureExtension extends OwnedStructure<STRUCTURE_EXTENSION> {
     readonly prototype: StructureExtension;
 
     /**
      * The amount of energy containing in the extension.
+     *
      * @deprecated An alias for .store[RESOURCE_ENERGY].
      */
     energy: number;
     /**
      * The total amount of energy the extension can contain.
+     *
      * @deprecated An alias for .store.getCapacity(RESOURCE_ENERGY).
      */
     energyCapacity: number;
@@ -199,6 +231,16 @@ interface StructureLink extends OwnedStructure<STRUCTURE_LINK> {
      * Remote transfer process implies 3% energy loss and cooldown delay depending on the distance.
      * @param target The target object.
      * @param amount The amount of energy to be transferred. If omitted, all the available energy is used.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this link.
+     * - ERR_NOT_ENOUGH_RESOURCES: The structure does not have the given amount of energy.
+     * - ERR_INVALID_TARGET: The target is not a valid StructureLink object.
+     * - ERR_FULL: The target cannot receive any more energy.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_INVALID_ARGS: The energy amount is incorrect.
+     * - ERR_TIRED: The link is still cooling down.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this link.
      */
     transferEnergy(target: StructureLink, amount?: number): ScreepsReturnCode;
 }
@@ -208,8 +250,10 @@ interface StructureLinkConstructor extends _Constructor<StructureLink>, _Constru
 declare const StructureLink: StructureLinkConstructor;
 
 /**
- * Non-player structure. Spawns NPC Source Keepers that guards energy sources
- * and minerals in some rooms. This structure cannot be destroyed.
+ * Non-player structure.
+ *
+ * Spawns NPC Source Keepers that guards energy sources and minerals in some rooms.
+ * This structure cannot be destroyed.
  */
 interface StructureKeeperLair extends OwnedStructure<STRUCTURE_KEEPER_LAIR> {
     readonly prototype: StructureKeeperLair;
@@ -231,8 +275,16 @@ interface StructureObserver extends OwnedStructure<STRUCTURE_OBSERVER> {
     readonly prototype: StructureObserver;
 
     /**
-     * Provide visibility into a distant room from your script. The target room object will be available on the next tick. The maximum range is 5 rooms.
+     * Provide visibility into a distant room from your script.
+     *
+     * The target room object will be available on the next tick. The maximum range is 5 rooms.
      * @param roomName The room to observe.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
+     * - ERR_NOT_IN_RANGE: Room roomName is not in observing range.
+     * - ERR_INVALID_ARGS: roomName argument is not a valid room name value.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
     observeRoom(roomName: string): ScreepsReturnCode;
 }
@@ -242,7 +294,10 @@ interface StructureObserverConstructor extends _Constructor<StructureObserver>, 
 declare const StructureObserver: StructureObserverConstructor;
 
 /**
- * Non-player structure. Contains power resource which can be obtained by destroying the structure. Hits the attacker creep back on each attack.
+ * Non-player structure.
+ *
+ * Contains power resource which can be obtained by destroying the structure.
+ * Hits the attacker creep back on each attack.
  */
 interface StructurePowerBank extends OwnedStructure<STRUCTURE_POWER_BANK> {
     readonly prototype: StructurePowerBank;
@@ -262,8 +317,10 @@ interface StructurePowerBankConstructor extends _Constructor<StructurePowerBank>
 declare const StructurePowerBank: StructurePowerBankConstructor;
 
 /**
- * Non-player structure. Contains power resource which can be obtained by
- * destroying the structure. Hits the attacker creep back on each attack.
+ * Non-player structure.
+ *
+ * Contains power resource which can be obtained by destroying the structure.
+ * Hits the attacker creep back on each attack.
  */
 interface StructurePowerSpawn extends OwnedStructure<STRUCTURE_POWER_SPAWN> {
     readonly prototype: StructurePowerSpawn;
@@ -288,12 +345,19 @@ interface StructurePowerSpawn extends OwnedStructure<STRUCTURE_POWER_SPAWN> {
      */
     powerCapacity: number;
     /**
-     *
+     * A Store object that contains cargo of this structure.
      */
     store: Store<RESOURCE_ENERGY | RESOURCE_POWER, false>;
 
     /**
-     * Register power resource units into your account. Registered power allows to develop power creeps skills. Consumes 1 power resource unit and 50 energy resource units.
+     * Register power resource units into your account.
+     *
+     * Registered power allows to develop power creeps skills. Consumes 1 power resource unit and 50 energy resource units.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
+     * - ERR_NOT_ENOUGH_RESOURCES: The structure does not have enough energy or power resource units.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
     processPower(): ScreepsReturnCode;
 }
@@ -303,6 +367,8 @@ interface StructurePowerSpawnConstructor extends _Constructor<StructurePowerSpaw
 declare const StructurePowerSpawn: StructurePowerSpawnConstructor;
 
 /**
+ * A rampart structure.
+ *
  * Blocks movement of hostile creeps, and defends your creeps and structures on
  * the same tile. Can be used as a controllable gate.
  */
@@ -315,13 +381,19 @@ interface StructureRampart extends OwnedStructure<STRUCTURE_RAMPART> {
     ticksToDecay: number;
 
     /**
-     * If false (default), only your creeps can step on the same square. If true, any hostile creeps can pass through.
+     * Whether the rampart is open to the public or not.
+     *
+     * If false (default), only your creeps can step on the same square.
+     * If true, any hostile creeps can pass through.
      */
     isPublic: boolean;
 
     /**
      * Make this rampart public to allow other players' creeps to pass through.
      * @param isPublic Whether this rampart should be public or non-public
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
      */
     setPublic(isPublic: boolean): undefined;
 }
@@ -331,8 +403,9 @@ interface StructureRampartConstructor extends _Constructor<StructureRampart>, _C
 declare const StructureRampart: StructureRampartConstructor;
 
 /**
- * Decreases movement cost to 1. Using roads allows creating creeps with less
- * `MOVE` body parts.
+ * Decreases movement cost to 1.
+ *
+ * Using roads allows creating creeps with less `MOVE` body parts.
  */
 interface StructureRoad extends Structure<STRUCTURE_ROAD> {
     readonly prototype: StructureRoad;
@@ -348,8 +421,9 @@ interface StructureRoadConstructor extends _Constructor<StructureRoad>, _Constru
 declare const StructureRoad: StructureRoadConstructor;
 
 /**
- * A structure that can store huge amount of resource units. Only one structure
- * per room is allowed that can be addressed by `Room.storage` property.
+ * A structure that can store huge amount of resource units.
+ *
+ * Only one structure per room is allowed that can be addressed by {@link Room.storage} property.
  */
 interface StructureStorage extends OwnedStructure<STRUCTURE_STORAGE> {
     readonly prototype: StructureStorage;
@@ -370,8 +444,9 @@ interface StructureStorageConstructor extends _Constructor<StructureStorage>, _C
 declare const StructureStorage: StructureStorageConstructor;
 
 /**
- * Remotely attacks or heals creeps, or repairs structures. Can be targeted to
- * any object in the room. However, its effectiveness highly depends on the
+ * Remotely attacks or heals creeps, or repairs structures.
+ *
+ * Can be targeted to any object in the room. However, its effectiveness highly depends on the
  * distance. Each action consumes energy.
  */
 interface StructureTower extends OwnedStructure<STRUCTURE_TOWER> {
@@ -393,18 +468,42 @@ interface StructureTower extends OwnedStructure<STRUCTURE_TOWER> {
     store: Store<RESOURCE_ENERGY, false>;
 
     /**
-     * Remotely attack any creep or structure in the room. Consumes 10 energy units per tick. Attack power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
+     * Remotely attack any creep or structure in the room.
+     *
+     * Consumes 10 energy units per tick. Attack power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
      * @param target The target creep.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
+     * - ERR_NOT_ENOUGH_ENERGY: The tower does not have enough energy.
+     * - ERR_INVALID_TARGET: The target is not a valid attackable object.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
     attack(target: AnyCreep | Structure): ScreepsReturnCode;
     /**
-     * Remotely heal any creep in the room. Consumes 10 energy units per tick. Heal power depends on the distance to the target: from 400 hits at range 10 to 200 hits at range 40.
+     * Remotely heal any creep in the room.
+     *
+     * Consumes 10 energy units per tick. Heal power depends on the distance to the target: from 400 hits at range 10 to 200 hits at range 40.
      * @param target The target creep.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
+     * - ERR_NOT_ENOUGH_ENERGY: The tower does not have enough energy.
+     * - ERR_INVALID_TARGET: The target is not a valid attackable object.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
     heal(target: AnyCreep): ScreepsReturnCode;
     /**
-     * Remotely repair any structure in the room. Consumes 10 energy units per tick. Repair power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
+     * Remotely repair any structure in the room.
+     *
+     * Consumes 10 energy units per tick. Repair power depends on the distance to the target: from 600 hits at range 10 to 300 hits at range 40.
      * @param target The target structure.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
+     * - ERR_NOT_ENOUGH_ENERGY: The tower does not have enough energy.
+     * - ERR_INVALID_TARGET: The target is not a valid attackable object.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
     repair(target: Structure): ScreepsReturnCode;
 }
@@ -468,7 +567,9 @@ interface StructureLab extends OwnedStructure<STRUCTURE_LAB> {
      */
     mineralAmount: number;
     /**
-     * The type of minerals containing in the lab. Labs can contain only one mineral type at the same time.
+     * The type of minerals containing in the lab.
+     *
+     * Labs can contain only one mineral type at the same time.
      * Null in case there is no mineral resource in the lab.
      */
     mineralType: MineralConstant | MineralCompoundConstant | null;
@@ -482,32 +583,74 @@ interface StructureLab extends OwnedStructure<STRUCTURE_LAB> {
      */
     store: Store<RESOURCE_ENERGY | MineralConstant | MineralCompoundConstant, false>;
     /**
-     * Boosts creep body part using the containing mineral compound. The creep has to be at adjacent square to the lab. Boosting one body part consumes 30 mineral units and 20 energy units.
+     * Boosts creep body part using the containing mineral compound.
+     *
+     * The creep has to be at adjacent square to the lab. Boosting one body part consumes 30 mineral units and 20 energy units.
      * @param creep The target creep.
      * @param bodyPartsCount The number of body parts of the corresponding type to be boosted.
-     *
      * Body parts are always counted left-to-right for TOUGH, and right-to-left for other types.
-     *
      * If undefined, all the eligible body parts are boosted.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this lab.
+     * - ERR_NOT_FOUND: The mineral containing in the lab cannot boost any of the creep's body parts.
+     * - ERR_NOT_ENOUGH_RESOURCES: The lab does not have enough energy or minerals.
+     * - ERR_INVALID_TARGET: The targets is not valid creep object.
+     * - ERR_NOT_IN_RANGE: The targets are too far away.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
     boostCreep(creep: Creep, bodyPartsCount?: number): ScreepsReturnCode;
     /**
+     * Unboost a creep.
+     *
      * Immediately remove boosts from the creep and drop 50% of the mineral compounds used to boost it onto the ground regardless of the creep's remaining time to live.
      * The creep has to be at adjacent square to the lab.
      * Unboosting requires cooldown time equal to the total sum of the reactions needed to produce all the compounds applied to the creep.
      * @param creep The target creep.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this lab, or the target creep.
+     * - ERR_NOT_FOUND: The target has no boosted parts.
+     * - ERR_INVALID_TARGET: The target is not a valid Creep object.
+     * - ERR_NOT_IN_RANGE: The target is too far away.
+     * - ERR_TIRED: The lab is still cooling down.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
     unboostCreep(creep: Creep): ScreepsReturnCode;
     /**
-     * Breaks mineral compounds back into reagents. The same output labs can be used by many source labs.
+     * Breaks mineral compounds back into reagents.
+     *
+     * The same output labs can be used by many source labs.
      * @param lab1 The first result lab.
      * @param lab2 The second result lab.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this lab.
+     * - ERR_NOT_ENOUGH_RESOURCES: The source lab do not have enough resources.
+     * - ERR_INVALID_TARGET: The targets are not valid lab objects.
+     * - ERR_FULL: One of targets cannot receive any more resource.
+     * - ERR_NOT_IN_RANGE: The targets are too far away.
+     * - ERR_INVALID_ARGS: The reaction cannot be reversed into this resources.
+     * - ERR_TIRED: The lab is still cooling down.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
     reverseReaction(lab1: StructureLab, lab2: StructureLab): ScreepsReturnCode;
     /**
-     * Produce mineral compounds using reagents from two another labs. Each lab has to be within 2 squares range. The same input labs can be used by many output labs
+     * Produce mineral compounds using reagents from two another labs.
+     *
+     * Each lab has to be within 2 squares range. The same input labs can be used by many output labs
      * @param lab1 The first source lab.
      * @param lab2 The second source lab.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this lab.
+     * - ERR_NOT_ENOUGH_RESOURCES: The source lab do not have enough resources.
+     * - ERR_INVALID_TARGET: The targets are not valid lab objects.
+     * - ERR_FULL: The target cannot receive any more resource.
+     * - ERR_NOT_IN_RANGE: The targets are too far away.
+     * - ERR_INVALID_ARGS: The reaction cannot be run using this resources.
+     * - ERR_TIRED: The lab is still cooling down.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
     runReaction(lab1: StructureLab, lab2: StructureLab): ScreepsReturnCode;
 }
@@ -522,7 +665,7 @@ declare const StructureLab: StructureLabConstructor;
 interface StructureTerminal extends OwnedStructure<STRUCTURE_TERMINAL> {
     readonly prototype: StructureTerminal;
     /**
-     * The remaining amount of ticks while this terminal cannot be used to make StructureTerminal.send or Game.market.deal calls.
+     * The remaining amount of ticks while this terminal cannot be used to make {@link StructureTerminal.send} or {@link Game.market.deal} calls.
      */
     cooldown: number;
     /**
@@ -536,10 +679,16 @@ interface StructureTerminal extends OwnedStructure<STRUCTURE_TERMINAL> {
     storeCapacity: number;
     /**
      * Sends resource to a Terminal in another room with the specified name.
-     * @param resourceType One of the RESOURCE_* constants.
+     * @param resourceType One of the {@link ResourceConstant} constants.
      * @param amount The amount of resources to be sent.
      * @param destination The name of the target room. You don't have to gain visibility in this room.
      * @param description The description of the transaction. It is visible to the recipient. The maximum length is 100 characters.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
+     * - ERR_NOT_ENOUGH_RESOURCES: The structure does not have the required amount of resources.
+     * - ERR_INVALID_ARGS: The arguments provided are incorrect.
+     * - ERR_TIRED: The terminal is still cooling down.
      */
     send(resourceType: ResourceConstant, amount: number, destination: string, description?: string): ScreepsReturnCode;
 }
@@ -549,13 +698,17 @@ interface StructureTerminalConstructor extends _Constructor<StructureTerminal>, 
 declare const StructureTerminal: StructureTerminalConstructor;
 
 /**
+ * A small resource store.
+ *
  * Contains up to 2,000 resource units. Can be constructed in neutral rooms. Decays for 5,000 hits per 100 ticks.
  */
 interface StructureContainer extends Structure<STRUCTURE_CONTAINER> {
     readonly prototype: StructureContainer;
     /**
-     * An object with the structure contents. Each object key is one of the RESOURCE_* constants, values are resources
-     * amounts. Use _.sum(structure.store) to get the total amount of contents
+     * An object with the structure contents.
+     *
+     * Each object key is one of the {@link ResourceConstant} constants, values are resources
+     * amounts. Use `_.sum(structure.store)` to get the total amount of contents.
      */
     store: StoreDefinition;
     /**
@@ -575,6 +728,7 @@ declare const StructureContainer: StructureContainerConstructor;
 
 /**
  * Launches a nuke to another room dealing huge damage to the landing area.
+ *
  * Each launch has a cooldown and requires energy and ghodium resources. Launching
  * creates a Nuke object at the target room position which is visible to any player
  * until it is landed. Incoming nuke cannot be moved or cancelled. Nukes cannot
@@ -613,6 +767,15 @@ interface StructureNuker extends OwnedStructure<STRUCTURE_NUKER> {
     /**
      * Launch a nuke to the specified position.
      * @param pos The target room position.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
+     * - ERR_NOT_ENOUGH_RESOURCES: The structure does not have enough energy and/or ghodium.
+     * - ERR_INVALID_TARGET: The nuke can't be launched to the specified RoomPosition (see Start Areas).
+     * - ERR_NOT_IN_RANGE: The target room is out of range.
+     * - ERR_INVALID_ARGS: The target is not a valid RoomPosition.
+     * - ERR_TIRED: This structure is still cooling down.
+     * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
     launchNuke(pos: RoomPosition): ScreepsReturnCode;
 }
@@ -623,13 +786,16 @@ declare const StructureNuker: StructureNukerConstructor;
 
 /**
  * A non-player structure.
+ *
  * Instantly teleports your creeps to a distant room acting as a room exit tile.
  * Portals appear randomly in the central room of each sector.
  */
 interface StructurePortal extends Structure<STRUCTURE_PORTAL> {
     readonly prototype: StructurePortal;
     /**
-     * If this is an inter-room portal, then this property contains a RoomPosition object leading to the point in the destination room.
+     * The portal's destination.
+     *
+     * If this is an inter-room portal, then this property contains a {@link RoomPosition} object leading to the point in the destination room.
      * If this is an inter-shard portal, then this property contains an object with shard and room string properties.
      * Exact coordinates are undetermined, the creep will appear at any free spot in the destination room.
      */
@@ -655,7 +821,8 @@ interface StructureFactory extends OwnedStructure<STRUCTURE_FACTORY> {
     cooldown: number;
     /**
      * The level of the factory.
-     * Can be set by applying the PWR_OPERATE_FACTORY power to a newly built factory.
+     *
+     * Can be set by applying the {@link PWR_OPERATE_FACTORY} power to a newly built factory.
      * Once set, the level cannot be changed.
      */
     level?: number;
@@ -665,7 +832,19 @@ interface StructureFactory extends OwnedStructure<STRUCTURE_FACTORY> {
     store: StoreDefinition;
     /**
      * Produces the specified commodity.
+     *
      * All ingredients should be available in the factory store.
+     * @param resource One of the {@link ResourceConstant} constants.
+     * @returns One of the following codes:
+     * - OK: The operation has been scheduled successfully.
+     * - ERR_NOT_OWNER: You are not the owner of this structure.
+     * - ERR_BUSY: The factory is not operated by the PWR_OPERATE_FACTORY power.
+     * - ERR_NOT_ENOUGH_RESOURCES: The structure does not have the required amount of resources.
+     * - ERR_INVALID_TARGET: The factory cannot produce the commodity of this level.
+     * - ERR_FULL: The factory cannot contain the produce.
+     * - ERR_INVALID_ARGS: The arguments provided are incorrect.
+     * - ERR_TIRED: The factory is still cooling down.
+     * - ERR_RCL_NOT_ENOUGH: Your Room Controller level is insufficient to use the factory.
      */
     produce(resource: CommoditiesTypes): ScreepsReturnCode;
 }
@@ -680,7 +859,9 @@ declare const StructureFactory: StructureFactoryConstructor;
 interface StructureInvaderCore extends OwnedStructure<STRUCTURE_INVADER_CORE> {
     readonly prototype: StructureInvaderCore;
     /**
-     * The level of the stronghold. The amount and quality of the loot depends on the level.
+     * The level of the stronghold.
+     *
+     * The amount and quality of the loot depends on the level.
      */
     level: number;
     /**
@@ -688,7 +869,7 @@ interface StructureInvaderCore extends OwnedStructure<STRUCTURE_INVADER_CORE> {
      */
     ticksToDeploy: number;
     /**
-     * If the core is in process of spawning a new creep, this object will contain a `StructureSpawn.Spawning` object, or `null` otherwise.
+     * If the core is in process of spawning a new creep, this object will contain a {@link StructureSpawn.Spawning} object, or `null` otherwise.
      */
     spawning: Spawning | null;
 }
@@ -733,7 +914,7 @@ type AnyStoreStructure =
     | StructureContainer;
 
 /**
- * A discriminated union on Structure.type of all structure types
+ * A discriminated union on {@link Structure.structureType} of all structure types
  */
 type AnyStructure = AnyOwnedStructure | StructureContainer | StructurePortal | StructureRoad | StructureWall;
 
@@ -766,6 +947,7 @@ interface ConcreteStructureMap {
 
 /**
  * Conditional type for all concrete implementations of Structure.
- * Unlike Structure<T>, ConcreteStructure<T> gives you the actual concrete class that extends Structure<T>.
+ *
+ * Unlike {@link Structure<T>}, {@link ConcreteStructure<T>} gives you the actual concrete class that extends {@link Structure<T>}.
  */
 type ConcreteStructure<T extends StructureConstant> = ConcreteStructureMap[T];

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -26,7 +26,7 @@ interface Structure<T extends StructureConstant = StructureConstant> extends Roo
      */
     room: Room;
     /**
-     * One of the {@link StructureConstant} constants.
+     * One of the {@link StructureConstant STRUCTURE_*} constants.
      */
     structureType: T;
     /**
@@ -157,7 +157,7 @@ interface StructureController extends OwnedStructure<STRUCTURE_CONTROLLER> {
     activateSafeMode(): ScreepsReturnCode;
     /**
      * Make your claimed controller neutral again.
-     * @returnsOne of the following codes:
+     * @returns One of the following codes:
      * - OK: The operation has been scheduled successfully.
      * - ERR_NOT_OWNER: You are not the owner of this controller.
      */
@@ -679,7 +679,7 @@ interface StructureTerminal extends OwnedStructure<STRUCTURE_TERMINAL> {
     storeCapacity: number;
     /**
      * Sends resource to a Terminal in another room with the specified name.
-     * @param resourceType One of the {@link ResourceConstant} constants.
+     * @param resourceType One of the {@link ResourceConstant RESOURCE_*} constants.
      * @param amount The amount of resources to be sent.
      * @param destination The name of the target room. You don't have to gain visibility in this room.
      * @param description The description of the transaction. It is visible to the recipient. The maximum length is 100 characters.
@@ -707,7 +707,7 @@ interface StructureContainer extends Structure<STRUCTURE_CONTAINER> {
     /**
      * An object with the structure contents.
      *
-     * Each object key is one of the {@link ResourceConstant} constants, values are resources
+     * Each object key is one of the {@link ResourceConstant RESOURCE_*} constants, values are resources
      * amounts. Use `_.sum(structure.store)` to get the total amount of contents.
      */
     store: StoreDefinition;
@@ -834,7 +834,7 @@ interface StructureFactory extends OwnedStructure<STRUCTURE_FACTORY> {
      * Produces the specified commodity.
      *
      * All ingredients should be available in the factory store.
-     * @param resource One of the {@link ResourceConstant} constants.
+     * @param resource One of the {@link CommoditiesTypes producible RESOURCE_*} constants.
      * @returns One of the following codes:
      * - OK: The operation has been scheduled successfully.
      * - ERR_NOT_OWNER: You are not the owner of this structure.

--- a/src/tombstone.ts
+++ b/src/tombstone.ts
@@ -18,7 +18,7 @@ interface Tombstone extends RoomObject {
     /**
      * An object with the tombstone contents.
      *
-     * Each object key is one of the {@link ResourceConstant} constants, values are resources amounts.
+     * Each object key is one of the {@link ResourceConstant RESOURCE_*} constants, values are resources amounts.
      * {@link RESOURCE_ENERGY} is always defined and equals to 0 when empty, other resources are undefined when empty.
      * You can use `_.sum(tombstone.store)` to get the total amount of contents.
      */

--- a/src/tombstone.ts
+++ b/src/tombstone.ts
@@ -1,13 +1,14 @@
 /**
- * A remnant of dead creeps. This is a walkable structure.
- * <ul>
- *     <li>Decay: 5 ticks per body part of the deceased creep</li>
- * </ul>
+ * A creep's final resting place.
+ *
+ * This is a walkable structure.
+ * Will decay 5 ticks per body part of the deceased creep.
  */
 interface Tombstone extends RoomObject {
     /**
-     * A unique object identificator.
-     * You can use {@link Game.getObjectById} method to retrieve an object instance by its id.
+     * A unique object identifier.
+     *
+     * You can use {@link Game.getObjectById} to retrieve an object instance by its id.
      */
     id: Id<this>;
     /**
@@ -16,10 +17,10 @@ interface Tombstone extends RoomObject {
     deathTime: number;
     /**
      * An object with the tombstone contents.
-     * Each object key is one of the RESOURCE_* constants, values are resources amounts.
-     * RESOURCE_ENERGY is always defined and equals to 0 when empty,
-     * other resources are undefined when empty.
-     * You can use lodash.sum to get the total amount of contents.
+     *
+     * Each object key is one of the {@link ResourceConstant} constants, values are resources amounts.
+     * {@link RESOURCE_ENERGY} is always defined and equals to 0 when empty, other resources are undefined when empty.
+     * You can use `_.sum(tombstone.store)` to get the total amount of contents.
      */
     store: StoreDefinitionUnlimited;
     /**


### PR DESCRIPTION
### Brief Description

This copies over the return into from the official docs to have their meaning directly into the docs. Should be purely comment changes (except a few long lines prettier decided to reformat).

### Checklists

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run compile` to update `index.d.ts`
