### PR TITLE
Add PathFinder.CostMatrix._bits property

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3919,6 +3919,10 @@ interface CostMatrix {
      * Returns a compact representation of this CostMatrix which can be stored via JSON.stringify.
      */
     serialize(): number[];
+    /**
+     * Internal storage of 2500 8-bit values.
+     */
+    _bits: Uint8Array;
 }
 
 declare const PathFinder: PathFinder;

--- a/src/path-finder.ts
+++ b/src/path-finder.ts
@@ -170,6 +170,10 @@ interface CostMatrix {
      * Returns a compact representation of this CostMatrix which can be stored via JSON.stringify.
      */
     serialize(): number[];
+    /**
+     * Internal storage of 2500 8-bit values.
+     */
+    _bits: Uint8Array;
 }
 
 declare const PathFinder: PathFinder;


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

Adds the `_bits` property to `PathFinder.CostMatrix`

https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/path-finder.js#L19

Fixes #248 (which was previously closed without resolution)

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run compile` to update `index.d.ts`

I let the commit hook do the compile, which I think is what CONTRIBUTING.md suggests.