### PR TITLE
Feat!: Add `createdTimestamp` and make `created` optional on `Order`

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3635,12 +3635,14 @@ interface Transaction {
 interface Order {
     /** The unique order ID. */
     id: string;
+    /** The order creation time in game ticks. This property is absent for orders of the inter-shard market. */
+    created?: number;
     /**
-     * The order creation time in milliseconds since UNIX epoch time.
+     * The order creation time {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime#Syntax|in milliseconds since UNIX epoch time}.
      *
      * This property is absent for old orders.
      */
-    created: number;
+    createdTimestamp: number;
     /** Whether the order is active or not.
      *
      * Only exists for your own orders. */

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -451,6 +451,24 @@ function resources(o: GenericStore): ResourceConstant[] {
     const pixelHistory = Game.market.getHistory(PIXEL);
 }
 
+function priceToMove(order: Order): boolean {
+    if (!order.remainingAmount) {
+        return false;
+    }
+
+    // @ts-expect-error: created is undefined for intershard orders
+    Game.time - order.created < 10_000;
+
+    const isOpenTooLong =
+        order.created !== undefined ? Game.time - order.created > 10_000 : Date.now() - order.createdTimestamp > 7_200_000;
+    if (!isOpenTooLong) {
+        return false;
+    }
+
+    Game.market.changeOrderPrice(order.id, order.price * (order.type === ORDER_BUY ? 1.05 : 0.95));
+    return true;
+}
+
 // PathFinder
 
 {

--- a/src/market.ts
+++ b/src/market.ts
@@ -156,12 +156,14 @@ interface Transaction {
 interface Order {
     /** The unique order ID. */
     id: string;
+    /** The order creation time in game ticks. This property is absent for orders of the inter-shard market. */
+    created?: number;
     /**
-     * The order creation time in milliseconds since UNIX epoch time.
+     * The order creation time {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime#Syntax|in milliseconds since UNIX epoch time}.
      *
      * This property is absent for old orders.
      */
-    created: number;
+    createdTimestamp: number;
     /** Whether the order is active or not.
      *
      * Only exists for your own orders. */


### PR DESCRIPTION
### Brief Description

Updates `Order`'s time fields to reflect the [API docs](https://docs.screeps.com/api/#Game.market.getAllOrders):
* `created` is the creation time in ticks; it is not defined for intershard orders
    * This is a breaking change for users who rely on this field and don't trade intershard resources
* `createdTimestamp` is the creation UNIX timestamp
    * While not defined for older orders, this definition was added long after any such legacy orders expired, so it will always be defined

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run build` to update `index.d.ts`
