### PR TITLE
Correct createConstructionSite structureType params

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -5109,7 +5109,7 @@ interface Room {
      * - ERR_INVALID_ARGS: The location is incorrect.
      * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient.
      */
-    createConstructionSite(pos: RoomPosition | _HasRoomPosition, structureType: StructureConstant): ScreepsReturnCode;
+    createConstructionSite(pos: RoomPosition | _HasRoomPosition, structureType: BuildableStructureConstant): ScreepsReturnCode;
     /**
      * Create new {@link ConstructionSite} at the specified location.
      * @param x The X position

--- a/src/room.ts
+++ b/src/room.ts
@@ -78,7 +78,7 @@ interface Room {
      * - ERR_INVALID_ARGS: The location is incorrect.
      * - ERR_RCL_NOT_ENOUGH: Room Controller Level insufficient.
      */
-    createConstructionSite(pos: RoomPosition | _HasRoomPosition, structureType: StructureConstant): ScreepsReturnCode;
+    createConstructionSite(pos: RoomPosition | _HasRoomPosition, structureType: BuildableStructureConstant): ScreepsReturnCode;
     /**
      * Create new {@link ConstructionSite} at the specified location.
      * @param x The X position


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

Update `createConstructionSite` param types to specify only buildable structures, ~~allow all buildable structures, not just spawns. I'm not sure how calls for non-spawn structures were passing type checks previously. This seems like a correct update, but because tests weren't failing before I'm not sure how to verify that I haven't made some mistake here. I also made a few related corrections~~, narrowing one of the signatures from the overly broad type that includes non-buildable structures.

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [X] Test passed
- [X] Coding style (indentation, etc)
- [X] Edits have been made to `src/` files not `index.d.ts`
- [X] Run `npm run compile` to update `index.d.ts`
