### PR TITLE
Type color hex strings

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2325,6 +2325,9 @@ declare namespace Tag {
 type Id<T extends _HasId> = string & Tag.OpaqueTag<T>;
 
 type fromId<T> = T extends Id<infer R> ? R : never;
+
+/** color in the following format: #ffffff (hex triplet). */
+type HexColor = `#${string}`;
 /**
  * `InterShardMemory` object provides an interface for communicating between shards.
  *
@@ -3291,7 +3294,7 @@ interface MapLineStyle {
      * Line color in the following format: #ffffff (hex triplet).
      * @default #ffffff
      */
-    color?: string;
+    color?: HexColor;
     /**
      * Opacity value
      * @default 0.5
@@ -3309,7 +3312,7 @@ interface MapPolyStyle {
      * Fill color in the following format: #ffffff (hex triplet).
      * @default undefined (no fill).
      */
-    fill?: string | undefined;
+    fill?: HexColor | undefined;
     /**
      * Opacity value
      * @default 0.5
@@ -3319,7 +3322,7 @@ interface MapPolyStyle {
      * Stroke color in the following format: #ffffff (hex triplet).
      * @default #ffffff
      */
-    stroke?: string;
+    stroke?: HexColor;
     /**
      * Stroke line width.
      * @default 0.5
@@ -3345,7 +3348,7 @@ interface MapTextStyle {
      * Font color in the following format: #ffffff (hex triplet).
      * @default #ffffff
      */
-    color?: string;
+    color?: HexColor;
     /**
      * The font family.
      * @default sans-serif
@@ -3368,7 +3371,7 @@ interface MapTextStyle {
      * Stroke color in the following format: #ffffff (hex triplet)
      * @default undefined (no stroke).
      */
-    stroke?: string | undefined;
+    stroke?: HexColor | undefined;
     /**
      * Stroke width.
      * @default 0.15
@@ -3380,7 +3383,7 @@ interface MapTextStyle {
      * When background is enabled, text vertical align is set to middle (default is baseline).
      * @default undefined (no background).
      */
-    backgroundColor?: string | undefined;
+    backgroundColor?: HexColor | undefined;
     /**
      * Background rectangle padding.
      * @default 2
@@ -4938,7 +4941,7 @@ interface LineStyle {
      * Line color in any web format.
      * @default #ffffff (white)
      */
-    color?: string;
+    color?: HexColor;
     /**
      * Opacity value.
      * @default 0.5
@@ -4956,7 +4959,7 @@ interface PolyStyle {
      * Fill color in any web format.
      * @default undefined (no fill).
      */
-    fill?: string | undefined;
+    fill?: HexColor | undefined;
     /**
      * Opacity value, default is 0.5.
      */
@@ -4965,7 +4968,7 @@ interface PolyStyle {
      * Stroke color in any web format.
      * @default #ffffff (white)
      */
-    stroke?: string;
+    stroke?: HexColor;
     /**
      * Stroke line width.
      * @default 0.1
@@ -4991,7 +4994,7 @@ interface TextStyle {
      * Font color in any web format.
      * @default #ffffff (white)
      */
-    color?: string;
+    color?: HexColor;
     /**
      * Either a number or a string in one of the following forms:
      * - 0.7 - relative size in game coordinates
@@ -5004,7 +5007,7 @@ interface TextStyle {
      * Stroke color in any web format.
      * @default undefined (no stroke)
      */
-    stroke?: string | undefined;
+    stroke?: HexColor | undefined;
     /**
      * Stroke width.
      * @default 0.15

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -1273,6 +1273,8 @@ function atackPower(creep: Creep) {
     const point4 = new RoomPosition(1, 1, "E1N8");
 
     mapVis.line(point1, point2).circle(point3, { fill: "#f2f2f2" }).poly([point1, point2, point3, point4]).rect(point3, 50, 50);
+    /// @ts-expect-error
+    mapVis.line(point1, point2).circle(point3, { fill: "badcolor" });
 
     const size: number = mapVis.getSize();
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -478,3 +478,6 @@ declare namespace Tag {
 type Id<T extends _HasId> = string & Tag.OpaqueTag<T>;
 
 type fromId<T> = T extends Id<infer R> ? R : never;
+
+/** color in the following format: #ffffff (hex triplet). */
+type HexColor = `#${string}`;

--- a/src/map.ts
+++ b/src/map.ts
@@ -221,7 +221,7 @@ interface MapLineStyle {
      * Line color in the following format: #ffffff (hex triplet).
      * @default #ffffff
      */
-    color?: string;
+    color?: HexColor;
     /**
      * Opacity value
      * @default 0.5
@@ -239,7 +239,7 @@ interface MapPolyStyle {
      * Fill color in the following format: #ffffff (hex triplet).
      * @default undefined (no fill).
      */
-    fill?: string | undefined;
+    fill?: HexColor | undefined;
     /**
      * Opacity value
      * @default 0.5
@@ -249,7 +249,7 @@ interface MapPolyStyle {
      * Stroke color in the following format: #ffffff (hex triplet).
      * @default #ffffff
      */
-    stroke?: string;
+    stroke?: HexColor;
     /**
      * Stroke line width.
      * @default 0.5
@@ -275,7 +275,7 @@ interface MapTextStyle {
      * Font color in the following format: #ffffff (hex triplet).
      * @default #ffffff
      */
-    color?: string;
+    color?: HexColor;
     /**
      * The font family.
      * @default sans-serif
@@ -298,7 +298,7 @@ interface MapTextStyle {
      * Stroke color in the following format: #ffffff (hex triplet)
      * @default undefined (no stroke).
      */
-    stroke?: string | undefined;
+    stroke?: HexColor | undefined;
     /**
      * Stroke width.
      * @default 0.15
@@ -310,7 +310,7 @@ interface MapTextStyle {
      * When background is enabled, text vertical align is set to middle (default is baseline).
      * @default undefined (no background).
      */
-    backgroundColor?: string | undefined;
+    backgroundColor?: HexColor | undefined;
     /**
      * Background rectangle padding.
      * @default 2

--- a/src/room-visual.ts
+++ b/src/room-visual.ts
@@ -146,7 +146,7 @@ interface LineStyle {
      * Line color in any web format.
      * @default #ffffff (white)
      */
-    color?: string;
+    color?: HexColor;
     /**
      * Opacity value.
      * @default 0.5
@@ -164,7 +164,7 @@ interface PolyStyle {
      * Fill color in any web format.
      * @default undefined (no fill).
      */
-    fill?: string | undefined;
+    fill?: HexColor | undefined;
     /**
      * Opacity value, default is 0.5.
      */
@@ -173,7 +173,7 @@ interface PolyStyle {
      * Stroke color in any web format.
      * @default #ffffff (white)
      */
-    stroke?: string;
+    stroke?: HexColor;
     /**
      * Stroke line width.
      * @default 0.1
@@ -199,7 +199,7 @@ interface TextStyle {
      * Font color in any web format.
      * @default #ffffff (white)
      */
-    color?: string;
+    color?: HexColor;
     /**
      * Either a number or a string in one of the following forms:
      * - 0.7 - relative size in game coordinates
@@ -212,7 +212,7 @@ interface TextStyle {
      * Stroke color in any web format.
      * @default undefined (no stroke)
      */
-    stroke?: string | undefined;
+    stroke?: HexColor | undefined;
     /**
      * Stroke width.
      * @default 0.15


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

This PR restricts color strings (color, fill. stroke, etc) to starting with `"#"`. Unfortunately there's no performant way to narrow it down to just hex characters (requires a monstrous union type) or the correct length (requires recursive types or other tricks).

Added one new test line with a bad color.

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run compile` to update `index.d.ts`
