### PR TITLE
feat: add compliant screeps console

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,3 +1,27 @@
+interface Console {
+    /**
+     * Prints a message to the console.
+     *
+     * If {@link console.logUnsafe} is defined then this function will escape HTML in {@link args},
+     * so that they will be displayed as plain text in the client console, rather than being evaluated as HTML.
+     *
+     * If you still wish to inject raw HTML into the client console, use {@link console.logUnsafe} instead.
+     * @param args arguments to print.
+     */
+    log(...args: any[]): void;
+    /**
+     * An alternative to {@link console.log} that doesn't perform safe-HTML escapes.
+     * This can be used to output messages to the client that will be parsed as raw HTML, allowing some sort of
+     * injection attack. As such, it's unsafe to pass it things you have do not have control over, like player creep
+     * names, signs, market transaction messages.
+     *
+     * In versions of screeps server prior to 4.2.20, this function is not defined and {@link console.log} do not escape HTML entities.
+     * @param args arguments to print without escaping HTML entities.
+     */
+    logUnsafe?(...args: any[]): void;
+}
+
+declare var console: Console;
 // Game Constants
 
 declare const OK: OK;

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "@types/screeps",
-    "version": "3.3.9999",
+    "version": "3.4.9999",
     "projects": [
         "https://github.com/screeps/screeps"
     ],
@@ -40,6 +40,10 @@
         {
             "name": "Mofeng",
             "githubUsername": "DiamondMofeng"
+        },
+        {
+            "name": "Shu",
+            "githubUsername": "shup1"
         }
     ]
 }

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -1424,3 +1424,28 @@ function atackPower(creep: Creep) {
     /// @ts-expect-error
     const foo = Game.getObjectById<StructureTower>("" as Id<Creep>);
 }
+
+// Console
+{
+    // should be available in global scope and provide log function
+    {
+        console.log("Hello, world!");
+    }
+    // should not provide standard console functions that are not in the Screeps environment
+    {
+        // @ts-expect-error
+        console.error("This should not be allowed");
+        // @ts-expect-error
+        console.warn("This should not be allowed");
+        // @ts-expect-error
+        console.info("This should not be allowed");
+        // @ts-expect-error
+        console.debug("This should not be allowed");
+    }
+    // may provide logUnsafe function that allows logging of unsafe HTML
+    {
+        (console.logUnsafe || console.log)("<p>This is an unsafe log message</p>");
+        // @ts-expect-error
+        console.logUnsafe("this function is not guaranteed to exist on old servers");
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-screeps",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "description": "Strong TypeScript declarations for the game Screeps.",
   "repository": "screepers/typed-screeps",
   "types": "./dist/index.d.ts",
@@ -33,7 +33,7 @@
     "lint-staged": "^12.3.8",
     "prettier": "^2.6.2",
     "typescript": "^5.5.0",
-    "typescript-eslint": "^7.16.1"
+    "typescript-eslint": "^8.57.0"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/src/console.ts
+++ b/src/console.ts
@@ -1,0 +1,24 @@
+interface Console {
+    /**
+     * Prints a message to the console.
+     *
+     * If {@link console.logUnsafe} is defined then this function will escape HTML in {@link args},
+     * so that they will be displayed as plain text in the client console, rather than being evaluated as HTML.
+     *
+     * If you still wish to inject raw HTML into the client console, use {@link console.logUnsafe} instead.
+     * @param args arguments to print.
+     */
+    log(...args: any[]): void;
+    /**
+     * An alternative to {@link console.log} that doesn't perform safe-HTML escapes.
+     * This can be used to output messages to the client that will be parsed as raw HTML, allowing some sort of
+     * injection attack. As such, it's unsafe to pass it things you have do not have control over, like player creep
+     * names, signs, market transaction messages.
+     *
+     * In versions of screeps server prior to 4.2.20, this function is not defined and {@link console.log} do not escape HTML entities.
+     * @param args arguments to print without escaping HTML entities.
+     */
+    logUnsafe?(...args: any[]): void;
+}
+
+declare var console: Console;


### PR DESCRIPTION
<!-- Thank you for your contribution to typed-screeps! Please replace {Please write here} with your description. -->

### Brief Description

Add a global `console` with `log` and `logUnsafe` without relying on `@types/node` nor `lib.dom.d.ts`.

Alterative to https://github.com/screepers/typed-screeps/pull/288

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run compile` to update `index.d.ts`
