### PR TITLE
Feat: declare SIGN_PLANNED_AREA const

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -796,6 +796,8 @@ declare const INVADERS_ENERGY_GOAL: number;
 
 declare const SYSTEM_USERNAME: string;
 
+declare const SIGN_PLANNED_AREA: string;
+
 declare const TOMBSTONE_DECAY_PER_PART: 5;
 declare const TOMBSTONE_DECAY_POWER_CREEP: 500;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -762,6 +762,8 @@ declare const INVADERS_ENERGY_GOAL: number;
 
 declare const SYSTEM_USERNAME: string;
 
+declare const SIGN_PLANNED_AREA: string;
+
 declare const TOMBSTONE_DECAY_PER_PART: 5;
 declare const TOMBSTONE_DECAY_POWER_CREEP: 500;
 


### PR DESCRIPTION
### Brief Description

From the API docs:
```js
    // SIGN_NOVICE_AREA and SIGN_RESPAWN_AREA constants are deprecated, please use SIGN_PLANNED_AREA instead
    SIGN_NOVICE_AREA: 'A new Novice or Respawn Area is being planned somewhere in this sector. Please make sure all important rooms are reserved.',
    SIGN_RESPAWN_AREA: 'A new Novice or Respawn Area is being planned somewhere in this sector. Please make sure all important rooms are reserved.',
    SIGN_PLANNED_AREA: 'A new Novice or Respawn Area is being planned somewhere in this sector. Please make sure all important rooms are reserved.',
```

`SIGN_NOVICE_AREA` and `SIGN_RESPAWN_AREA` have been omitted since the values are identical and they are deprecated.

I wasn't sure it made sense to add a test for a single const declaration, but I can write one if needed.

### Checklists

- [ ] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run build` to update `index.d.ts`
