### PR TITLE
Feat!: Remove `prototype` access to instance interfaces

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1035,7 +1035,6 @@ declare const POWER_INFO: {
  * You can remove enemy construction sites by moving a creep on it.
  */
 interface ConstructionSite<T extends BuildableStructureConstant = BuildableStructureConstant> extends RoomObject {
-    readonly prototype: ConstructionSite;
     /**
      * A unique object identifier.
      *
@@ -1100,8 +1099,6 @@ declare const ConstructionSite: ConstructionSiteConstructor;
  * | TOUGH           | 10         | No effect, just additional hit points to the creep's body. Can be boosted to resist damage.
  */
 interface Creep extends RoomObject {
-    readonly prototype: Creep;
-
     /**
      * An array describing the creep's body.
      */
@@ -1679,8 +1676,6 @@ declare const Deposit: DepositConstructor;
  * Flags can be used to mark particular spots in a room. Flags are visible to their owners only. You cannot have more than 10,000 flags.
  */
 interface Flag extends RoomObject {
-    readonly prototype: Flag;
-
     /**
      * Flag color. One of the {@link ColorConstant COLOR_*} constants.
      */
@@ -3672,10 +3667,6 @@ declare const Memory: Memory;
  */
 interface Mineral<T extends MineralConstant = MineralConstant> extends RoomObject {
     /**
-     * The prototype is stored in the Mineral.prototype global object. You can use it to extend game objects behaviour globally.
-     */
-    readonly prototype: Mineral;
-    /**
      * The density of this mineral deposit, one of the {@link DensityConstant DENSITY_*} constants.
      */
     density: DensityConstant;
@@ -3723,8 +3714,6 @@ declare const Mineral: MineralConstructor;
  * The room controller is hit by triggering {@link StructureController.upgradeBlocked} period, which means it is unavailable to activate safe mode again within the next 200 ticks.
  */
 interface Nuke extends RoomObject {
-    readonly prototype: Nuke;
-
     /**
      * A unique object identifier.
      *
@@ -4412,8 +4401,6 @@ declare const RawMemory: RawMemory;
  */
 
 interface Resource<T extends ResourceConstant = ResourceConstant> extends RoomObject {
-    readonly prototype: Resource;
-
     /**
      * The amount of resource units containing.
      */
@@ -4440,7 +4427,6 @@ declare const Resource: ResourceConstructor;
  */
 
 interface RoomObject {
-    readonly prototype: RoomObject;
     /**
      * Effects currently being applied to the object.
      */
@@ -4521,8 +4507,6 @@ interface PowerEffect {
  * The position object of a custom location can be obtained using the {@link Room.getPositionAt()} method or using the constructor.
  */
 interface RoomPosition {
-    readonly prototype: RoomPosition;
-
     /**
      * The name of the room.
      */
@@ -5034,8 +5018,6 @@ interface TextStyle {
  * Every object in the room contains its linked Room instance in the {@link RoomObject.room} property.
  */
 interface Room {
-    readonly prototype: Room;
-
     /**
      * The Controller structure of this room, if present, otherwise undefined.
      */
@@ -5361,10 +5343,6 @@ declare const Ruin: RuinConstructor;
  */
 interface Source extends RoomObject {
     /**
-     * The prototype is stored in the Source.prototype global object. You can use it to extend game objects behaviour globally:
-     */
-    readonly prototype: Source;
-    /**
      * The remaining amount of energy.
      */
     energy: number;
@@ -5415,7 +5393,6 @@ declare const Source: SourceConstructor;
  * | **Energy auto-regeneration**  | 1 energy unit per tick while energy available | in the room (in all spawns and extensions) is less than 300
  */
 interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
-    readonly prototype: StructureSpawn;
     /**
      * The amount of energy containing in the spawn.
      * @deprecated An alias for .store[RESOURCE_ENERGY].
@@ -5576,8 +5553,6 @@ declare const Spawn: StructureSpawnConstructor; // legacy alias
 // declare type Spawn = StructureSpawn;
 
 interface Spawning {
-    readonly prototype: Spawning;
-
     /**
      * An array with the spawn directions
      *
@@ -5755,8 +5730,6 @@ type GenericStore = GenericStoreBase & { [P in ResourceConstant]: number };
  * The base prototype object of all structures.
  */
 interface Structure<T extends StructureConstant = StructureConstant> extends RoomObject {
-    readonly prototype: Structure;
-
     /**
      * The current amount of hit points of the structure.
      */
@@ -5815,8 +5788,6 @@ declare const Structure: StructureConstructor;
  * Such structures can be found using {@link Room.find} and the {@link FIND_MY_STRUCTURES} & {@link FIND_HOSTILE_STRUCTURES} constants.
  */
 interface OwnedStructure<T extends StructureConstant = StructureConstant> extends Structure<T> {
-    readonly prototype: OwnedStructure;
-
     /**
      * Whether this is your own structure.
      *
@@ -5846,8 +5817,6 @@ declare const OwnedStructure: OwnedStructureConstructor;
  * It can be addressed by {@link Room.controller} property.
  */
 interface StructureController extends OwnedStructure<STRUCTURE_CONTROLLER> {
-    readonly prototype: StructureController;
-
     /**
      * Whether using power is enabled in this room.
      *
@@ -5927,8 +5896,6 @@ declare const StructureController: StructureControllerConstructor;
  * Extensions can be placed anywhere in the room, any spawns will be able to use them regardless of distance.
  */
 interface StructureExtension extends OwnedStructure<STRUCTURE_EXTENSION> {
-    readonly prototype: StructureExtension;
-
     /**
      * The amount of energy containing in the extension.
      *
@@ -5956,8 +5923,6 @@ declare const StructureExtension: StructureExtensionConstructor;
  * Remotely transfers energy to another Link in the same room.
  */
 interface StructureLink extends OwnedStructure<STRUCTURE_LINK> {
-    readonly prototype: StructureLink;
-
     /**
      * The amount of game ticks the link has to wait until the next transfer is possible.
      */
@@ -6009,8 +5974,6 @@ declare const StructureLink: StructureLinkConstructor;
  * This structure cannot be destroyed.
  */
 interface StructureKeeperLair extends OwnedStructure<STRUCTURE_KEEPER_LAIR> {
-    readonly prototype: StructureKeeperLair;
-
     /**
      * Time to spawning of the next Source Keeper.
      */
@@ -6025,8 +5988,6 @@ declare const StructureKeeperLair: StructureKeeperLairConstructor;
  * Provides visibility into a distant room from your script.
  */
 interface StructureObserver extends OwnedStructure<STRUCTURE_OBSERVER> {
-    readonly prototype: StructureObserver;
-
     /**
      * Provide visibility into a distant room from your script.
      *
@@ -6053,8 +6014,6 @@ declare const StructureObserver: StructureObserverConstructor;
  * Hits the attacker creep back on each attack.
  */
 interface StructurePowerBank extends OwnedStructure<STRUCTURE_POWER_BANK> {
-    readonly prototype: StructurePowerBank;
-
     /**
      * The amount of power containing.
      */
@@ -6076,7 +6035,6 @@ declare const StructurePowerBank: StructurePowerBankConstructor;
  * Hits the attacker creep back on each attack.
  */
 interface StructurePowerSpawn extends OwnedStructure<STRUCTURE_POWER_SPAWN> {
-    readonly prototype: StructurePowerSpawn;
     /**
      * The amount of energy containing in this structure.
      * @deprecated An alias for .store[RESOURCE_ENERGY].
@@ -6126,8 +6084,6 @@ declare const StructurePowerSpawn: StructurePowerSpawnConstructor;
  * the same tile. Can be used as a controllable gate.
  */
 interface StructureRampart extends OwnedStructure<STRUCTURE_RAMPART> {
-    readonly prototype: StructureRampart;
-
     /**
      * The amount of game ticks when this rampart will lose some hit points.
      */
@@ -6161,8 +6117,6 @@ declare const StructureRampart: StructureRampartConstructor;
  * Using roads allows creating creeps with less `MOVE` body parts.
  */
 interface StructureRoad extends Structure<STRUCTURE_ROAD> {
-    readonly prototype: StructureRoad;
-
     /**
      * The amount of game ticks when this road will lose some hit points.
      */
@@ -6179,8 +6133,6 @@ declare const StructureRoad: StructureRoadConstructor;
  * Only one structure per room is allowed that can be addressed by {@link Room.storage} property.
  */
 interface StructureStorage extends OwnedStructure<STRUCTURE_STORAGE> {
-    readonly prototype: StructureStorage;
-
     /**
      * An object with the storage contents.
      */
@@ -6203,8 +6155,6 @@ declare const StructureStorage: StructureStorageConstructor;
  * distance. Each action consumes energy.
  */
 interface StructureTower extends OwnedStructure<STRUCTURE_TOWER> {
-    readonly prototype: StructureTower;
-
     /**
      * The amount of energy containing in this structure.
      * @deprecated An alias for .store[RESOURCE_ENERGY].
@@ -6269,7 +6219,6 @@ declare const StructureTower: StructureTowerConstructor;
  * Blocks movement of all creeps.
  */
 interface StructureWall extends Structure<STRUCTURE_WALL> {
-    readonly prototype: StructureWall;
     /**
      * The amount of game ticks when the wall will disappear (only for automatically placed border walls at the start of the game).
      */
@@ -6284,7 +6233,6 @@ declare const StructureWall: StructureWallConstructor;
  * Allows to harvest mineral deposits.
  */
 interface StructureExtractor extends OwnedStructure<STRUCTURE_EXTRACTOR> {
-    readonly prototype: StructureExtractor;
     /**
      * The amount of game ticks until the next harvest action is possible.
      */
@@ -6299,7 +6247,6 @@ declare const StructureExtractor: StructureExtractorConstructor;
  * Produces mineral compounds from base minerals and boosts creeps.
  */
 interface StructureLab extends OwnedStructure<STRUCTURE_LAB> {
-    readonly prototype: StructureLab;
     /**
      * The amount of game ticks the lab has to wait until the next reaction is possible.
      */
@@ -6416,7 +6363,6 @@ declare const StructureLab: StructureLabConstructor;
  * Sends any resources to a Terminal in another room.
  */
 interface StructureTerminal extends OwnedStructure<STRUCTURE_TERMINAL> {
-    readonly prototype: StructureTerminal;
     /**
      * The remaining amount of ticks while this terminal cannot be used to make {@link StructureTerminal.send} or {@link Game.market.deal} calls.
      */
@@ -6456,7 +6402,6 @@ declare const StructureTerminal: StructureTerminalConstructor;
  * Contains up to 2,000 resource units. Can be constructed in neutral rooms. Decays for 5,000 hits per 100 ticks.
  */
 interface StructureContainer extends Structure<STRUCTURE_CONTAINER> {
-    readonly prototype: StructureContainer;
     /**
      * An object with the structure contents.
      *
@@ -6488,7 +6433,6 @@ declare const StructureContainer: StructureContainerConstructor;
  * be launched from or to novice rooms.
  */
 interface StructureNuker extends OwnedStructure<STRUCTURE_NUKER> {
-    readonly prototype: StructureNuker;
     /**
      * The amount of energy contained in this structure.
      * @deprecated An alias for .store[RESOURCE_ENERGY].
@@ -6544,7 +6488,6 @@ declare const StructureNuker: StructureNukerConstructor;
  * Portals appear randomly in the central room of each sector.
  */
 interface StructurePortal extends Structure<STRUCTURE_PORTAL> {
-    readonly prototype: StructurePortal;
     /**
      * The portal's destination.
      *
@@ -6567,7 +6510,6 @@ declare const StructurePortal: StructurePortalConstructor;
  * A structure which produces trade commodities from base minerals and other commodities.
  */
 interface StructureFactory extends OwnedStructure<STRUCTURE_FACTORY> {
-    readonly prototype: StructureFactory;
     /**
      * The amount of game ticks the factory has to wait until the next produce is possible.
      */
@@ -6610,7 +6552,6 @@ declare const StructureFactory: StructureFactoryConstructor;
  * A structure which is a control center of NPC Strongholds, and also rules all invaders in the sector.
  */
 interface StructureInvaderCore extends OwnedStructure<STRUCTURE_INVADER_CORE> {
-    readonly prototype: StructureInvaderCore;
     /**
      * The level of the stronghold.
      *

--- a/src/construction-site.ts
+++ b/src/construction-site.ts
@@ -8,7 +8,6 @@
  * You can remove enemy construction sites by moving a creep on it.
  */
 interface ConstructionSite<T extends BuildableStructureConstant = BuildableStructureConstant> extends RoomObject {
-    readonly prototype: ConstructionSite;
     /**
      * A unique object identifier.
      *

--- a/src/creep.ts
+++ b/src/creep.ts
@@ -26,8 +26,6 @@
  * | TOUGH           | 10         | No effect, just additional hit points to the creep's body. Can be boosted to resist damage.
  */
 interface Creep extends RoomObject {
-    readonly prototype: Creep;
-
     /**
      * An array describing the creep's body.
      */

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -4,8 +4,6 @@
  * Flags can be used to mark particular spots in a room. Flags are visible to their owners only. You cannot have more than 10,000 flags.
  */
 interface Flag extends RoomObject {
-    readonly prototype: Flag;
-
     /**
      * Flag color. One of the {@link ColorConstant COLOR_*} constants.
      */

--- a/src/mineral.ts
+++ b/src/mineral.ts
@@ -19,10 +19,6 @@
  */
 interface Mineral<T extends MineralConstant = MineralConstant> extends RoomObject {
     /**
-     * The prototype is stored in the Mineral.prototype global object. You can use it to extend game objects behaviour globally.
-     */
-    readonly prototype: Mineral;
-    /**
      * The density of this mineral deposit, one of the {@link DensityConstant DENSITY_*} constants.
      */
     density: DensityConstant;

--- a/src/nuke.ts
+++ b/src/nuke.ts
@@ -19,8 +19,6 @@
  * The room controller is hit by triggering {@link StructureController.upgradeBlocked} period, which means it is unavailable to activate safe mode again within the next 200 ticks.
  */
 interface Nuke extends RoomObject {
-    readonly prototype: Nuke;
-
     /**
      * A unique object identifier.
      *

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -6,8 +6,6 @@
  */
 
 interface Resource<T extends ResourceConstant = ResourceConstant> extends RoomObject {
-    readonly prototype: Resource;
-
     /**
      * The amount of resource units containing.
      */

--- a/src/room-object.ts
+++ b/src/room-object.ts
@@ -5,7 +5,6 @@
  */
 
 interface RoomObject {
-    readonly prototype: RoomObject;
     /**
      * Effects currently being applied to the object.
      */

--- a/src/room-position.ts
+++ b/src/room-position.ts
@@ -6,8 +6,6 @@
  * The position object of a custom location can be obtained using the {@link Room.getPositionAt()} method or using the constructor.
  */
 interface RoomPosition {
-    readonly prototype: RoomPosition;
-
     /**
      * The name of the room.
      */

--- a/src/room.ts
+++ b/src/room.ts
@@ -6,8 +6,6 @@
  * Every object in the room contains its linked Room instance in the {@link RoomObject.room} property.
  */
 interface Room {
-    readonly prototype: Room;
-
     /**
      * The Controller structure of this room, if present, otherwise undefined.
      */

--- a/src/source.ts
+++ b/src/source.ts
@@ -12,10 +12,6 @@
  */
 interface Source extends RoomObject {
     /**
-     * The prototype is stored in the Source.prototype global object. You can use it to extend game objects behaviour globally:
-     */
-    readonly prototype: Source;
-    /**
      * The remaining amount of energy.
      */
     energy: number;

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -20,7 +20,6 @@
  * | **Energy auto-regeneration**  | 1 energy unit per tick while energy available | in the room (in all spawns and extensions) is less than 300
  */
 interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
-    readonly prototype: StructureSpawn;
     /**
      * The amount of energy containing in the spawn.
      * @deprecated An alias for .store[RESOURCE_ENERGY].
@@ -181,8 +180,6 @@ declare const Spawn: StructureSpawnConstructor; // legacy alias
 // declare type Spawn = StructureSpawn;
 
 interface Spawning {
-    readonly prototype: Spawning;
-
     /**
      * An array with the spawn directions
      *

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -2,8 +2,6 @@
  * The base prototype object of all structures.
  */
 interface Structure<T extends StructureConstant = StructureConstant> extends RoomObject {
-    readonly prototype: Structure;
-
     /**
      * The current amount of hit points of the structure.
      */
@@ -62,8 +60,6 @@ declare const Structure: StructureConstructor;
  * Such structures can be found using {@link Room.find} and the {@link FIND_MY_STRUCTURES} & {@link FIND_HOSTILE_STRUCTURES} constants.
  */
 interface OwnedStructure<T extends StructureConstant = StructureConstant> extends Structure<T> {
-    readonly prototype: OwnedStructure;
-
     /**
      * Whether this is your own structure.
      *
@@ -93,8 +89,6 @@ declare const OwnedStructure: OwnedStructureConstructor;
  * It can be addressed by {@link Room.controller} property.
  */
 interface StructureController extends OwnedStructure<STRUCTURE_CONTROLLER> {
-    readonly prototype: StructureController;
-
     /**
      * Whether using power is enabled in this room.
      *
@@ -174,8 +168,6 @@ declare const StructureController: StructureControllerConstructor;
  * Extensions can be placed anywhere in the room, any spawns will be able to use them regardless of distance.
  */
 interface StructureExtension extends OwnedStructure<STRUCTURE_EXTENSION> {
-    readonly prototype: StructureExtension;
-
     /**
      * The amount of energy containing in the extension.
      *
@@ -203,8 +195,6 @@ declare const StructureExtension: StructureExtensionConstructor;
  * Remotely transfers energy to another Link in the same room.
  */
 interface StructureLink extends OwnedStructure<STRUCTURE_LINK> {
-    readonly prototype: StructureLink;
-
     /**
      * The amount of game ticks the link has to wait until the next transfer is possible.
      */
@@ -256,8 +246,6 @@ declare const StructureLink: StructureLinkConstructor;
  * This structure cannot be destroyed.
  */
 interface StructureKeeperLair extends OwnedStructure<STRUCTURE_KEEPER_LAIR> {
-    readonly prototype: StructureKeeperLair;
-
     /**
      * Time to spawning of the next Source Keeper.
      */
@@ -272,8 +260,6 @@ declare const StructureKeeperLair: StructureKeeperLairConstructor;
  * Provides visibility into a distant room from your script.
  */
 interface StructureObserver extends OwnedStructure<STRUCTURE_OBSERVER> {
-    readonly prototype: StructureObserver;
-
     /**
      * Provide visibility into a distant room from your script.
      *
@@ -300,8 +286,6 @@ declare const StructureObserver: StructureObserverConstructor;
  * Hits the attacker creep back on each attack.
  */
 interface StructurePowerBank extends OwnedStructure<STRUCTURE_POWER_BANK> {
-    readonly prototype: StructurePowerBank;
-
     /**
      * The amount of power containing.
      */
@@ -323,7 +307,6 @@ declare const StructurePowerBank: StructurePowerBankConstructor;
  * Hits the attacker creep back on each attack.
  */
 interface StructurePowerSpawn extends OwnedStructure<STRUCTURE_POWER_SPAWN> {
-    readonly prototype: StructurePowerSpawn;
     /**
      * The amount of energy containing in this structure.
      * @deprecated An alias for .store[RESOURCE_ENERGY].
@@ -373,8 +356,6 @@ declare const StructurePowerSpawn: StructurePowerSpawnConstructor;
  * the same tile. Can be used as a controllable gate.
  */
 interface StructureRampart extends OwnedStructure<STRUCTURE_RAMPART> {
-    readonly prototype: StructureRampart;
-
     /**
      * The amount of game ticks when this rampart will lose some hit points.
      */
@@ -408,8 +389,6 @@ declare const StructureRampart: StructureRampartConstructor;
  * Using roads allows creating creeps with less `MOVE` body parts.
  */
 interface StructureRoad extends Structure<STRUCTURE_ROAD> {
-    readonly prototype: StructureRoad;
-
     /**
      * The amount of game ticks when this road will lose some hit points.
      */
@@ -426,8 +405,6 @@ declare const StructureRoad: StructureRoadConstructor;
  * Only one structure per room is allowed that can be addressed by {@link Room.storage} property.
  */
 interface StructureStorage extends OwnedStructure<STRUCTURE_STORAGE> {
-    readonly prototype: StructureStorage;
-
     /**
      * An object with the storage contents.
      */
@@ -450,8 +427,6 @@ declare const StructureStorage: StructureStorageConstructor;
  * distance. Each action consumes energy.
  */
 interface StructureTower extends OwnedStructure<STRUCTURE_TOWER> {
-    readonly prototype: StructureTower;
-
     /**
      * The amount of energy containing in this structure.
      * @deprecated An alias for .store[RESOURCE_ENERGY].
@@ -516,7 +491,6 @@ declare const StructureTower: StructureTowerConstructor;
  * Blocks movement of all creeps.
  */
 interface StructureWall extends Structure<STRUCTURE_WALL> {
-    readonly prototype: StructureWall;
     /**
      * The amount of game ticks when the wall will disappear (only for automatically placed border walls at the start of the game).
      */
@@ -531,7 +505,6 @@ declare const StructureWall: StructureWallConstructor;
  * Allows to harvest mineral deposits.
  */
 interface StructureExtractor extends OwnedStructure<STRUCTURE_EXTRACTOR> {
-    readonly prototype: StructureExtractor;
     /**
      * The amount of game ticks until the next harvest action is possible.
      */
@@ -546,7 +519,6 @@ declare const StructureExtractor: StructureExtractorConstructor;
  * Produces mineral compounds from base minerals and boosts creeps.
  */
 interface StructureLab extends OwnedStructure<STRUCTURE_LAB> {
-    readonly prototype: StructureLab;
     /**
      * The amount of game ticks the lab has to wait until the next reaction is possible.
      */
@@ -663,7 +635,6 @@ declare const StructureLab: StructureLabConstructor;
  * Sends any resources to a Terminal in another room.
  */
 interface StructureTerminal extends OwnedStructure<STRUCTURE_TERMINAL> {
-    readonly prototype: StructureTerminal;
     /**
      * The remaining amount of ticks while this terminal cannot be used to make {@link StructureTerminal.send} or {@link Game.market.deal} calls.
      */
@@ -703,7 +674,6 @@ declare const StructureTerminal: StructureTerminalConstructor;
  * Contains up to 2,000 resource units. Can be constructed in neutral rooms. Decays for 5,000 hits per 100 ticks.
  */
 interface StructureContainer extends Structure<STRUCTURE_CONTAINER> {
-    readonly prototype: StructureContainer;
     /**
      * An object with the structure contents.
      *
@@ -735,7 +705,6 @@ declare const StructureContainer: StructureContainerConstructor;
  * be launched from or to novice rooms.
  */
 interface StructureNuker extends OwnedStructure<STRUCTURE_NUKER> {
-    readonly prototype: StructureNuker;
     /**
      * The amount of energy contained in this structure.
      * @deprecated An alias for .store[RESOURCE_ENERGY].
@@ -791,7 +760,6 @@ declare const StructureNuker: StructureNukerConstructor;
  * Portals appear randomly in the central room of each sector.
  */
 interface StructurePortal extends Structure<STRUCTURE_PORTAL> {
-    readonly prototype: StructurePortal;
     /**
      * The portal's destination.
      *
@@ -814,7 +782,6 @@ declare const StructurePortal: StructurePortalConstructor;
  * A structure which produces trade commodities from base minerals and other commodities.
  */
 interface StructureFactory extends OwnedStructure<STRUCTURE_FACTORY> {
-    readonly prototype: StructureFactory;
     /**
      * The amount of game ticks the factory has to wait until the next produce is possible.
      */
@@ -857,7 +824,6 @@ declare const StructureFactory: StructureFactoryConstructor;
  * A structure which is a control center of NPC Strongholds, and also rules all invaders in the sector.
  */
 interface StructureInvaderCore extends OwnedStructure<STRUCTURE_INVADER_CORE> {
-    readonly prototype: StructureInvaderCore;
     /**
      * The level of the stronghold.
      *


### PR DESCRIPTION
In the javascript world, `prototype` can only be accessed from constructors. Adding `prototype` to these interfaces is invalid and wrong

Anyway, this may break something. Please merge this PR only if we are about to release a major update.

<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->


### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run compile` to update `index.d.ts`
