### PR TITLE
Add typing for the newly added console.logUnsafe function

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2325,6 +2325,18 @@ declare namespace Tag {
 type Id<T extends _HasId> = string & Tag.OpaqueTag<T>;
 
 type fromId<T> = T extends Id<infer R> ? R : never;
+
+interface Console {
+    /**
+     * An alternative to {@link console.log} that doesn't perform safe-HTML escapes.
+     * This can be used to output messages to the client that will be parsed as raw HTML, allowing some sort of
+     * injection attack. As such, it's unsafe to pass it things you have do not have control over, like player creep
+     * names, signs, market transaction messages.
+     * @param message
+     * @param optionalParams
+     */
+    logUnsafe(message?: any, ...optionalParams: any[]): void;
+}
 /**
  * `InterShardMemory` object provides an interface for communicating between shards.
  *

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -1424,3 +1424,10 @@ function atackPower(creep: Creep) {
     /// @ts-expect-error
     const foo = Game.getObjectById<StructureTower>("" as Id<Creep>);
 }
+
+// console.logUnsafe
+{
+    // @ts-ignore: we're cheating there as we don't need the DOM types loaded
+    const console: Console = {};
+    console.logUnsafe("test");
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -478,3 +478,15 @@ declare namespace Tag {
 type Id<T extends _HasId> = string & Tag.OpaqueTag<T>;
 
 type fromId<T> = T extends Id<infer R> ? R : never;
+
+interface Console {
+    /**
+     * An alternative to {@link console.log} that doesn't perform safe-HTML escapes.
+     * This can be used to output messages to the client that will be parsed as raw HTML, allowing some sort of
+     * injection attack. As such, it's unsafe to pass it things you have do not have control over, like player creep
+     * names, signs, market transaction messages.
+     * @param message
+     * @param optionalParams
+     */
+    logUnsafe(message?: any, ...optionalParams: any[]): void;
+}


### PR DESCRIPTION
### Brief Description

Not sure if this is proper to do it that way, since we don't have a dependency on the DOM types being here, but that should at least make TS not frown at the function.

### Checklists

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run compile` to update `index.d.ts`
