### PR TITLE
Feat: Narrow type of `Game.resources`

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1823,7 +1823,7 @@ interface Game {
      *
      * Each object key is a resource constant, values are resources amounts.
      */
-    resources: { [key: string]: any };
+    resources: { [key in InterShardResourceConstant]?: number };
     /**
      * A hash containing all the rooms available to you with room names as hash keys.
      *

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -134,6 +134,28 @@ function resources(o: GenericStore): ResourceConstant[] {
     typeof POWER_INFO[PWR_GENERATE_OPS].level[0] === "number";
 }
 
+// Game.resources
+
+{
+    // Account-bound resources are valid keys
+    if (Game.resources[CPU_UNLOCK]) {
+        Game.cpu.unlock();
+    }
+    const canPixelize = (Game.resources[PIXEL] ?? 0) >= 500;
+
+    // Properties are optional
+    // @ts-expect-error
+    const cantPixelize = Game.resources[PIXEL] < 500;
+
+    // Properties are not defined for local resource constants
+    // @ts-expect-error
+    const totalEnergy = Game.resources[RESOURCE_ENERGY];
+
+    // Properties are not defined for arbitrary keys
+    // @ts-expect-error
+    const amIFamous = Game.resources.fame > 9_000;
+}
+
 // Game.spawns
 
 {

--- a/src/game.ts
+++ b/src/game.ts
@@ -41,7 +41,7 @@ interface Game {
      *
      * Each object key is a resource constant, values are resources amounts.
      */
-    resources: { [key: string]: any };
+    resources: { [key in InterShardResourceConstant]?: number };
     /**
      * A hash containing all the rooms available to you with room names as hash keys.
      *


### PR DESCRIPTION
### Brief Description

As the docblock for this property explains, `Game.resources` keys are account-bound resources, and its values are numbers.

Properties within `Game.resources` are all optional because they will not be defined outside MMO.

I do not believe this counts as a breaking change since code that treats `Game.resources` properties as anything other than `number | undefined` would lead to errors.

### Checklists

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run compile` to update `index.d.ts`
