### PR TITLE
Type `cancelOrder` `methodName` parameter to method keys of `Creep`/`PowerCreep`

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1242,7 +1242,7 @@ interface Creep extends RoomObject {
      * - OK: The operation has been cancelled successfully.
      * - ERR_NOT_FOUND: The order with the specified name is not found.
      */
-    cancelOrder(methodName: string): OK | ERR_NOT_FOUND;
+    cancelOrder(methodName: MethodKey<Creep>): OK | ERR_NOT_FOUND;
     /**
      * Claim a controller.
      *
@@ -2325,6 +2325,10 @@ declare namespace Tag {
 type Id<T extends _HasId> = string & Tag.OpaqueTag<T>;
 
 type fromId<T> = T extends Id<infer R> ? R : never;
+
+type MethodKey<T> = {
+    [K in keyof T]: T[K] extends Function ? K : never;
+}[keyof T];
 /**
  * `InterShardMemory` object provides an interface for communicating between shards.
  *
@@ -4034,7 +4038,7 @@ interface PowerCreep extends RoomObject {
      * - ERR_BUSY: The power creep is not spawned in the world.
      * - ERR_NOT_FOUND: The order with the specified name is not found.
      */
-    cancelOrder(methodName: string): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_FOUND;
+    cancelOrder(methodName: MethodKey<PowerCreep>): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_FOUND;
     /**
      * Delete the power creep permanently from your account.
      *

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -1424,3 +1424,11 @@ function atackPower(creep: Creep) {
     /// @ts-expect-error
     const foo = Game.getObjectById<StructureTower>("" as Id<Creep>);
 }
+
+// CancelOrder
+{
+    const creep = Game.creeps.sampleCreep;
+    creep.cancelOrder("repair");
+    /// @ts-expect-error
+    creep.cancelOrder("fake");
+}

--- a/src/creep.ts
+++ b/src/creep.ts
@@ -168,7 +168,7 @@ interface Creep extends RoomObject {
      * - OK: The operation has been cancelled successfully.
      * - ERR_NOT_FOUND: The order with the specified name is not found.
      */
-    cancelOrder(methodName: string): OK | ERR_NOT_FOUND;
+    cancelOrder(methodName: MethodKey<Creep>): OK | ERR_NOT_FOUND;
     /**
      * Claim a controller.
      *

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -478,3 +478,7 @@ declare namespace Tag {
 type Id<T extends _HasId> = string & Tag.OpaqueTag<T>;
 
 type fromId<T> = T extends Id<infer R> ? R : never;
+
+type MethodKey<T> = {
+    [K in keyof T]: T[K] extends Function ? K : never;
+}[keyof T];

--- a/src/power-creep.ts
+++ b/src/power-creep.ts
@@ -110,7 +110,7 @@ interface PowerCreep extends RoomObject {
      * - ERR_BUSY: The power creep is not spawned in the world.
      * - ERR_NOT_FOUND: The order with the specified name is not found.
      */
-    cancelOrder(methodName: string): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_FOUND;
+    cancelOrder(methodName: MethodKey<PowerCreep>): OK | ERR_NOT_OWNER | ERR_BUSY | ERR_NOT_FOUND;
     /**
      * Delete the power creep permanently from your account.
      *


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

Currently `Creep.cancelOrder` (and `PowerCreep`) accept any string as the `methodName` to cancel. This can be more tightly typed as strings at are keys of methods (not data properties) in those types.

A more accurate solution would be to enumerate all of the methods that register intents.

A few new lines in the tests file include one good and one bad call to `cancelOrder`.

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [X] Test passed
- [X] Coding style (indentation, etc)
- [X] Edits have been made to `src/` files not `index.d.ts`
- [X] Run `npm run compile` to update `index.d.ts`
