### PR TITLE
Updates to POWER_INFO and PowerCreep.powers

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -897,6 +897,7 @@ declare const POWER_INFO: {
         effect?: number[];
         range?: number;
         ops?: number | number[];
+        energy?: number;
         duration?: number | number[];
     };
     [PWR_GENERATE_OPS]: {
@@ -4375,8 +4376,12 @@ interface PowerCreepConstructor extends _Constructor<PowerCreep>, _ConstructorBy
 
 declare const PowerCreep: PowerCreepConstructor;
 
+type PowerId = keyof typeof POWER_INFO;
+
 /**
- * Available powers, an object with power ID as a key, and the following properties
+ * Available powers, an object with power ID as a key, and the following properties.
+ *
+ * If a PowerCreep does not have at least level 1 for a given power, undefined is returned.
  */
 interface PowerCreepPowers {
     [powerID: number]: {
@@ -4386,11 +4391,9 @@ interface PowerCreepPowers {
         level: number;
         /**
          * Cooldown ticks remaining
-         *
-         * Will be undefined if the power creep is not spawned in the world.
          */
-        cooldown: number | undefined;
-    };
+        cooldown: number;
+    } | undefined;
 }
 /**
  * RawMemory object allows to implement your own memory stringifier instead of built-in serializer based on JSON.stringify.

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -4376,24 +4376,24 @@ interface PowerCreepConstructor extends _Constructor<PowerCreep>, _ConstructorBy
 
 declare const PowerCreep: PowerCreepConstructor;
 
-type PowerId = keyof typeof POWER_INFO;
-
 /**
  * Available powers, an object with power ID as a key, and the following properties.
  *
  * If a PowerCreep does not have at least level 1 for a given power, undefined is returned.
  */
 interface PowerCreepPowers {
-    [powerID: number]: {
-        /**
-         * Current level of the power
-         */
-        level: number;
-        /**
-         * Cooldown ticks remaining
-         */
-        cooldown: number;
-    } | undefined;
+    [powerID: number]:
+        | {
+              /**
+               * Current level of the power
+               */
+              level: number;
+              /**
+               * Cooldown ticks remaining
+               */
+              cooldown: number;
+          }
+        | undefined;
 }
 /**
  * RawMemory object allows to implement your own memory stringifier instead of built-in serializer based on JSON.stringify.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -863,6 +863,7 @@ declare const POWER_INFO: {
         effect?: number[];
         range?: number;
         ops?: number | number[];
+        energy?: number;
         duration?: number | number[];
     };
     [PWR_GENERATE_OPS]: {

--- a/src/power-creep.ts
+++ b/src/power-creep.ts
@@ -372,8 +372,12 @@ interface PowerCreepConstructor extends _Constructor<PowerCreep>, _ConstructorBy
 
 declare const PowerCreep: PowerCreepConstructor;
 
+type PowerId = keyof typeof POWER_INFO;
+
 /**
- * Available powers, an object with power ID as a key, and the following properties
+ * Available powers, an object with power ID as a key, and the following properties.
+ *
+ * If a PowerCreep does not have at least level 1 for a given power, undefined is returned.
  */
 interface PowerCreepPowers {
     [powerID: number]: {
@@ -383,9 +387,7 @@ interface PowerCreepPowers {
         level: number;
         /**
          * Cooldown ticks remaining
-         *
-         * Will be undefined if the power creep is not spawned in the world.
          */
-        cooldown: number | undefined;
-    };
+        cooldown: number;
+    } | undefined;
 }

--- a/src/power-creep.ts
+++ b/src/power-creep.ts
@@ -372,22 +372,22 @@ interface PowerCreepConstructor extends _Constructor<PowerCreep>, _ConstructorBy
 
 declare const PowerCreep: PowerCreepConstructor;
 
-type PowerId = keyof typeof POWER_INFO;
-
 /**
  * Available powers, an object with power ID as a key, and the following properties.
  *
  * If a PowerCreep does not have at least level 1 for a given power, undefined is returned.
  */
 interface PowerCreepPowers {
-    [powerID: number]: {
-        /**
-         * Current level of the power
-         */
-        level: number;
-        /**
-         * Cooldown ticks remaining
-         */
-        cooldown: number;
-    } | undefined;
+    [powerID: number]:
+        | {
+              /**
+               * Current level of the power
+               */
+              level: number;
+              /**
+               * Cooldown ticks remaining
+               */
+              cooldown: number;
+          }
+        | undefined;
 }


### PR DESCRIPTION
### Brief Description

* `POWER_INFO[PWR_SHIELD].energy` is now exposed as a number field
* `PowerCreep.powers` reflects undefined results for missing powers
* `PowerCreep.powers[*].cooldown` has had the undefined type removed.
  Even if a PC is not spawned, the cooldown for its powers will be 0.

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run compile` to update `index.d.ts`
