### PR TITLE
Type market orders

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3417,7 +3417,7 @@ interface Market {
     /**
      * An object with your active and inactive buy/sell orders on the market.
      */
-    orders: { [key: string]: Order };
+    orders: { [key: Id<Order>]: Order };
     /**
      * An array of the last 100 outgoing transactions from your terminals
      */
@@ -3446,7 +3446,7 @@ interface Market {
      * - OK: The operation has been scheduled successfully.
      * - ERR_INVALID_ARGS: The order ID is not valid.
      */
-    cancelOrder(orderId: string): ScreepsReturnCode;
+    cancelOrder(orderId: Id<Order>): ScreepsReturnCode;
     /**
      * Change the price of an existing order.
      *
@@ -3459,7 +3459,7 @@ interface Market {
      * - ERR_NOT_ENOUGH_RESOURCES: You don't have enough credits to pay a fee.
      * - ERR_INVALID_ARGS: The arguments provided are invalid.
      */
-    changeOrderPrice(orderId: string, newPrice: number): ScreepsReturnCode;
+    changeOrderPrice(orderId: Id<Order>, newPrice: number): ScreepsReturnCode;
     /**
      * Create a market order in your terminal.
      *
@@ -3502,7 +3502,7 @@ interface Market {
      * - ERR_INVALID_ARGS: The arguments provided are invalid.
      * - ERR_TIRED: The target terminal is still cooling down.
      */
-    deal(orderId: string, amount: number, yourRoomName?: string): ScreepsReturnCode;
+    deal(orderId: Id<Order>, amount: number, yourRoomName?: string): ScreepsReturnCode;
     /**
      * Add more capacity to an existing order.
      *
@@ -3516,7 +3516,7 @@ interface Market {
      * - ERR_NOT_ENOUGH_RESOURCES: You don't have enough credits to pay a fee.
      * - ERR_INVALID_ARGS:  The arguments provided are invalid.
      */
-    extendOrder(orderId: string, addAmount: number): ScreepsReturnCode;
+    extendOrder(orderId: Id<Order>, addAmount: number): ScreepsReturnCode;
     /**
      * Get other players' orders currently active on the market.
      * @param filter (optional) An object or function that will filter the resulting list using the lodash.filter method.
@@ -3534,7 +3534,7 @@ interface Market {
      * @param orderId The order ID.
      * @returns An object with the order info. See {@link Order}.
      */
-    getOrderById(id: string): Order | null;
+    getOrderById(id: Id<Order>): Order | null;
 }
 
 // No static is available
@@ -3554,7 +3554,7 @@ interface Transaction {
 
 interface Order {
     /** The unique order ID. */
-    id: string;
+    id: Id<this>;
     /**
      * The order creation time in milliseconds since UNIX epoch time.
      *
@@ -3584,15 +3584,15 @@ interface Order {
 }
 
 interface TransactionOrder {
-    id: string;
-    type: string;
+    id: Id<this>;
+    type: ORDER_BUY | ORDER_SELL;
     price: number;
 }
 
 interface OrderFilter {
-    id?: string;
+    id?: Id<Order>;
     created?: number;
-    type?: string;
+    type?: ORDER_BUY | ORDER_SELL;
     resourceType?: MarketResourceConstant;
     roomName?: string;
     amount?: number;

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -371,12 +371,12 @@ function resources(o: GenericStore): ResourceConstant[] {
     const cost = Game.market.calcTransactionCost(1000, "W0N0", "W10N5");
 
     // Game.market.cancelOrder(orderId)
-    for (const id of Object.keys(Game.market.orders)) {
+    for (const id of Object.keys(Game.market.orders) as Array<keyof typeof Game.market.orders>) {
         Game.market.cancelOrder(id);
     }
 
     // Game.market.changeOrderPrice(orderId, newPrice)
-    Game.market.changeOrderPrice("57bec1bf77f4d17c4c011960", 9.95);
+    Game.market.changeOrderPrice("57bec1bf77f4d17c4c011960" as Id<Order>, 9.95);
 
     // Game.market.createOrder({type, resourceType, price, totalAmount, [roomName]})
     Game.market.createOrder({ type: ORDER_SELL, resourceType: RESOURCE_GHODIUM, price: 9.95, totalAmount: 10000, roomName: "W1N1" });
@@ -398,7 +398,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     }
 
     // Game.market.deal(orderId, amount, [yourRoomName])
-    Game.market.deal("57cd2b12cda69a004ae223a3", 1000, "W1N1");
+    Game.market.deal("57cd2b12cda69a004ae223a3" as Id<Order>, 1000, "W1N1");
 
     const amountToBuy = 2000;
     const maxTransferEnergyCost = 500;
@@ -416,7 +416,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     }
 
     // Game.market.extendOrder(orderId, addAmount)
-    Game.market.extendOrder("57bec1bf77f4d17c4c011960", 10000);
+    Game.market.extendOrder("57bec1bf77f4d17c4c011960" as Id<Order>, 10000);
 
     // Game.market.getAllOrders([filter])
     Game.market.getAllOrders();
@@ -431,7 +431,7 @@ function resources(o: GenericStore): ResourceConstant[] {
     );
 
     // Game.market.getOrderById(id)
-    const order = Game.market.getOrderById("55c34a6b5be41a0a6e80c123");
+    const order = Game.market.getOrderById("55c34a6b5be41a0a6e80c123" as Id<Order>);
 
     // Subscription tokens
     Game.market.getAllOrders({ type: ORDER_SELL, resourceType: SUBSCRIPTION_TOKEN });

--- a/src/market.ts
+++ b/src/market.ts
@@ -18,7 +18,7 @@ interface Market {
     /**
      * An object with your active and inactive buy/sell orders on the market.
      */
-    orders: { [key: string]: Order };
+    orders: { [key: Id<Order>]: Order };
     /**
      * An array of the last 100 outgoing transactions from your terminals
      */
@@ -47,7 +47,7 @@ interface Market {
      * - OK: The operation has been scheduled successfully.
      * - ERR_INVALID_ARGS: The order ID is not valid.
      */
-    cancelOrder(orderId: string): ScreepsReturnCode;
+    cancelOrder(orderId: Id<Order>): ScreepsReturnCode;
     /**
      * Change the price of an existing order.
      *
@@ -60,7 +60,7 @@ interface Market {
      * - ERR_NOT_ENOUGH_RESOURCES: You don't have enough credits to pay a fee.
      * - ERR_INVALID_ARGS: The arguments provided are invalid.
      */
-    changeOrderPrice(orderId: string, newPrice: number): ScreepsReturnCode;
+    changeOrderPrice(orderId: Id<Order>, newPrice: number): ScreepsReturnCode;
     /**
      * Create a market order in your terminal.
      *
@@ -103,7 +103,7 @@ interface Market {
      * - ERR_INVALID_ARGS: The arguments provided are invalid.
      * - ERR_TIRED: The target terminal is still cooling down.
      */
-    deal(orderId: string, amount: number, yourRoomName?: string): ScreepsReturnCode;
+    deal(orderId: Id<Order>, amount: number, yourRoomName?: string): ScreepsReturnCode;
     /**
      * Add more capacity to an existing order.
      *
@@ -117,7 +117,7 @@ interface Market {
      * - ERR_NOT_ENOUGH_RESOURCES: You don't have enough credits to pay a fee.
      * - ERR_INVALID_ARGS:  The arguments provided are invalid.
      */
-    extendOrder(orderId: string, addAmount: number): ScreepsReturnCode;
+    extendOrder(orderId: Id<Order>, addAmount: number): ScreepsReturnCode;
     /**
      * Get other players' orders currently active on the market.
      * @param filter (optional) An object or function that will filter the resulting list using the lodash.filter method.
@@ -135,7 +135,7 @@ interface Market {
      * @param orderId The order ID.
      * @returns An object with the order info. See {@link Order}.
      */
-    getOrderById(id: string): Order | null;
+    getOrderById(id: Id<Order>): Order | null;
 }
 
 // No static is available
@@ -155,7 +155,7 @@ interface Transaction {
 
 interface Order {
     /** The unique order ID. */
-    id: string;
+    id: Id<this>;
     /**
      * The order creation time in milliseconds since UNIX epoch time.
      *
@@ -185,15 +185,15 @@ interface Order {
 }
 
 interface TransactionOrder {
-    id: string;
-    type: string;
+    id: Id<this>;
+    type: ORDER_BUY | ORDER_SELL;
     price: number;
 }
 
 interface OrderFilter {
-    id?: string;
+    id?: Id<Order>;
     created?: number;
-    type?: string;
+    type?: ORDER_BUY | ORDER_SELL;
     resourceType?: MarketResourceConstant;
     roomName?: string;
     amount?: number;


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

The market types `Order` and `TransactionOrder` have `id` properties with some related `get...ById` and `filter` functions, so this PR types those `id`s.

Unfortunately `Transaction` is an outlier, with a `transactionId` property instead of `id`.

Oddly, although my IDE required me to fix the test references to orders, the eslint test didn't care about them, so I wasn't able to convince it to confirm a known bad case. I'm open to suggestions there.

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [X] Test passed
- [X] Coding style (indentation, etc)
- [X] Edits have been made to `src/` files not `index.d.ts`
- [X] Run `npm run compile` to update `index.d.ts`
