### PR TITLE
Feat: Add more discriminated Structure and StructureConstant unions

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2660,7 +2660,20 @@ type COLOR_WHITE = 10;
 
 // Structure Constants
 
-type BuildableStructureConstant =
+/**
+ * Utility type that extracts underlying {@link StructureConstant}s from a discriminated union of {@link Structure}s
+ */
+type ExtractStructureType<T> = T extends Structure<infer U> ? U : never;
+
+type BuildableStructureConstant = ExtractStructureType<AnyBuildableStructure>;
+
+type NpcStructureConstant = ExtractStructureType<AnyNpcStructure>;
+
+type OwnedStructureConstant = ExtractStructureType<AnyOwnedStructure>;
+
+type StoreStructureConstant = ExtractStructureType<AnyStoreStructure>;
+
+type StructureConstant =
     | STRUCTURE_EXTENSION
     | STRUCTURE_RAMPART
     | STRUCTURE_ROAD
@@ -2676,15 +2689,14 @@ type BuildableStructureConstant =
     | STRUCTURE_TERMINAL
     | STRUCTURE_CONTAINER
     | STRUCTURE_NUKER
-    | STRUCTURE_FACTORY;
-
-type StructureConstant =
-    | BuildableStructureConstant
+    | STRUCTURE_FACTORY
     | STRUCTURE_KEEPER_LAIR
     | STRUCTURE_CONTROLLER
     | STRUCTURE_POWER_BANK
     | STRUCTURE_PORTAL
     | STRUCTURE_INVADER_CORE;
+
+type VulnerableStructureConstant = ExtractStructureType<AnyVulnerableStructure>;
 
 type STRUCTURE_EXTENSION = "extension";
 type STRUCTURE_RAMPART = "rampart";
@@ -6717,7 +6729,29 @@ interface StructureInvaderCoreConstructor extends _Constructor<StructureInvaderC
 declare const StructureInvaderCore: StructureInvaderCoreConstructor;
 
 /**
- * A discriminated union on Structure.type of all owned structure types
+ * A discriminated union of all structures that can be built by a player via a {@link ConstructionSite}.
+ * These structure types can be dismantled by creeps with {@link WORK} parts.
+ */
+type AnyBuildableStructure =
+    | StructureContainer
+    | StructureExtension
+    | StructureExtractor
+    | StructureFactory
+    | StructureLab
+    | StructureLink
+    | StructureNuker
+    | StructureObserver
+    | StructurePowerSpawn
+    | StructureRampart
+    | StructureRoad
+    | StructureSpawn
+    | StructureStorage
+    | StructureTerminal
+    | StructureTower
+    | StructureWall;
+
+/**
+ * A discriminated union on {@link Structure.structureType} of all {@link OwnedStructure} types
  */
 type AnyOwnedStructure =
     | StructureController
@@ -6738,6 +6772,14 @@ type AnyOwnedStructure =
     | StructureTerminal
     | StructureTower;
 
+/**
+ * A discriminated union of {@link OwnedStructure} types that can only be owned by NPCs (invaders / source keepers / etc)
+ */
+type AnyNpcStructure = StructureInvaderCore | StructureKeeperLair | StructurePowerBank;
+
+/**
+ * A discriminated union of all {@link Structure} types with a `store` property
+ */
 type AnyStoreStructure =
     | StructureExtension
     | StructureFactory
@@ -6755,6 +6797,12 @@ type AnyStoreStructure =
  * A discriminated union on {@link Structure.structureType} of all structure types
  */
 type AnyStructure = AnyOwnedStructure | StructureContainer | StructurePortal | StructureRoad | StructureWall;
+
+/**
+ * A discriminated union of all structures that have hit points and can be damaged with attacks.
+ * Note that this includes {@link StructureInvaderCore} even though it can be temporarily invulnerable.
+ */
+type AnyVulnerableStructure = AnyBuildableStructure | StructureInvaderCore | StructurePowerBank;
 
 /**
  * Map of structure constant to the concrete structure class

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -1024,6 +1024,25 @@ function resources(o: GenericStore): ResourceConstant[] {
             filter: (s) => s.structureType === STRUCTURE_RAMPART,
         })
         .forEach((r) => r.notifyWhenAttacked(false));
+
+    const NPC_STRUCTURE_CONSTANTS_SET = new Set<StructureConstant>([STRUCTURE_INVADER_CORE, STRUCTURE_KEEPER_LAIR, STRUCTURE_POWER_BANK]);
+
+    const structureTargets: AnyVulnerableStructure[] = Game.rooms.myRoom.find(FIND_STRUCTURES, {
+        filter: (s) => (!("my" in s) || !s.my) && s.hits > 0,
+    });
+
+    const dismantleTargets = structureTargets.filter((s: AnyVulnerableStructure): s is AnyBuildableStructure => {
+        return !NPC_STRUCTURE_CONSTANTS_SET.has(s.structureType);
+    });
+
+    const hostilePlayerStructures: Exclude<AnyOwnedStructure, AnyNpcStructure>[] = Game.rooms.myRoom.find(FIND_HOSTILE_STRUCTURES, {
+        filter: (s) => !NPC_STRUCTURE_CONSTANTS_SET.has(s.structureType),
+    });
+
+    function findMyOwnedStructuresByType<T extends OwnedStructureConstant>(room: Room, structureType: T): ConcreteStructure<T>[] {
+        return room.find(FIND_MY_STRUCTURES, { filter: (s) => s.structureType === structureType });
+    }
+    const myTowers = findMyOwnedStructuresByType(Game.rooms.myRoom, STRUCTURE_TOWER);
 }
 
 {

--- a/src/literals.ts
+++ b/src/literals.ts
@@ -221,7 +221,20 @@ type COLOR_WHITE = 10;
 
 // Structure Constants
 
-type BuildableStructureConstant =
+/**
+ * Utility type that extracts underlying {@link StructureConstant}s from a discriminated union of {@link Structure}s
+ */
+type ExtractStructureType<T> = T extends Structure<infer U> ? U : never;
+
+type BuildableStructureConstant = ExtractStructureType<AnyBuildableStructure>;
+
+type NpcStructureConstant = ExtractStructureType<AnyNpcStructure>;
+
+type OwnedStructureConstant = ExtractStructureType<AnyOwnedStructure>;
+
+type StoreStructureConstant = ExtractStructureType<AnyStoreStructure>;
+
+type StructureConstant =
     | STRUCTURE_EXTENSION
     | STRUCTURE_RAMPART
     | STRUCTURE_ROAD
@@ -237,15 +250,14 @@ type BuildableStructureConstant =
     | STRUCTURE_TERMINAL
     | STRUCTURE_CONTAINER
     | STRUCTURE_NUKER
-    | STRUCTURE_FACTORY;
-
-type StructureConstant =
-    | BuildableStructureConstant
+    | STRUCTURE_FACTORY
     | STRUCTURE_KEEPER_LAIR
     | STRUCTURE_CONTROLLER
     | STRUCTURE_POWER_BANK
     | STRUCTURE_PORTAL
     | STRUCTURE_INVADER_CORE;
+
+type VulnerableStructureConstant = ExtractStructureType<AnyVulnerableStructure>;
 
 type STRUCTURE_EXTENSION = "extension";
 type STRUCTURE_RAMPART = "rampart";

--- a/src/structure.ts
+++ b/src/structure.ts
@@ -879,7 +879,29 @@ interface StructureInvaderCoreConstructor extends _Constructor<StructureInvaderC
 declare const StructureInvaderCore: StructureInvaderCoreConstructor;
 
 /**
- * A discriminated union on Structure.type of all owned structure types
+ * A discriminated union of all structures that can be built by a player via a {@link ConstructionSite}.
+ * These structure types can be dismantled by creeps with {@link WORK} parts.
+ */
+type AnyBuildableStructure =
+    | StructureContainer
+    | StructureExtension
+    | StructureExtractor
+    | StructureFactory
+    | StructureLab
+    | StructureLink
+    | StructureNuker
+    | StructureObserver
+    | StructurePowerSpawn
+    | StructureRampart
+    | StructureRoad
+    | StructureSpawn
+    | StructureStorage
+    | StructureTerminal
+    | StructureTower
+    | StructureWall;
+
+/**
+ * A discriminated union on {@link Structure.structureType} of all {@link OwnedStructure} types
  */
 type AnyOwnedStructure =
     | StructureController
@@ -900,6 +922,14 @@ type AnyOwnedStructure =
     | StructureTerminal
     | StructureTower;
 
+/**
+ * A discriminated union of {@link OwnedStructure} types that can only be owned by NPCs (invaders / source keepers / etc)
+ */
+type AnyNpcStructure = StructureInvaderCore | StructureKeeperLair | StructurePowerBank;
+
+/**
+ * A discriminated union of all {@link Structure} types with a `store` property
+ */
 type AnyStoreStructure =
     | StructureExtension
     | StructureFactory
@@ -917,6 +947,12 @@ type AnyStoreStructure =
  * A discriminated union on {@link Structure.structureType} of all structure types
  */
 type AnyStructure = AnyOwnedStructure | StructureContainer | StructurePortal | StructureRoad | StructureWall;
+
+/**
+ * A discriminated union of all structures that have hit points and can be damaged with attacks.
+ * Note that this includes {@link StructureInvaderCore} even though it can be temporarily invulnerable.
+ */
+type AnyVulnerableStructure = AnyBuildableStructure | StructureInvaderCore | StructurePowerBank;
 
 /**
  * Map of structure constant to the concrete structure class


### PR DESCRIPTION
### Brief Description

This change addresses issue #229 by implementing `AnyNpcStructure` and `NpcStructureConstant`. It includes similar types I've been using in my project.

New `Structure` unions:
* `AnyBuildableStructure`: Structures that can be created by players
* `AnyNpcStructure`: OwnedStructures that can only be owned by NPCs
* `AnyVulnerableStructure`: Structures that can be damaged by creep/tower attacks

New `StructureConstant` unions (to mirror all `Structure` unions):
* `NpcStructureConstant`
* `OwnedStructureConstant`
* `StoreStructureConstant`
* `VulnerableStructureConstant`

Rather than manually synchronize each structure union with its associated structure constant union, I created a utility type, `ExtractStructureType` that generates the latter from the former.

### Checklists

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run build` to update `index.d.ts`
