### PR TITLE
Use unique Name<T> type for names of creeps, rooms, spawns, etc

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1152,7 +1152,7 @@ interface Creep extends RoomObject {
      * You can choose the name while creating a new creep, and it cannot be changed later.
      * This name is a hash key to access the creep via the {@link Game.creeps} object.
      */
-    name: string;
+    name: Name<this>;
     /**
      * An object with the creep’s owner info.
      */
@@ -1698,7 +1698,7 @@ interface Flag extends RoomObject {
      *
      * This name is a hash key to access the flag via the {@link Game.flags} object. The maximum name length is 60 characters.
      */
-    name: string;
+    name: Name<this>;
     /**
      * Flag secondary color. One of the {@link ColorConstant COLOR_*} constants.
      */
@@ -1737,8 +1737,8 @@ interface Flag extends RoomObject {
 }
 
 interface FlagConstructor extends _Constructor<Flag> {
-    new (name: string, color: ColorConstant, secondaryColor: ColorConstant, roomName: string, x: number, y: number): Flag;
-    (name: string, color: ColorConstant, secondaryColor: ColorConstant, roomName: string, x: number, y: number): Flag;
+    new (name: Name<Flag>, color: ColorConstant, secondaryColor: ColorConstant, roomName: Name<Room>, x: number, y: number): Flag;
+    (name: Name<Flag>, color: ColorConstant, secondaryColor: ColorConstant, roomName: Name<Room>, x: number, y: number): Flag;
 }
 
 declare const Flag: FlagConstructor;
@@ -1753,11 +1753,11 @@ interface Game {
     /**
      * A hash containing all your creeps with creep names as hash keys.
      */
-    creeps: { [creepName: string]: Creep };
+    creeps: { [creepName: Name<Creep>]: Creep };
     /**
      * A hash containing all your flags with flag names as hash keys.
      */
-    flags: { [flagName: string]: Flag };
+    flags: { [flagName: Name<Flag>]: Flag };
     /**
      * Your Global Control Level.
      */
@@ -1779,7 +1779,7 @@ interface Game {
      *
      * Even power creeps not spawned in the world can be accessed here.
      */
-    powerCreeps: { [creepName: string]: PowerCreep };
+    powerCreeps: { [creepName: Name<PowerCreep>]: PowerCreep };
     /**
      * An object with your global resources that are bound to the account, like pixels or cpu unlocks.
      *
@@ -1791,11 +1791,11 @@ interface Game {
      *
      * A room is visible if you have a creep or an owned structure in it.
      */
-    rooms: { [roomName: string]: Room };
+    rooms: { [roomName: Name<Room>]: Room };
     /**
      * A hash containing all your spawns with spawn names as hash keys.
      */
-    spawns: { [spawnName: string]: StructureSpawn };
+    spawns: { [spawnName: Name<StructureSpawn>]: StructureSpawn };
     /**
      * A hash containing all your structures with structure id as hash keys.
      */
@@ -1849,6 +1849,10 @@ interface _HasId {
     id: Id<this>;
 }
 
+interface _HasName {
+    name: Name<this>;
+}
+
 interface _HasRoomPosition {
     pos: RoomPosition;
 }
@@ -1887,7 +1891,7 @@ interface Shard {
     /**
      * The name of the shard.
      */
-    name: string;
+    name: Name<this>;
     /**
      * Currently always equals to normal.
      */
@@ -2047,7 +2051,7 @@ interface SignDefinition {
 }
 
 interface CPUShardLimits {
-    [shard: string]: number;
+    [shard: Name<Shard>]: number;
 }
 
 /** A general purpose Store, which has a limited capacity */
@@ -2065,7 +2069,7 @@ type StoreDefinitionUnlimited = Store<ResourceConstant, true>;
  *   "7": "W9N3"        // LEFT
  * }
  */
-type ExitsInformation = Partial<Record<ExitKey, string>>;
+type ExitsInformation = Partial<Record<ExitKey, Name<Room>>>;
 
 interface AllLookAtTypes {
     [LOOK_CONSTRUCTION_SITES]: ConstructionSite;
@@ -2193,7 +2197,7 @@ interface FindPathOpts {
      * @param costMatrix The current CostMatrix
      * @returns The new CostMatrix to use
      */
-    costCallback?: (roomName: string, costMatrix: CostMatrix) => void | CostMatrix;
+    costCallback?: (roomName: Name<Room>, costMatrix: CostMatrix) => void | CostMatrix;
 
     /**
      * An array of the room's objects or RoomPosition objects which should be treated as walkable tiles during the search.
@@ -2325,6 +2329,10 @@ declare namespace Tag {
 type Id<T extends _HasId> = string & Tag.OpaqueTag<T>;
 
 type fromId<T> = T extends Id<infer R> ? R : never;
+
+type Name<T extends _HasName> = string & Tag.OpaqueTag<T>;
+
+type fromName<T> = T extends Name<infer R> ? R : never;
 /**
  * `InterShardMemory` object provides an interface for communicating between shards.
  *
@@ -2354,7 +2362,7 @@ interface InterShardMemory {
      * @param shard Shard name.
      * @throws if shard name is invalid
      */
-    getRemote(shard: string): string | null;
+    getRemote(shard: Name<Shard>): string | null;
 }
 
 declare const InterShardMemory: InterShardMemory;
@@ -2995,7 +3003,7 @@ interface EventData {
         energySpent: number;
     };
     [EVENT_EXIT]: {
-        room: string;
+        room: Name<Room>;
         x: number;
         y: number;
     };
@@ -3079,7 +3087,7 @@ interface RouteOptions {
      * @param fromRoomName The room we're coming from
      * @returns a floating point to steer the route toward a given room, or Infinity to block it entirely.
      */
-    routeCallback: (roomName: string, fromRoomName: string) => number;
+    routeCallback: (roomName: Name<Room>, fromRoomName: Name<Room>) => number;
 }
 
 interface RoomStatusPermanent {
@@ -3105,7 +3113,7 @@ interface GameMap {
      * @param roomName The room name.
      * @returns The exits information or null if the room not found.
      */
-    describeExits(roomName: string): ExitsInformation | null;
+    describeExits(roomName: Name<Room>): ExitsInformation | null;
     /**
      * Find the exit direction from the given room en route to another room.
      * @param fromRoom Start room name or room object.
@@ -3116,7 +3124,7 @@ interface GameMap {
      * Or one of the following Result codes:
      * ERR_NO_PATH, ERR_INVALID_ARGS
      */
-    findExit(fromRoom: string | Room, toRoom: string | Room, opts?: RouteOptions): ExitConstant | ERR_NO_PATH | ERR_INVALID_ARGS;
+    findExit(fromRoom: Name<Room> | Room, toRoom: Name<Room> | Room, opts?: RouteOptions): ExitConstant | ERR_NO_PATH | ERR_INVALID_ARGS;
     /**
      * Find route from the given room to another room.
      * @param fromRoom Start room name or room object.
@@ -3124,7 +3132,11 @@ interface GameMap {
      * @param opts (optional) An object with the pathfinding options.
      * @returns either an array of room exits / room name, or ERR_NO_PATH if the destination room cannot be reached.
      */
-    findRoute(fromRoom: string | Room, toRoom: string | Room, opts?: RouteOptions): { exit: ExitConstant; room: string }[] | ERR_NO_PATH;
+    findRoute(
+        fromRoom: Name<Room> | Room,
+        toRoom: Name<Room> | Room,
+        opts?: RouteOptions,
+    ): { exit: ExitConstant; room: string }[] | ERR_NO_PATH;
     /**
      * Get the linear distance (in rooms) between two rooms.
      *
@@ -3144,7 +3156,7 @@ interface GameMap {
      * @param roomName The room name.
      * @deprecated use {@link Game.map.getRoomTerrain} instead
      */
-    getTerrainAt(x: number, y: number, roomName: string): Terrain;
+    getTerrainAt(x: number, y: number, roomName: Name<Room>): Terrain;
     /**
      * Get terrain type at the specified room position.
      *
@@ -3159,7 +3171,7 @@ interface GameMap {
      * This method works for any room in the world even if you have no access to it.
      * @param roomName String name of the room.
      */
-    getRoomTerrain(roomName: string): RoomTerrain;
+    getRoomTerrain(roomName: Name<Room>): RoomTerrain;
     /**
      * Returns the world size as a number of rooms between world corners.
      *
@@ -3173,14 +3185,14 @@ interface GameMap {
      * @returns A boolean value.
      * @deprecated Use `Game.map.getRoomStatus` instead
      */
-    isRoomAvailable(roomName: string): boolean;
+    isRoomAvailable(roomName: Name<Room>): boolean;
 
     /**
      * Get the room status to determine if it's available, or in a reserved area.
      * @param roomName The room name.
      * @returns A {@link RoomStatus} object.
      */
-    getRoomStatus(roomName: string): RoomStatus;
+    getRoomStatus(roomName: Name<Room>): RoomStatus;
 
     /**
      * Map visuals provide a way to show various visual debug info on the game map.
@@ -3436,7 +3448,7 @@ interface Market {
      * @param roomName2 The name of the second room.
      * @returns The amount of energy required to perform the transaction.
      */
-    calcTransactionCost(amount: number, roomName1: string, roomName2: string): number;
+    calcTransactionCost(amount: number, roomName1: Name<Room>, roomName2: Name<Room>): number;
     /**
      * Cancel a previously created order.
      *
@@ -3502,7 +3514,7 @@ interface Market {
      * - ERR_INVALID_ARGS: The arguments provided are invalid.
      * - ERR_TIRED: The target terminal is still cooling down.
      */
-    deal(orderId: string, amount: number, yourRoomName?: string): ScreepsReturnCode;
+    deal(orderId: string, amount: number, yourRoomName?: Name<Room>): ScreepsReturnCode;
     /**
      * Add more capacity to an existing order.
      *
@@ -3546,8 +3558,8 @@ interface Transaction {
     recipient?: { username: string };
     resourceType: MarketResourceConstant;
     amount: number;
-    from: string;
-    to: string;
+    from: Name<Room>;
+    to: Name<Room>;
     description: string;
     order?: TransactionOrder;
 }
@@ -3572,7 +3584,7 @@ interface Order {
      */
     resourceType: MarketResourceConstant;
     /** The room where this order is placed. */
-    roomName?: string;
+    roomName?: Name<Room>;
     /** Currently available quantity of resource to trade. */
     amount: number;
     /** Remaining quantity of resources to trade. */
@@ -3594,7 +3606,7 @@ interface OrderFilter {
     created?: number;
     type?: string;
     resourceType?: MarketResourceConstant;
-    roomName?: string;
+    roomName?: Name<Room>;
     amount?: number;
     remainingAmount?: number;
     price?: number;
@@ -3637,14 +3649,14 @@ interface CreateOrderParam {
      * You must have your own Terminal structure in this room, otherwise the created order will be temporary inactive.
      * This argument is not used when `resourceType` is one of the {@link InterShardResourceConstant} resources.
      */
-    roomName?: string;
+    roomName?: Name<Room>;
 }
 interface Memory {
-    creeps: { [name: string]: CreepMemory };
-    powerCreeps: { [name: string]: PowerCreepMemory };
-    flags: { [name: string]: FlagMemory };
-    rooms: { [name: string]: RoomMemory };
-    spawns: { [name: string]: SpawnMemory };
+    creeps: { [name: Name<Creep>]: CreepMemory };
+    powerCreeps: { [name: Name<PowerCreep>]: PowerCreepMemory };
+    flags: { [name: Name<Flag>]: FlagMemory };
+    rooms: { [name: Name<Room>]: RoomMemory };
+    spawns: { [name: Name<StructureSpawn>]: SpawnMemory };
 }
 
 interface CreepMemory {}
@@ -3737,7 +3749,7 @@ interface Nuke extends RoomObject {
     /**
      * The name of the room where this nuke has been launched from.
      */
-    launchRoomName: string;
+    launchRoomName: Name<Room>;
     /**
      * The remaining landing time.
      */
@@ -3873,7 +3885,7 @@ interface PathFinderOpts {
      *
      * @param roomName The name of the room the pathfinder needs a cost matrix for.
      */
-    roomCallback?(roomName: string): boolean | CostMatrix;
+    roomCallback?(roomName: Name<Room>): boolean | CostMatrix;
 }
 
 interface CostMatrixConstructor extends _Constructor<CostMatrix> {
@@ -3990,7 +4002,7 @@ interface PowerCreep extends RoomObject {
      * You can choose the name while creating a new power creep, and `rename` it while unspawned.
      * This name is a hash key to access the creep via the {@link Game.powerCreeps} object.
      */
-    name: string;
+    name: Name<this>;
     /**
      * An object with the creep's owner information.
      */
@@ -4010,7 +4022,7 @@ interface PowerCreep extends RoomObject {
     /**
      * The name of the shard where the power creeps is spawned, or undefined.
      */
-    shard: string | undefined;
+    shard: Name<Shard> | undefined;
     /**
      * The timestamp when spawning or deleting this creep will become available.
      *
@@ -4462,8 +4474,8 @@ interface RoomObject {
 }
 
 interface RoomObjectConstructor extends _Constructor<RoomObject> {
-    new (x: number, y: number, roomName: string): RoomObject;
-    (x: number, y: number, roomName: string): RoomObject;
+    new (x: number, y: number, roomName: Name<Room>): RoomObject;
+    (x: number, y: number, roomName: Name<Room>): RoomObject;
 }
 
 declare const RoomObject: RoomObjectConstructor;
@@ -4529,7 +4541,7 @@ interface RoomPosition {
     /**
      * The name of the room.
      */
-    roomName: string;
+    roomName: Name<Room>;
     /**
      * X position in the room.
      */
@@ -4572,7 +4584,7 @@ interface RoomPosition {
      * @param secondaryColor The secondary color of a new flag. Should be one of the {@link ColorConstant COLOR_*} constants. The default value is equal to color.
      * @returns The name of the flag if created, or one of the following error codes: ERR_NAME_EXISTS, ERR_INVALID_ARGS
      */
-    createFlag(name?: string, color?: ColorConstant, secondaryColor?: ColorConstant): ERR_NAME_EXISTS | ERR_INVALID_ARGS | string;
+    createFlag(name?: string, color?: ColorConstant, secondaryColor?: ColorConstant): ERR_NAME_EXISTS | ERR_INVALID_ARGS | Name<Flag>;
     /**
      * Find the object with the shortest path from the given position.
      *
@@ -4736,8 +4748,8 @@ interface RoomPositionConstructor extends _Constructor<RoomPosition> {
      * @param roomName The room name.
      * @throws if `x` or `y` are out of bounds, or `roomName` isn't a valid room name.
      */
-    new (x: number, y: number, roomName: string): RoomPosition;
-    (x: number, y: number, roomName: string): RoomPosition;
+    new (x: number, y: number, roomName: Name<Room>): RoomPosition;
+    (x: number, y: number, roomName: Name<Room>): RoomPosition;
 }
 
 declare const RoomPosition: RoomPositionConstructor;
@@ -4788,7 +4800,7 @@ interface RoomTerrainConstructor extends _Constructor<RoomTerrain> {
      * This method works for any room in the world even if you have no access to it.
      * @param roomName String name of the room.
      */
-    new (roomName: string): RoomTerrain;
+    new (roomName: Name<Room>): RoomTerrain;
 }
 /**
  * Room visuals provide a way to show various visual debug info in game rooms.
@@ -4808,12 +4820,12 @@ declare class RoomVisual {
      * You can create new RoomVisual object using its constructor.
      * @param roomName The room name. If undefined, visuals will be posted to all rooms simultaneously.
      */
-    constructor(roomName?: string);
+    constructor(roomName?: Name<Room>);
 
     /**
      * The name of the room.
      */
-    roomName: string;
+    roomName: Name<Room>;
 
     /**
      * Draw a line.
@@ -5068,7 +5080,7 @@ interface Room {
     /**
      * The name of the room.
      */
-    readonly name: string;
+    readonly name: Name<this>;
     /**
      * The {@link StructureStorage} of this room, if present, otherwise undefined.
      */
@@ -5202,7 +5214,7 @@ interface Room {
      * @returns The room direction constant, one of the following: FIND_EXIT_TOP, FIND_EXIT_RIGHT, FIND_EXIT_BOTTOM, FIND_EXIT_LEFT
      * Or one of the following error codes: ERR_NO_PATH, ERR_INVALID_ARGS
      */
-    findExitTo(room: string | Room): ExitConstant | ERR_NO_PATH | ERR_INVALID_ARGS;
+    findExitTo(room: Name<Room> | Room): ExitConstant | ERR_NO_PATH | ERR_INVALID_ARGS;
     /**
      * Find an optimal path inside the room between fromPos and toPos using A* search algorithm.
      * @param fromPos The start position.
@@ -5297,7 +5309,7 @@ interface Room {
 }
 
 interface RoomConstructor extends _Constructor<Room> {
-    new (id: string): Room;
+    new (id: Name<Room>): Room;
 
     Terrain: RoomTerrainConstructor;
 
@@ -5443,7 +5455,7 @@ interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
      * You choose the name upon creating a new spawn, and it cannot be changed later.
      * This name is a hash key to access the spawn via the {@link Game.spawns} object.
      */
-    name: string;
+    name: Name<this>;
     /**
      * If the spawn is in process of spawning a new creep, this object will contain the new creep’s information, or null otherwise.
      */
@@ -5591,7 +5603,7 @@ interface Spawning {
     /**
      * The name of the creep
      */
-    name: string;
+    name: Name<Creep>;
 
     /**
      * Time needed in total to complete the spawning.
@@ -6042,7 +6054,7 @@ interface StructureObserver extends OwnedStructure<STRUCTURE_OBSERVER> {
      * - ERR_INVALID_ARGS: roomName argument is not a valid room name value.
      * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
-    observeRoom(roomName: string): ScreepsReturnCode;
+    observeRoom(roomName: Name<Room>): ScreepsReturnCode;
 }
 
 interface StructureObserverConstructor extends _Constructor<StructureObserver>, _ConstructorById<StructureObserver> {}
@@ -6446,7 +6458,7 @@ interface StructureTerminal extends OwnedStructure<STRUCTURE_TERMINAL> {
      * - ERR_INVALID_ARGS: The arguments provided are incorrect.
      * - ERR_TIRED: The terminal is still cooling down.
      */
-    send(resourceType: ResourceConstant, amount: number, destination: string, description?: string): ScreepsReturnCode;
+    send(resourceType: ResourceConstant, amount: number, destination: Name<Room>, description?: string): ScreepsReturnCode;
 }
 
 interface StructureTerminalConstructor extends _Constructor<StructureTerminal>, _ConstructorById<StructureTerminal> {}
@@ -6555,7 +6567,7 @@ interface StructurePortal extends Structure<STRUCTURE_PORTAL> {
      * If this is an inter-shard portal, then this property contains an object with shard and room string properties.
      * Exact coordinates are undetermined, the creep will appear at any free spot in the destination room.
      */
-    destination: RoomPosition | { shard: string; room: string };
+    destination: RoomPosition | { shard: Name<Shard>; room: Name<Room> };
     /**
      * The amount of game ticks when the portal disappears, or undefined when the portal is stable.
      */

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -12,15 +12,22 @@
 
 // Sample inputs
 
-const creep: Creep = Game.creeps.sampleCreep;
-const room: Room = Game.rooms.W10S10;
-const flag: Flag = Game.flags.Flag1;
-const powerCreep: PowerCreep = Game.powerCreeps.samplePowerCreep;
-const spawn: StructureSpawn = Game.spawns.Spawn1;
+const creepName = "sampleCreep" as Name<Creep>;
+const creep: Creep = Game.creeps[creepName];
+const roomName = "W11S11" as Name<Room>;
+const room: Room = Game.rooms[roomName];
+const flagName = "Flag1" as Name<Flag>;
+const flag: Flag = Game.flags[flagName];
+const powerCreepName = "samplePowerCreep" as Name<PowerCreep>;
+const powerCreep: PowerCreep = Game.powerCreeps[powerCreepName];
+const spawnName = "Spawn1" as Name<StructureSpawn>;
+const spawn: StructureSpawn = Game.spawns[spawnName];
 const body: BodyPartConstant[] = [WORK, WORK, CARRY, MOVE];
+const shardName = "shard0" as Name<Shard>;
 
 // Sample inputs for Game.map.findRoute testing
-const anotherRoomName: Room = Game.rooms.W10S11;
+const anotherRoomName = "E22S22" as Name<Room>;
+const anotherRoom: Room = Game.rooms[anotherRoomName];
 
 // Sample memory extensions
 interface CreepMemory {
@@ -74,7 +81,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Game.creeps
 
 {
-    for (const creepName of Object.keys(Game.creeps)) {
+    for (const creepName of Object.keys(Game.creeps) as Array<keyof typeof Game.creeps>) {
         Game.creeps[creepName].moveTo(flag);
     }
 }
@@ -82,7 +89,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Game.flags
 
 {
-    creep.moveTo(Game.flags.Flag1);
+    creep.moveTo(Game.flags[flagName]);
 }
 
 // Game.powerCreeps
@@ -90,8 +97,8 @@ function resources(o: GenericStore): ResourceConstant[] {
 {
     PowerCreep.create("steve", POWER_CLASS.OPERATOR) === OK;
 
-    for (const i of Object.keys(Game.powerCreeps)) {
-        const powerCreep = Game.powerCreeps[i];
+    for (const powerCreepName of Object.keys(Game.powerCreeps) as Array<keyof typeof Game.powerCreeps>) {
+        const powerCreep = Game.powerCreeps[powerCreepName];
 
         if (powerCreep.ticksToLive === undefined) {
             // Not spawned in world; spawn creep
@@ -104,7 +111,7 @@ function resources(o: GenericStore): ResourceConstant[] {
                 powerCreep.powers[PWR_GENERATE_OPS].cooldown === 0 &&
                 (powerCreep.carry.ops || 0) < 10
             ) {
-                Game.powerCreeps[i].usePower(PWR_GENERATE_OPS);
+                Game.powerCreeps[powerCreepName].usePower(PWR_GENERATE_OPS);
             } else {
                 // Boost resource
                 const targetSource = Game.getObjectById("targetSourceID" as Id<Source>)!;
@@ -127,7 +134,7 @@ function resources(o: GenericStore): ResourceConstant[] {
         powerCreep.upgrade(PWR_GENERATE_OPS);
     }
 
-    const myPowaCreeps = Game.rooms.sim.find(FIND_MY_POWER_CREEPS);
+    const myPowaCreeps = Game.rooms["sim" as Name<Room>].find(FIND_MY_POWER_CREEPS);
 
     // Constant type checking
     POWER_INFO[PWR_GENERATE_OPS].className === POWER_CLASS.OPERATOR;
@@ -137,7 +144,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Game.spawns
 
 {
-    for (const i of Object.keys(Game.spawns)) {
+    for (const i of Object.keys(Game.spawns) as Array<keyof typeof Game.spawns>) {
         Game.spawns[i].createCreep(body);
 
         // Test StructureSpawn.Spawning
@@ -188,7 +195,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Game.cpu.setShardLimits()
 
 {
-    Game.cpu.setShardLimits({ shard0: 20, shard1: 10 });
+    Game.cpu.setShardLimits({ [shardName]: 20, ["privateshard" as Name<Shard>]: 10 });
 }
 
 // Game.cpu.halt()
@@ -227,9 +234,9 @@ function resources(o: GenericStore): ResourceConstant[] {
 }
 
 {
-    if (Game.spawns["Spawn1"].energy === 0) {
+    if (Game.spawns[spawnName].energy === 0) {
         Game.notify(
-            "Spawn1 is out of energy",
+            `${spawnName} is out of energy`,
             180, // group these notifications for 3 hours
         );
     }
@@ -238,7 +245,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Game.map.describeExits()
 
 {
-    const exits = Game.map.describeExits("W8N3");
+    const exits = Game.map.describeExits(roomName);
     if (exits) {
         keys(exits).map((exitKey) => {
             const nextRoom = exits[exitKey];
@@ -252,8 +259,8 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Game.map.findExit()
 
 {
-    if (creep.room.name !== anotherRoomName.name) {
-        const exitDir = Game.map.findExit(creep.room, anotherRoomName);
+    if (creep.room.name !== anotherRoom.name) {
+        const exitDir = Game.map.findExit(creep.room, anotherRoom);
         if (exitDir !== ERR_NO_PATH && exitDir !== ERR_INVALID_ARGS) {
             const exit = creep.pos.findClosestByRange(exitDir);
             if (exit !== null) {
@@ -266,13 +273,13 @@ function resources(o: GenericStore): ResourceConstant[] {
 }
 
 {
-    creep.moveTo(new RoomPosition(25, 25, anotherRoomName.name));
+    creep.moveTo(new RoomPosition(25, 25, anotherRoom.name));
 }
 
 // Game.map.findRoute()
 
 {
-    const route = Game.map.findRoute(creep.room, anotherRoomName);
+    const route = Game.map.findRoute(creep.room, anotherRoom);
 
     if (route !== ERR_NO_PATH && route.length > 0) {
         const exit = creep.pos.findClosestByRange(route[0].exit);
@@ -283,7 +290,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 }
 
 {
-    const route = Game.map.findRoute(creep.room, anotherRoomName, {
+    const route = Game.map.findRoute(creep.room, anotherRoom, {
         routeCallback(roomName, fromRoomName) {
             if (roomName === "W10S10") {
                 // avoid this room
@@ -295,8 +302,8 @@ function resources(o: GenericStore): ResourceConstant[] {
 }
 
 {
-    const from = new RoomPosition(25, 25, "E1N1");
-    const to = new RoomPosition(25, 25, "E4N1");
+    const from = new RoomPosition(25, 25, roomName);
+    const to = new RoomPosition(25, 25, "W1S1" as Name<Room>);
 
     // Use `findRoute` to calculate a high-level plan for this path,
     // prioritizing highways and owned rooms
@@ -348,11 +355,11 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Game.map.getTerrainAt(pos)
 
 {
-    Game.map.getTerrainAt(25, 20, "W10N10");
+    Game.map.getTerrainAt(25, 20, roomName);
 }
 
 {
-    Game.map.getTerrainAt(new RoomPosition(25, 20, "W10N10"));
+    Game.map.getTerrainAt(new RoomPosition(25, 20, roomName));
 }
 
 // Game.map.getRoomStatus(roomName)
@@ -368,7 +375,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 
 {
     // Game.market.calcTransactionCost(amount, roomName1, roomName2)
-    const cost = Game.market.calcTransactionCost(1000, "W0N0", "W10N5");
+    const cost = Game.market.calcTransactionCost(1000, roomName, anotherRoomName);
 
     // Game.market.cancelOrder(orderId)
     for (const id of Object.keys(Game.market.orders)) {
@@ -379,7 +386,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     Game.market.changeOrderPrice("57bec1bf77f4d17c4c011960", 9.95);
 
     // Game.market.createOrder({type, resourceType, price, totalAmount, [roomName]})
-    Game.market.createOrder({ type: ORDER_SELL, resourceType: RESOURCE_GHODIUM, price: 9.95, totalAmount: 10000, roomName: "W1N1" });
+    Game.market.createOrder({ type: ORDER_SELL, resourceType: RESOURCE_GHODIUM, price: 9.95, totalAmount: 10000, roomName: roomName });
     Game.market.createOrder({ type: ORDER_SELL, resourceType: RESOURCE_GHODIUM, price: 9.95, totalAmount: 10000 });
 
     // Testing the hardcoded string literal value of the `type` field
@@ -398,7 +405,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     }
 
     // Game.market.deal(orderId, amount, [yourRoomName])
-    Game.market.deal("57cd2b12cda69a004ae223a3", 1000, "W1N1");
+    Game.market.deal("57cd2b12cda69a004ae223a3", 1000, roomName);
 
     const amountToBuy = 2000;
     const maxTransferEnergyCost = 500;
@@ -406,10 +413,10 @@ function resources(o: GenericStore): ResourceConstant[] {
 
     for (const i of orders) {
         if (i.roomName) {
-            const transferEnergyCost = Game.market.calcTransactionCost(amountToBuy, "W1N1", i.roomName);
+            const transferEnergyCost = Game.market.calcTransactionCost(amountToBuy, roomName, i.roomName);
 
             if (transferEnergyCost < maxTransferEnergyCost) {
-                Game.market.deal(i.id, amountToBuy, "W1N1");
+                Game.market.deal(i.id, amountToBuy, roomName);
                 break;
             }
         }
@@ -427,7 +434,7 @@ function resources(o: GenericStore): ResourceConstant[] {
         (currentOrder) =>
             currentOrder.resourceType === RESOURCE_GHODIUM &&
             currentOrder.type === ORDER_SELL &&
-            Game.market.calcTransactionCost(1000, targetRoom, currentOrder.roomName!) < 500,
+            Game.market.calcTransactionCost(1000, anotherRoomName, currentOrder.roomName!) < 500,
     );
 
     // Game.market.getOrderById(id)
@@ -451,7 +458,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 // PathFinder
 
 {
-    const pfCreep = Game.creeps.John;
+    const pfCreep = Game.creeps[creepName];
 
     const goals = pfCreep.room.find(FIND_SOURCES).map((source) => {
         // We can't actually walk on sources-- set `range` to 1
@@ -573,7 +580,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     InterShardMemory.setLocal(localShardData);
     localShardData = InterShardMemory.getLocal();
 
-    const remoteShardData: string = InterShardMemory.getRemote("shard2") || "";
+    const remoteShardData: string = InterShardMemory.getRemote("shard2" as Name<Shard>) || "";
 }
 
 // Find Overloads
@@ -984,7 +991,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     // test discriminated union
     switch (unowned.structureType) {
         case STRUCTURE_TOWER:
-            unowned.heal(Game.creeps.myCreep);
+            unowned.heal(Game.creeps["myCreep" as Name<Creep>]);
             break;
         case STRUCTURE_CONTAINER:
         case STRUCTURE_STORAGE:
@@ -1000,7 +1007,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     // test discriminated union using filter functions on find
 
     // $ExpectType AnyStructure
-    const from = Game.rooms.myRoom.find(FIND_STRUCTURES, {
+    const from = Game.rooms["myRoom" as Name<Room>].find(FIND_STRUCTURES, {
         filter: (s) => (s.structureType === STRUCTURE_CONTAINER || s.structureType === STRUCTURE_STORAGE) && s.store.energy > 0,
     })[0];
     // $ExpectType AnyOwnedStructure | null
@@ -1008,7 +1015,7 @@ function resources(o: GenericStore): ResourceConstant[] {
         filter: (s) => (s.structureType === STRUCTURE_SPAWN || s.structureType === STRUCTURE_EXTENSION) && s.energy < s.energyCapacity,
     });
 
-    Game.rooms.myRoom
+    Game.rooms["myRoom" as Name<Room>]
         .find(FIND_MY_STRUCTURES, {
             filter: (s) => s.structureType === STRUCTURE_RAMPART,
         })
@@ -1017,7 +1024,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 
 {
     // Test that you can use signatures
-    EXTENSION_ENERGY_CAPACITY[Game.rooms.myRoom.controller!.level];
+    EXTENSION_ENERGY_CAPACITY[Game.rooms[roomName].controller!.level];
 
     REACTIONS[Object.keys(creep.carry)[0]];
 
@@ -1036,7 +1043,7 @@ function resources(o: GenericStore): ResourceConstant[] {
 
     tombstone.id;
 
-    const creep = Game.creeps["dave"];
+    const creep = Game.creeps["dave" as Name<Creep>];
     creep.withdraw(tombstone, RESOURCE_ENERGY);
 }
 
@@ -1127,13 +1134,13 @@ function resources(o: GenericStore): ResourceConstant[] {
 // Room.Terrain
 
 {
-    const room = Game.rooms[""];
+    const room = Game.rooms["" as Name<Room>];
 
     const myTerrain = room.getTerrain();
 
-    const otherTerrain = new Room.Terrain("E2S7");
+    const otherTerrain = new Room.Terrain(roomName);
 
-    const anotherTerrain = Game.map.getRoomTerrain("W2N5");
+    const anotherTerrain = Game.map.getRoomTerrain(anotherRoomName);
 
     const ret = myTerrain.get(5, 5);
     if (ret === 0) {
@@ -1267,10 +1274,10 @@ function atackPower(creep: Creep) {
 // Game.map.visual
 {
     const mapVis = Game.map.visual;
-    const point1 = new RoomPosition(1, 1, "E1N1");
-    const point2 = new RoomPosition(1, 1, "E1N8");
-    const point3 = new RoomPosition(1, 1, "E8N8");
-    const point4 = new RoomPosition(1, 1, "E1N8");
+    const point1 = new RoomPosition(1, 1, roomName);
+    const point2 = new RoomPosition(1, 1, anotherRoomName);
+    const point3 = new RoomPosition(1, 1, "E8N8" as Name<Room>);
+    const point4 = new RoomPosition(1, 1, "E1N8" as Name<Room>);
 
     mapVis.line(point1, point2).circle(point3, { fill: "#f2f2f2" }).poly([point1, point2, point3, point4]).rect(point3, 50, 50);
 

--- a/src/creep.ts
+++ b/src/creep.ts
@@ -78,7 +78,7 @@ interface Creep extends RoomObject {
      * You can choose the name while creating a new creep, and it cannot be changed later.
      * This name is a hash key to access the creep via the {@link Game.creeps} object.
      */
-    name: string;
+    name: Name<this>;
     /**
      * An object with the creep’s owner info.
      */

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -23,7 +23,7 @@ interface Flag extends RoomObject {
      *
      * This name is a hash key to access the flag via the {@link Game.flags} object. The maximum name length is 60 characters.
      */
-    name: string;
+    name: Name<this>;
     /**
      * Flag secondary color. One of the {@link ColorConstant COLOR_*} constants.
      */
@@ -62,8 +62,8 @@ interface Flag extends RoomObject {
 }
 
 interface FlagConstructor extends _Constructor<Flag> {
-    new (name: string, color: ColorConstant, secondaryColor: ColorConstant, roomName: string, x: number, y: number): Flag;
-    (name: string, color: ColorConstant, secondaryColor: ColorConstant, roomName: string, x: number, y: number): Flag;
+    new (name: Name<Flag>, color: ColorConstant, secondaryColor: ColorConstant, roomName: Name<Room>, x: number, y: number): Flag;
+    (name: Name<Flag>, color: ColorConstant, secondaryColor: ColorConstant, roomName: Name<Room>, x: number, y: number): Flag;
 }
 
 declare const Flag: FlagConstructor;

--- a/src/game.ts
+++ b/src/game.ts
@@ -9,11 +9,11 @@ interface Game {
     /**
      * A hash containing all your creeps with creep names as hash keys.
      */
-    creeps: { [creepName: string]: Creep };
+    creeps: { [creepName: Name<Creep>]: Creep };
     /**
      * A hash containing all your flags with flag names as hash keys.
      */
-    flags: { [flagName: string]: Flag };
+    flags: { [flagName: Name<Flag>]: Flag };
     /**
      * Your Global Control Level.
      */
@@ -35,7 +35,7 @@ interface Game {
      *
      * Even power creeps not spawned in the world can be accessed here.
      */
-    powerCreeps: { [creepName: string]: PowerCreep };
+    powerCreeps: { [creepName: Name<PowerCreep>]: PowerCreep };
     /**
      * An object with your global resources that are bound to the account, like pixels or cpu unlocks.
      *
@@ -47,11 +47,11 @@ interface Game {
      *
      * A room is visible if you have a creep or an owned structure in it.
      */
-    rooms: { [roomName: string]: Room };
+    rooms: { [roomName: Name<Room>]: Room };
     /**
      * A hash containing all your spawns with spawn names as hash keys.
      */
-    spawns: { [spawnName: string]: StructureSpawn };
+    spawns: { [spawnName: Name<StructureSpawn>]: StructureSpawn };
     /**
      * A hash containing all your structures with structure id as hash keys.
      */

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,6 +2,10 @@ interface _HasId {
     id: Id<this>;
 }
 
+interface _HasName {
+    name: Name<this>;
+}
+
 interface _HasRoomPosition {
     pos: RoomPosition;
 }
@@ -40,7 +44,7 @@ interface Shard {
     /**
      * The name of the shard.
      */
-    name: string;
+    name: Name<this>;
     /**
      * Currently always equals to normal.
      */
@@ -200,7 +204,7 @@ interface SignDefinition {
 }
 
 interface CPUShardLimits {
-    [shard: string]: number;
+    [shard: Name<Shard>]: number;
 }
 
 /** A general purpose Store, which has a limited capacity */
@@ -218,7 +222,7 @@ type StoreDefinitionUnlimited = Store<ResourceConstant, true>;
  *   "7": "W9N3"        // LEFT
  * }
  */
-type ExitsInformation = Partial<Record<ExitKey, string>>;
+type ExitsInformation = Partial<Record<ExitKey, Name<Room>>>;
 
 interface AllLookAtTypes {
     [LOOK_CONSTRUCTION_SITES]: ConstructionSite;
@@ -346,7 +350,7 @@ interface FindPathOpts {
      * @param costMatrix The current CostMatrix
      * @returns The new CostMatrix to use
      */
-    costCallback?: (roomName: string, costMatrix: CostMatrix) => void | CostMatrix;
+    costCallback?: (roomName: Name<Room>, costMatrix: CostMatrix) => void | CostMatrix;
 
     /**
      * An array of the room's objects or RoomPosition objects which should be treated as walkable tiles during the search.
@@ -478,3 +482,7 @@ declare namespace Tag {
 type Id<T extends _HasId> = string & Tag.OpaqueTag<T>;
 
 type fromId<T> = T extends Id<infer R> ? R : never;
+
+type Name<T extends _HasName> = string & Tag.OpaqueTag<T>;
+
+type fromName<T> = T extends Name<infer R> ? R : never;

--- a/src/inter-shard-memory.ts
+++ b/src/inter-shard-memory.ts
@@ -27,7 +27,7 @@ interface InterShardMemory {
      * @param shard Shard name.
      * @throws if shard name is invalid
      */
-    getRemote(shard: string): string | null;
+    getRemote(shard: Name<Shard>): string | null;
 }
 
 declare const InterShardMemory: InterShardMemory;

--- a/src/literals.ts
+++ b/src/literals.ts
@@ -635,7 +635,7 @@ interface EventData {
         energySpent: number;
     };
     [EVENT_EXIT]: {
-        room: string;
+        room: Name<Room>;
         x: number;
         y: number;
     };

--- a/src/map.ts
+++ b/src/map.ts
@@ -9,7 +9,7 @@ interface RouteOptions {
      * @param fromRoomName The room we're coming from
      * @returns a floating point to steer the route toward a given room, or Infinity to block it entirely.
      */
-    routeCallback: (roomName: string, fromRoomName: string) => number;
+    routeCallback: (roomName: Name<Room>, fromRoomName: Name<Room>) => number;
 }
 
 interface RoomStatusPermanent {
@@ -35,7 +35,7 @@ interface GameMap {
      * @param roomName The room name.
      * @returns The exits information or null if the room not found.
      */
-    describeExits(roomName: string): ExitsInformation | null;
+    describeExits(roomName: Name<Room>): ExitsInformation | null;
     /**
      * Find the exit direction from the given room en route to another room.
      * @param fromRoom Start room name or room object.
@@ -46,7 +46,7 @@ interface GameMap {
      * Or one of the following Result codes:
      * ERR_NO_PATH, ERR_INVALID_ARGS
      */
-    findExit(fromRoom: string | Room, toRoom: string | Room, opts?: RouteOptions): ExitConstant | ERR_NO_PATH | ERR_INVALID_ARGS;
+    findExit(fromRoom: Name<Room> | Room, toRoom: Name<Room> | Room, opts?: RouteOptions): ExitConstant | ERR_NO_PATH | ERR_INVALID_ARGS;
     /**
      * Find route from the given room to another room.
      * @param fromRoom Start room name or room object.
@@ -54,7 +54,11 @@ interface GameMap {
      * @param opts (optional) An object with the pathfinding options.
      * @returns either an array of room exits / room name, or ERR_NO_PATH if the destination room cannot be reached.
      */
-    findRoute(fromRoom: string | Room, toRoom: string | Room, opts?: RouteOptions): { exit: ExitConstant; room: string }[] | ERR_NO_PATH;
+    findRoute(
+        fromRoom: Name<Room> | Room,
+        toRoom: Name<Room> | Room,
+        opts?: RouteOptions,
+    ): { exit: ExitConstant; room: string }[] | ERR_NO_PATH;
     /**
      * Get the linear distance (in rooms) between two rooms.
      *
@@ -74,7 +78,7 @@ interface GameMap {
      * @param roomName The room name.
      * @deprecated use {@link Game.map.getRoomTerrain} instead
      */
-    getTerrainAt(x: number, y: number, roomName: string): Terrain;
+    getTerrainAt(x: number, y: number, roomName: Name<Room>): Terrain;
     /**
      * Get terrain type at the specified room position.
      *
@@ -89,7 +93,7 @@ interface GameMap {
      * This method works for any room in the world even if you have no access to it.
      * @param roomName String name of the room.
      */
-    getRoomTerrain(roomName: string): RoomTerrain;
+    getRoomTerrain(roomName: Name<Room>): RoomTerrain;
     /**
      * Returns the world size as a number of rooms between world corners.
      *
@@ -103,14 +107,14 @@ interface GameMap {
      * @returns A boolean value.
      * @deprecated Use `Game.map.getRoomStatus` instead
      */
-    isRoomAvailable(roomName: string): boolean;
+    isRoomAvailable(roomName: Name<Room>): boolean;
 
     /**
      * Get the room status to determine if it's available, or in a reserved area.
      * @param roomName The room name.
      * @returns A {@link RoomStatus} object.
      */
-    getRoomStatus(roomName: string): RoomStatus;
+    getRoomStatus(roomName: Name<Room>): RoomStatus;
 
     /**
      * Map visuals provide a way to show various visual debug info on the game map.

--- a/src/market.ts
+++ b/src/market.ts
@@ -37,7 +37,7 @@ interface Market {
      * @param roomName2 The name of the second room.
      * @returns The amount of energy required to perform the transaction.
      */
-    calcTransactionCost(amount: number, roomName1: string, roomName2: string): number;
+    calcTransactionCost(amount: number, roomName1: Name<Room>, roomName2: Name<Room>): number;
     /**
      * Cancel a previously created order.
      *
@@ -103,7 +103,7 @@ interface Market {
      * - ERR_INVALID_ARGS: The arguments provided are invalid.
      * - ERR_TIRED: The target terminal is still cooling down.
      */
-    deal(orderId: string, amount: number, yourRoomName?: string): ScreepsReturnCode;
+    deal(orderId: string, amount: number, yourRoomName?: Name<Room>): ScreepsReturnCode;
     /**
      * Add more capacity to an existing order.
      *
@@ -147,8 +147,8 @@ interface Transaction {
     recipient?: { username: string };
     resourceType: MarketResourceConstant;
     amount: number;
-    from: string;
-    to: string;
+    from: Name<Room>;
+    to: Name<Room>;
     description: string;
     order?: TransactionOrder;
 }
@@ -173,7 +173,7 @@ interface Order {
      */
     resourceType: MarketResourceConstant;
     /** The room where this order is placed. */
-    roomName?: string;
+    roomName?: Name<Room>;
     /** Currently available quantity of resource to trade. */
     amount: number;
     /** Remaining quantity of resources to trade. */
@@ -195,7 +195,7 @@ interface OrderFilter {
     created?: number;
     type?: string;
     resourceType?: MarketResourceConstant;
-    roomName?: string;
+    roomName?: Name<Room>;
     amount?: number;
     remainingAmount?: number;
     price?: number;
@@ -238,5 +238,5 @@ interface CreateOrderParam {
      * You must have your own Terminal structure in this room, otherwise the created order will be temporary inactive.
      * This argument is not used when `resourceType` is one of the {@link InterShardResourceConstant} resources.
      */
-    roomName?: string;
+    roomName?: Name<Room>;
 }

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,9 +1,9 @@
 interface Memory {
-    creeps: { [name: string]: CreepMemory };
-    powerCreeps: { [name: string]: PowerCreepMemory };
-    flags: { [name: string]: FlagMemory };
-    rooms: { [name: string]: RoomMemory };
-    spawns: { [name: string]: SpawnMemory };
+    creeps: { [name: Name<Creep>]: CreepMemory };
+    powerCreeps: { [name: Name<PowerCreep>]: PowerCreepMemory };
+    flags: { [name: Name<Flag>]: FlagMemory };
+    rooms: { [name: Name<Room>]: RoomMemory };
+    spawns: { [name: Name<StructureSpawn>]: SpawnMemory };
 }
 
 interface CreepMemory {}

--- a/src/nuke.ts
+++ b/src/nuke.ts
@@ -30,7 +30,7 @@ interface Nuke extends RoomObject {
     /**
      * The name of the room where this nuke has been launched from.
      */
-    launchRoomName: string;
+    launchRoomName: Name<Room>;
     /**
      * The remaining landing time.
      */

--- a/src/path-finder.ts
+++ b/src/path-finder.ts
@@ -124,7 +124,7 @@ interface PathFinderOpts {
      *
      * @param roomName The name of the room the pathfinder needs a cost matrix for.
      */
-    roomCallback?(roomName: string): boolean | CostMatrix;
+    roomCallback?(roomName: Name<Room>): boolean | CostMatrix;
 }
 
 interface CostMatrixConstructor extends _Constructor<CostMatrix> {

--- a/src/power-creep.ts
+++ b/src/power-creep.ts
@@ -66,7 +66,7 @@ interface PowerCreep extends RoomObject {
      * You can choose the name while creating a new power creep, and `rename` it while unspawned.
      * This name is a hash key to access the creep via the {@link Game.powerCreeps} object.
      */
-    name: string;
+    name: Name<this>;
     /**
      * An object with the creep's owner information.
      */
@@ -86,7 +86,7 @@ interface PowerCreep extends RoomObject {
     /**
      * The name of the shard where the power creeps is spawned, or undefined.
      */
-    shard: string | undefined;
+    shard: Name<Shard> | undefined;
     /**
      * The timestamp when spawning or deleting this creep will become available.
      *

--- a/src/room-object.ts
+++ b/src/room-object.ts
@@ -24,8 +24,8 @@ interface RoomObject {
 }
 
 interface RoomObjectConstructor extends _Constructor<RoomObject> {
-    new (x: number, y: number, roomName: string): RoomObject;
-    (x: number, y: number, roomName: string): RoomObject;
+    new (x: number, y: number, roomName: Name<Room>): RoomObject;
+    (x: number, y: number, roomName: Name<Room>): RoomObject;
 }
 
 declare const RoomObject: RoomObjectConstructor;

--- a/src/room-position.ts
+++ b/src/room-position.ts
@@ -11,7 +11,7 @@ interface RoomPosition {
     /**
      * The name of the room.
      */
-    roomName: string;
+    roomName: Name<Room>;
     /**
      * X position in the room.
      */
@@ -54,7 +54,7 @@ interface RoomPosition {
      * @param secondaryColor The secondary color of a new flag. Should be one of the {@link ColorConstant COLOR_*} constants. The default value is equal to color.
      * @returns The name of the flag if created, or one of the following error codes: ERR_NAME_EXISTS, ERR_INVALID_ARGS
      */
-    createFlag(name?: string, color?: ColorConstant, secondaryColor?: ColorConstant): ERR_NAME_EXISTS | ERR_INVALID_ARGS | string;
+    createFlag(name?: string, color?: ColorConstant, secondaryColor?: ColorConstant): ERR_NAME_EXISTS | ERR_INVALID_ARGS | Name<Flag>;
     /**
      * Find the object with the shortest path from the given position.
      *
@@ -218,8 +218,8 @@ interface RoomPositionConstructor extends _Constructor<RoomPosition> {
      * @param roomName The room name.
      * @throws if `x` or `y` are out of bounds, or `roomName` isn't a valid room name.
      */
-    new (x: number, y: number, roomName: string): RoomPosition;
-    (x: number, y: number, roomName: string): RoomPosition;
+    new (x: number, y: number, roomName: Name<Room>): RoomPosition;
+    (x: number, y: number, roomName: Name<Room>): RoomPosition;
 }
 
 declare const RoomPosition: RoomPositionConstructor;

--- a/src/room-terrain.ts
+++ b/src/room-terrain.ts
@@ -45,5 +45,5 @@ interface RoomTerrainConstructor extends _Constructor<RoomTerrain> {
      * This method works for any room in the world even if you have no access to it.
      * @param roomName String name of the room.
      */
-    new (roomName: string): RoomTerrain;
+    new (roomName: Name<Room>): RoomTerrain;
 }

--- a/src/room-visual.ts
+++ b/src/room-visual.ts
@@ -16,12 +16,12 @@ declare class RoomVisual {
      * You can create new RoomVisual object using its constructor.
      * @param roomName The room name. If undefined, visuals will be posted to all rooms simultaneously.
      */
-    constructor(roomName?: string);
+    constructor(roomName?: Name<Room>);
 
     /**
      * The name of the room.
      */
-    roomName: string;
+    roomName: Name<Room>;
 
     /**
      * Draw a line.

--- a/src/room.ts
+++ b/src/room.ts
@@ -37,7 +37,7 @@ interface Room {
     /**
      * The name of the room.
      */
-    readonly name: string;
+    readonly name: Name<this>;
     /**
      * The {@link StructureStorage} of this room, if present, otherwise undefined.
      */
@@ -171,7 +171,7 @@ interface Room {
      * @returns The room direction constant, one of the following: FIND_EXIT_TOP, FIND_EXIT_RIGHT, FIND_EXIT_BOTTOM, FIND_EXIT_LEFT
      * Or one of the following error codes: ERR_NO_PATH, ERR_INVALID_ARGS
      */
-    findExitTo(room: string | Room): ExitConstant | ERR_NO_PATH | ERR_INVALID_ARGS;
+    findExitTo(room: Name<Room> | Room): ExitConstant | ERR_NO_PATH | ERR_INVALID_ARGS;
     /**
      * Find an optimal path inside the room between fromPos and toPos using A* search algorithm.
      * @param fromPos The start position.
@@ -266,7 +266,7 @@ interface Room {
 }
 
 interface RoomConstructor extends _Constructor<Room> {
-    new (id: string): Room;
+    new (id: Name<Room>): Room;
 
     Terrain: RoomTerrainConstructor;
 

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -45,7 +45,7 @@ interface StructureSpawn extends OwnedStructure<STRUCTURE_SPAWN> {
      * You choose the name upon creating a new spawn, and it cannot be changed later.
      * This name is a hash key to access the spawn via the {@link Game.spawns} object.
      */
-    name: string;
+    name: Name<this>;
     /**
      * If the spawn is in process of spawning a new creep, this object will contain the new creep’s information, or null otherwise.
      */
@@ -193,7 +193,7 @@ interface Spawning {
     /**
      * The name of the creep
      */
-    name: string;
+    name: Name<Creep>;
 
     /**
      * Time needed in total to complete the spawning.

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -286,7 +286,7 @@ interface StructureObserver extends OwnedStructure<STRUCTURE_OBSERVER> {
      * - ERR_INVALID_ARGS: roomName argument is not a valid room name value.
      * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient to use this structure.
      */
-    observeRoom(roomName: string): ScreepsReturnCode;
+    observeRoom(roomName: Name<Room>): ScreepsReturnCode;
 }
 
 interface StructureObserverConstructor extends _Constructor<StructureObserver>, _ConstructorById<StructureObserver> {}
@@ -690,7 +690,7 @@ interface StructureTerminal extends OwnedStructure<STRUCTURE_TERMINAL> {
      * - ERR_INVALID_ARGS: The arguments provided are incorrect.
      * - ERR_TIRED: The terminal is still cooling down.
      */
-    send(resourceType: ResourceConstant, amount: number, destination: string, description?: string): ScreepsReturnCode;
+    send(resourceType: ResourceConstant, amount: number, destination: Name<Room>, description?: string): ScreepsReturnCode;
 }
 
 interface StructureTerminalConstructor extends _Constructor<StructureTerminal>, _ConstructorById<StructureTerminal> {}
@@ -799,7 +799,7 @@ interface StructurePortal extends Structure<STRUCTURE_PORTAL> {
      * If this is an inter-shard portal, then this property contains an object with shard and room string properties.
      * Exact coordinates are undetermined, the creep will appear at any free spot in the destination room.
      */
-    destination: RoomPosition | { shard: string; room: string };
+    destination: RoomPosition | { shard: Name<Shard>; room: Name<Room> };
     /**
      * The amount of game ticks when the portal disappears, or undefined when the portal is stable.
      */


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

Similar to the `Id<T>` type, this PR distinguishes between non-interchangeable names (`Creep.name`, `Spawn.name`, `Room.name`, etc) using a unique tagged type.

Also similar to the `Id` type, this adds a bit of annoyance when using explicit name constants, which I think is a worthwhile tradeoff for the safety from using the wrong strings to index the various lookups by name, etc.

I opted to not type the `name` parameter to the various `create...()` functions. The *requested* name for a new creep doesn't become a `Name<Creep>` until there's a `Creep` for it to be associated with on a later tick.

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [X] Test passed
- [X] Coding style (indentation, etc)
- [X] Edits have been made to `src/` files not `index.d.ts`
- [X] Run `npm run compile` to update `index.d.ts`
