### PR TITLE
Type Ids for EventData and Game hashes

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1799,12 +1799,12 @@ interface Game {
     /**
      * A hash containing all your structures with structure id as hash keys.
      */
-    structures: { [structureId: string]: OwnedStructure };
+    structures: { [structureId: Id<OwnedStructure>]: OwnedStructure };
 
     /**
      * A hash containing all your construction sites with their id as hash keys.
      */
-    constructionSites: { [constructionSiteId: string]: ConstructionSite };
+    constructionSites: { [constructionSiteId: Id<ConstructionSite>]: ConstructionSite };
 
     /**
      * An object describing the world shard where your script is currently being executed in.
@@ -2322,7 +2322,7 @@ declare namespace Tag {
     }
 }
 
-type Id<T extends _HasId> = string & Tag.OpaqueTag<T>;
+type Id<T extends _HasId = _HasId> = string & Tag.OpaqueTag<T>;
 
 type fromId<T> = T extends Id<infer R> ? R : never;
 /**
@@ -2896,68 +2896,68 @@ type EventDestroyType = "creep" | StructureConstant;
 type EventItem =
     | {
           event: EVENT_ATTACK;
-          objectId: string;
+          objectId: Id<Creep> | Id<PowerCreep> | Id<Structure>;
           data: EventData[EVENT_ATTACK];
       }
     | {
           event: EVENT_OBJECT_DESTROYED;
-          objectId: string;
+          objectId: Id;
           data: EventData[EVENT_OBJECT_DESTROYED];
       }
     | {
           event: EVENT_ATTACK_CONTROLLER;
-          objectId: string;
+          objectId: Id<Creep> | Id<StructureInvaderCore>;
           data: EventData[EVENT_ATTACK_CONTROLLER];
       }
     | {
           event: EVENT_BUILD;
-          objectId: string;
+          objectId: Id<Creep>;
           data: EventData[EVENT_BUILD];
       }
     | {
           event: EVENT_HARVEST;
-          objectId: string;
+          objectId: Id<Creep>;
           data: EventData[EVENT_HARVEST];
       }
     | {
           event: EVENT_HEAL;
-          objectId: string;
+          objectId: Id<Creep> | Id<StructureTower>;
           data: EventData[EVENT_HEAL];
       }
     | {
           event: EVENT_REPAIR;
-          objectId: string;
+          objectId: Id<Creep> | Id<StructureTower>;
           data: EventData[EVENT_REPAIR];
       }
     | {
           event: EVENT_RESERVE_CONTROLLER;
-          objectId: string;
+          objectId: Id<Creep> | Id<StructureInvaderCore>;
           data: EventData[EVENT_RESERVE_CONTROLLER];
       }
     | {
           event: EVENT_UPGRADE_CONTROLLER;
-          objectId: string;
+          objectId: Id<Creep> | Id<StructureInvaderCore>;
           data: EventData[EVENT_UPGRADE_CONTROLLER];
       }
     | {
           event: EVENT_EXIT;
-          objectId: string;
+          objectId: Id<Creep> | Id<PowerCreep>;
           data: EventData[EVENT_EXIT];
       }
     | {
           event: EVENT_POWER;
-          objectId: string;
+          objectId: Id<PowerCreep>;
           data: EventData[EVENT_POWER];
       }
     | {
           event: EVENT_TRANSFER;
-          objectId: string;
+          objectId: Id<Creep> | Id<PowerCreep> | Id<StructureLink> | Id<StructureInvaderCore>;
           data: EventData[EVENT_TRANSFER];
       };
 
 interface EventData {
     [EVENT_ATTACK]: {
-        targetId: string;
+        targetId: Id;
         damage: number;
         attackType: EventAttackType;
     };
@@ -2966,7 +2966,7 @@ interface EventData {
     };
     [EVENT_ATTACK_CONTROLLER]: null;
     [EVENT_BUILD]: {
-        targetId: string;
+        targetId: Id<ConstructionSite>;
         amount: number;
         structureType: BuildableStructureConstant;
         x: number;
@@ -2974,16 +2974,16 @@ interface EventData {
         incomplete: boolean;
     };
     [EVENT_HARVEST]: {
-        targetId: string;
+        targetId: Id<Source> | Id<Mineral> | Id<Deposit>;
         amount: number;
     };
     [EVENT_HEAL]: {
-        targetId: string;
+        targetId: Id<Creep> | Id<PowerCreep>;
         amount: number;
         healType: EventHealType;
     };
     [EVENT_REPAIR]: {
-        targetId: string;
+        targetId: Id<Structure>;
         amount: number;
         energySpent: number;
     };
@@ -3000,11 +3000,11 @@ interface EventData {
         y: number;
     };
     [EVENT_POWER]: {
-        targetId: string;
+        targetId: Id;
         power: PowerConstant;
     };
     [EVENT_TRANSFER]: {
-        targetId: string;
+        targetId: Id<AnyStoreStructure> | Id<Creep> | Id<PowerCreep>;
         resourceType: ResourceConstant;
         amount: number;
     };

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -1114,9 +1114,11 @@ function resources(o: GenericStore): ResourceConstant[] {
     switch (event.event) {
         case EVENT_ATTACK:
             const attackType: EventAttackType = event.data.attackType;
+            const attacker: Creep | PowerCreep | Structure | null = Game.getObjectById(event.objectId);
             break;
         case EVENT_BUILD:
             const incomplete: boolean = event.data.incomplete;
+            const target: ConstructionSite = Game.getObjectById(event.data.targetId)!;
             break;
         case EVENT_POWER:
             const power = event.data.power;
@@ -1424,3 +1426,6 @@ function atackPower(creep: Creep) {
     /// @ts-expect-error
     const foo = Game.getObjectById<StructureTower>("" as Id<Creep>);
 }
+
+let x: EventItem;
+Game.getObjectById(x.objectId);

--- a/src/game.ts
+++ b/src/game.ts
@@ -55,12 +55,12 @@ interface Game {
     /**
      * A hash containing all your structures with structure id as hash keys.
      */
-    structures: { [structureId: string]: OwnedStructure };
+    structures: { [structureId: Id<OwnedStructure>]: OwnedStructure };
 
     /**
      * A hash containing all your construction sites with their id as hash keys.
      */
-    constructionSites: { [constructionSiteId: string]: ConstructionSite };
+    constructionSites: { [constructionSiteId: Id<ConstructionSite>]: ConstructionSite };
 
     /**
      * An object describing the world shard where your script is currently being executed in.

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -475,6 +475,6 @@ declare namespace Tag {
     }
 }
 
-type Id<T extends _HasId> = string & Tag.OpaqueTag<T>;
+type Id<T extends _HasId = _HasId> = string & Tag.OpaqueTag<T>;
 
 type fromId<T> = T extends Id<infer R> ? R : never;

--- a/src/literals.ts
+++ b/src/literals.ts
@@ -536,68 +536,68 @@ type EventDestroyType = "creep" | StructureConstant;
 type EventItem =
     | {
           event: EVENT_ATTACK;
-          objectId: string;
+          objectId: Id<Creep> | Id<PowerCreep> | Id<Structure>;
           data: EventData[EVENT_ATTACK];
       }
     | {
           event: EVENT_OBJECT_DESTROYED;
-          objectId: string;
+          objectId: Id;
           data: EventData[EVENT_OBJECT_DESTROYED];
       }
     | {
           event: EVENT_ATTACK_CONTROLLER;
-          objectId: string;
+          objectId: Id<Creep> | Id<StructureInvaderCore>;
           data: EventData[EVENT_ATTACK_CONTROLLER];
       }
     | {
           event: EVENT_BUILD;
-          objectId: string;
+          objectId: Id<Creep>;
           data: EventData[EVENT_BUILD];
       }
     | {
           event: EVENT_HARVEST;
-          objectId: string;
+          objectId: Id<Creep>;
           data: EventData[EVENT_HARVEST];
       }
     | {
           event: EVENT_HEAL;
-          objectId: string;
+          objectId: Id<Creep> | Id<StructureTower>;
           data: EventData[EVENT_HEAL];
       }
     | {
           event: EVENT_REPAIR;
-          objectId: string;
+          objectId: Id<Creep> | Id<StructureTower>;
           data: EventData[EVENT_REPAIR];
       }
     | {
           event: EVENT_RESERVE_CONTROLLER;
-          objectId: string;
+          objectId: Id<Creep> | Id<StructureInvaderCore>;
           data: EventData[EVENT_RESERVE_CONTROLLER];
       }
     | {
           event: EVENT_UPGRADE_CONTROLLER;
-          objectId: string;
+          objectId: Id<Creep> | Id<StructureInvaderCore>;
           data: EventData[EVENT_UPGRADE_CONTROLLER];
       }
     | {
           event: EVENT_EXIT;
-          objectId: string;
+          objectId: Id<Creep> | Id<PowerCreep>;
           data: EventData[EVENT_EXIT];
       }
     | {
           event: EVENT_POWER;
-          objectId: string;
+          objectId: Id<PowerCreep>;
           data: EventData[EVENT_POWER];
       }
     | {
           event: EVENT_TRANSFER;
-          objectId: string;
+          objectId: Id<Creep> | Id<PowerCreep> | Id<StructureLink> | Id<StructureInvaderCore>;
           data: EventData[EVENT_TRANSFER];
       };
 
 interface EventData {
     [EVENT_ATTACK]: {
-        targetId: string;
+        targetId: Id;
         damage: number;
         attackType: EventAttackType;
     };
@@ -606,7 +606,7 @@ interface EventData {
     };
     [EVENT_ATTACK_CONTROLLER]: null;
     [EVENT_BUILD]: {
-        targetId: string;
+        targetId: Id<ConstructionSite>;
         amount: number;
         structureType: BuildableStructureConstant;
         x: number;
@@ -614,16 +614,16 @@ interface EventData {
         incomplete: boolean;
     };
     [EVENT_HARVEST]: {
-        targetId: string;
+        targetId: Id<Source> | Id<Mineral> | Id<Deposit>;
         amount: number;
     };
     [EVENT_HEAL]: {
-        targetId: string;
+        targetId: Id<Creep> | Id<PowerCreep>;
         amount: number;
         healType: EventHealType;
     };
     [EVENT_REPAIR]: {
-        targetId: string;
+        targetId: Id<Structure>;
         amount: number;
         energySpent: number;
     };
@@ -640,11 +640,11 @@ interface EventData {
         y: number;
     };
     [EVENT_POWER]: {
-        targetId: string;
+        targetId: Id;
         power: PowerConstant;
     };
     [EVENT_TRANSFER]: {
-        targetId: string;
+        targetId: Id<AnyStoreStructure> | Id<Creep> | Id<PowerCreep>;
         resourceType: ResourceConstant;
         amount: number;
     };


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

The hashes in `Game` for structures and construction sites have typed values. This PR types their keys to IDs for those value types.

This PR also types the `objectId` (actor) `targetId` for the various `Event` types, and adds a couple more lines of tests related to that.

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [X] Test passed
- [X] Coding style (indentation, etc)
- [X] Edits have been made to `src/` files not `index.d.ts`
- [X] Run `npm run compile` to update `index.d.ts`
