### PR TITLE
Add interface for Screeps Console API

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -30,15 +30,7 @@ interface Console {
      *
      * To safely log unescaped messages on any environment, use `(console.logUnsafe ?? console.log)(...)`.
      */
-    logUnsafe(...data: any[]): void;
-
-    /**
-     * Append custom CSS data to a {@link RoomVisual} or {@link MapVisual}.
-     *
-     * @param roomName the name of the room (or "map" for {@link MapVisual})
-     * @param data the CSS to add; non-string data will be stringified via {@link JSON.stringify}
-     */
-    addVisual(roomName: string, data: any): void;
+    logUnsafe?(...data: any[]): void;
 }
 
 declare const console: Console;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -33,7 +33,7 @@ interface Console {
     logUnsafe?(...data: any[]): void;
 }
 
-declare const console: Console;
+declare var console: Console;
 // Game Constants
 
 declare const OK: OK;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -24,16 +24,13 @@ interface Console {
     /**
      * The **`console.logUnsafe()`** static method outputs a message to the console.
      *
-     * This is identical to the DOM implementation of {@link log}.
+     * `logUnsafe()` is a new addition that may not be present on older servers.
+     * When defined, it is identical to the DOM implementation of {@link log}.
+     * When undefined, {@link log} will not escape HTML characters.
+     *
+     * To safely log unescaped messages on any environment, use `(console.logUnsafe ?? console.log)(...)`.
      */
     logUnsafe(...data: any[]): void;
-
-    /**
-     * Record the evaluated value of a console expression sent via the client or API.
-     *
-     * @param message the result of evaluating the expression
-     */
-    commandResult(message: any): void;
 
     /**
      * Append custom CSS data to a {@link RoomVisual} or {@link MapVisual}.
@@ -42,36 +39,6 @@ interface Console {
      * @param data the CSS to add; non-string data will be stringified via {@link JSON.stringify}
      */
     addVisual(roomName: string, data: any): void;
-
-    /**
-     * Get the size of the CSS data added to a {@link RoomVisual} or {@link MapVisual}
-     *
-     * @param roomName the name of the room (or "map" for {@link MapVisual})
-     * @return the size in bytes of all CSS written to the specified room/map
-     *
-     * @see {@link RoomVisual.map} and {@link MapVisual.map}
-     */
-    getVisualSize(roomName: string): number;
-
-    /**
-     * Delete all data associated with a specific {@link RoomVisual} or {@link MapVisual}.
-     *
-     * @param roomName the name of the room (or "map" for {@link MapVisual})
-     *
-     * @see {@link RoomVisual.clear} and {@link MapVisual.clear}
-     */
-    clearVisual(roomName: string): void;
-
-    /**
-     * Get the CSS data added to a {@link RoomVisual} or {@link MapVisual}.
-     *
-     * @param roomName the name of the room (or "map" for {@link MapVisual})
-     * @return all visual data for the specified room/map as a string of CSS,
-     *  or undefined if data has not been written/cleared for this room/map on this tick.
-     *
-     * @see {@link RoomVisual.export} and {@link MapVisual.export}
-     */
-    getVisual(roomName: string): string | undefined;
 }
 
 declare const console: Console;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2,11 +2,9 @@
 
 /**
  * The Console API defined by
- * [screeps/engine](https://github.com/screeps/engine/blob/1b9b1541923f061311474a2f1bac0fea37911f70/src/game/console.js#L10).
+ * [screeps/engine](https://github.com/screeps/engine/blob/master/src/game/console.js#L10).
  *
  * Notes:
- * - This implementation is not compliant with the DOM [Console API](https://developer.mozilla.org/en-US/docs/Web/API/Console_API)
- *      - Ensure your project does not include "dom" in its tsconfig file's ".compilerOptions.lib" to avoid using the DOM version.
  * - `console` is not defined until the first tick. Any messages you log on init will not be emitted to the client.
  */
 interface Console {

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,5 +1,80 @@
 // Please contribute types to https://github.com/screepers/typed-screeps
 
+/**
+ * The Console API defined by
+ * [screeps/engine](https://github.com/screeps/engine/blob/1b9b1541923f061311474a2f1bac0fea37911f70/src/game/console.js#L10).
+ *
+ * Notes:
+ * - This implementation is not compliant with the DOM [Console API](https://developer.mozilla.org/en-US/docs/Web/API/Console_API)
+ *      - Ensure your project does not include "dom" in its tsconfig file's ".compilerOptions.lib" to avoid using the DOM version.
+ * - `console` is not defined until the first tick. Any messages you log on init will not be emitted to the client.
+ */
+interface Console {
+    /**
+     * The **`console.log()`** static method outputs a message to the console.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/log_static).
+     *
+     * Unlike the DOM implementation, HTML special characters are escaped to mitigate XSS attacks.
+     * To log HTML to the console, use {@link logUnsafe} instead.
+     * For more context, see [screeps/engine issue 162](https://github.com/screeps/screeps/issues/162).
+     */
+    log(...data: any[]): void;
+
+    /**
+     * The **`console.logUnsafe()`** static method outputs a message to the console.
+     *
+     * This is identical to the DOM implementation of {@link log}.
+     */
+    logUnsafe(...data: any[]): void;
+
+    /**
+     * Record the evaluated value of a console expression sent via the client or API.
+     *
+     * @param message the result of evaluating the expression
+     */
+    commandResult(message: any): void;
+
+    /**
+     * Append custom CSS data to a {@link RoomVisual} or {@link MapVisual}.
+     *
+     * @param roomName the name of the room (or "map" for {@link MapVisual})
+     * @param data the CSS to add; non-string data will be stringified via {@link JSON.stringify}
+     */
+    addVisual(roomName: string, data: any): void;
+
+    /**
+     * Get the size of the CSS data added to a {@link RoomVisual} or {@link MapVisual}
+     *
+     * @param roomName the name of the room (or "map" for {@link MapVisual})
+     * @return the size in bytes of all CSS written to the specified room/map
+     *
+     * @see {@link RoomVisual.map} and {@link MapVisual.map}
+     */
+    getVisualSize(roomName: string): number;
+
+    /**
+     * Delete all data associated with a specific {@link RoomVisual} or {@link MapVisual}.
+     *
+     * @param roomName the name of the room (or "map" for {@link MapVisual})
+     *
+     * @see {@link RoomVisual.clear} and {@link MapVisual.clear}
+     */
+    clearVisual(roomName: string): void;
+
+    /**
+     * Get the CSS data added to a {@link RoomVisual} or {@link MapVisual}.
+     *
+     * @param roomName the name of the room (or "map" for {@link MapVisual})
+     * @return all visual data for the specified room/map as a string of CSS,
+     *  or undefined if data has not been written/cleared for this room/map on this tick.
+     *
+     * @see {@link RoomVisual.export} and {@link MapVisual.export}
+     */
+    getVisual(roomName: string): string | undefined;
+}
+
+declare const console: Console;
 // Game Constants
 
 declare const OK: OK;

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -1438,3 +1438,28 @@ function atackPower(creep: Creep) {
     Game.shard.access;
     Game.shard.activateAccess?.();
 }
+
+// Console
+{
+    // should be available in global scope and provide log function
+    {
+        console.log("Hello, world!");
+    }
+    // should not provide standard console functions that are not in the Screeps environment
+    {
+        // @ts-expect-error
+        console.error("This should not be allowed");
+        // @ts-expect-error
+        console.warn("This should not be allowed");
+        // @ts-expect-error
+        console.info("This should not be allowed");
+        // @ts-expect-error
+        console.debug("This should not be allowed");
+    }
+    // may provide logUnsafe function that allows logging of unsafe HTML
+    {
+        (console.logUnsafe || console.log)("<p>This is an unsafe log message</p>");
+        // @ts-expect-error
+        console.logUnsafe("this function is not guaranteed to exist on old servers");
+    }
+}

--- a/src/console.ts
+++ b/src/console.ts
@@ -28,7 +28,7 @@ interface Console {
      *
      * To safely log unescaped messages on any environment, use `(console.logUnsafe ?? console.log)(...)`.
      */
-    logUnsafe(...data: any[]): void;
+    logUnsafe?(...data: any[]): void;
 
     /**
      * Append custom CSS data to a {@link RoomVisual} or {@link MapVisual}.

--- a/src/console.ts
+++ b/src/console.ts
@@ -1,0 +1,75 @@
+/**
+ * The Console API defined by
+ * [screeps/engine](https://github.com/screeps/engine/blob/1b9b1541923f061311474a2f1bac0fea37911f70/src/game/console.js#L10).
+ *
+ * Notes:
+ * - This implementation is not compliant with the DOM [Console API](https://developer.mozilla.org/en-US/docs/Web/API/Console_API)
+ *      - Ensure your project does not include "dom" in its tsconfig file's ".compilerOptions.lib" to avoid using the DOM version.
+ * - `console` is not defined until the first tick. Any messages you log on init will not be emitted to the client.
+ */
+interface Console {
+    /**
+     * The **`console.log()`** static method outputs a message to the console.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/log_static).
+     *
+     * Unlike the DOM implementation, HTML special characters are escaped to mitigate XSS attacks.
+     * To log HTML to the console, use {@link logUnsafe} instead.
+     * For more context, see [screeps/engine issue 162](https://github.com/screeps/screeps/issues/162).
+     */
+    log(...data: any[]): void;
+
+    /**
+     * The **`console.logUnsafe()`** static method outputs a message to the console.
+     *
+     * This is identical to the DOM implementation of {@link log}.
+     */
+    logUnsafe(...data: any[]): void;
+
+    /**
+     * Record the evaluated value of a console expression sent via the client or API.
+     *
+     * @param message the result of evaluating the expression
+     */
+    commandResult(message: any): void;
+
+    /**
+     * Append custom CSS data to a {@link RoomVisual} or {@link MapVisual}.
+     *
+     * @param roomName the name of the room (or "map" for {@link MapVisual})
+     * @param data the CSS to add; non-string data will be stringified via {@link JSON.stringify}
+     */
+    addVisual(roomName: string, data: any): void;
+
+    /**
+     * Get the size of the CSS data added to a {@link RoomVisual} or {@link MapVisual}
+     *
+     * @param roomName the name of the room (or "map" for {@link MapVisual})
+     * @return the size in bytes of all CSS written to the specified room/map
+     *
+     * @see {@link RoomVisual.map} and {@link MapVisual.map}
+     */
+    getVisualSize(roomName: string): number;
+
+    /**
+     * Delete all data associated with a specific {@link RoomVisual} or {@link MapVisual}.
+     *
+     * @param roomName the name of the room (or "map" for {@link MapVisual})
+     *
+     * @see {@link RoomVisual.clear} and {@link MapVisual.clear}
+     */
+    clearVisual(roomName: string): void;
+
+    /**
+     * Get the CSS data added to a {@link RoomVisual} or {@link MapVisual}.
+     *
+     * @param roomName the name of the room (or "map" for {@link MapVisual})
+     * @return all visual data for the specified room/map as a string of CSS,
+     *  or undefined if data has not been written/cleared for this room/map on this tick.
+     *
+     * @see {@link RoomVisual.export} and {@link MapVisual.export}
+     */
+    getVisual(roomName: string): string | undefined;
+}
+
+declare const console: Console;

--- a/src/console.ts
+++ b/src/console.ts
@@ -29,14 +29,6 @@ interface Console {
      * To safely log unescaped messages on any environment, use `(console.logUnsafe ?? console.log)(...)`.
      */
     logUnsafe?(...data: any[]): void;
-
-    /**
-     * Append custom CSS data to a {@link RoomVisual} or {@link MapVisual}.
-     *
-     * @param roomName the name of the room (or "map" for {@link MapVisual})
-     * @param data the CSS to add; non-string data will be stringified via {@link JSON.stringify}
-     */
-    addVisual(roomName: string, data: any): void;
 }
 
 declare const console: Console;

--- a/src/console.ts
+++ b/src/console.ts
@@ -22,16 +22,13 @@ interface Console {
     /**
      * The **`console.logUnsafe()`** static method outputs a message to the console.
      *
-     * This is identical to the DOM implementation of {@link log}.
+     * `logUnsafe()` is a new addition that may not be present on older servers.
+     * When defined, it is identical to the DOM implementation of {@link log}.
+     * When undefined, {@link log} will not escape HTML characters.
+     *
+     * To safely log unescaped messages on any environment, use `(console.logUnsafe ?? console.log)(...)`.
      */
     logUnsafe(...data: any[]): void;
-
-    /**
-     * Record the evaluated value of a console expression sent via the client or API.
-     *
-     * @param message the result of evaluating the expression
-     */
-    commandResult(message: any): void;
 
     /**
      * Append custom CSS data to a {@link RoomVisual} or {@link MapVisual}.
@@ -40,36 +37,6 @@ interface Console {
      * @param data the CSS to add; non-string data will be stringified via {@link JSON.stringify}
      */
     addVisual(roomName: string, data: any): void;
-
-    /**
-     * Get the size of the CSS data added to a {@link RoomVisual} or {@link MapVisual}
-     *
-     * @param roomName the name of the room (or "map" for {@link MapVisual})
-     * @return the size in bytes of all CSS written to the specified room/map
-     *
-     * @see {@link RoomVisual.map} and {@link MapVisual.map}
-     */
-    getVisualSize(roomName: string): number;
-
-    /**
-     * Delete all data associated with a specific {@link RoomVisual} or {@link MapVisual}.
-     *
-     * @param roomName the name of the room (or "map" for {@link MapVisual})
-     *
-     * @see {@link RoomVisual.clear} and {@link MapVisual.clear}
-     */
-    clearVisual(roomName: string): void;
-
-    /**
-     * Get the CSS data added to a {@link RoomVisual} or {@link MapVisual}.
-     *
-     * @param roomName the name of the room (or "map" for {@link MapVisual})
-     * @return all visual data for the specified room/map as a string of CSS,
-     *  or undefined if data has not been written/cleared for this room/map on this tick.
-     *
-     * @see {@link RoomVisual.export} and {@link MapVisual.export}
-     */
-    getVisual(roomName: string): string | undefined;
 }
 
 declare const console: Console;

--- a/src/console.ts
+++ b/src/console.ts
@@ -31,4 +31,4 @@ interface Console {
     logUnsafe?(...data: any[]): void;
 }
 
-declare const console: Console;
+declare var console: Console;

--- a/src/console.ts
+++ b/src/console.ts
@@ -1,10 +1,8 @@
 /**
  * The Console API defined by
- * [screeps/engine](https://github.com/screeps/engine/blob/1b9b1541923f061311474a2f1bac0fea37911f70/src/game/console.js#L10).
+ * [screeps/engine](https://github.com/screeps/engine/blob/master/src/game/console.js#L10).
  *
  * Notes:
- * - This implementation is not compliant with the DOM [Console API](https://developer.mozilla.org/en-US/docs/Web/API/Console_API)
- *      - Ensure your project does not include "dom" in its tsconfig file's ".compilerOptions.lib" to avoid using the DOM version.
  * - `console` is not defined until the first tick. Any messages you log on init will not be emitted to the client.
  */
 interface Console {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,10 @@
         "target": "es2017",
         "sourceMap": false,
         "declaration": true,
+        "lib": [
+            "ESNext",
+            "ES2017",
+        ],
         "strict": true,
         "noEmit": true,
         "newLine": "LF",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,10 +4,6 @@
         "target": "es2017",
         "sourceMap": false,
         "declaration": true,
-        "lib": [
-            "ESNext",
-            "ES2017",
-        ],
         "strict": true,
         "noEmit": true,
         "newLine": "LF",


### PR DESCRIPTION
### Brief Description

The Console API available in Screeps is not compliant with the version
defined in the DOM library, which can lead to issues when players
attempt to use methods such as `console.error()`.

Additionally, it may or may not define `logUnsafe()` to log messages without escaping HTML characters.

This pulls the following changes from #289 since the branch is stale and I couldn't add commits to it directly:
* Automated tests
* Make `logUnsafe` optional

### Checklists

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run compile` to update `index.d.ts`
