### PR TITLE
improvement: Make console.logUnsafe non-optional

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -28,7 +28,7 @@ interface Console {
      *
      * To safely log unescaped messages on any environment, use `(console.logUnsafe ?? console.log)(...)`.
      */
-    logUnsafe?(...data: any[]): void;
+    logUnsafe(...data: any[]): void;
 }
 
 declare var console: Console;

--- a/dist/screeps-tests.ts
+++ b/dist/screeps-tests.ts
@@ -1459,10 +1459,8 @@ function atackPower(creep: Creep) {
         // @ts-expect-error
         console.debug("This should not be allowed");
     }
-    // may provide logUnsafe function that allows logging of unsafe HTML
+    // provide logUnsafe function that allows logging of unescaped HTML tags
     {
-        (console.logUnsafe || console.log)("<p>This is an unsafe log message</p>");
-        // @ts-expect-error
-        console.logUnsafe("this function is not guaranteed to exist on old servers");
+        console.logUnsafe("<p>This is an unsafe log message</p>");
     }
 }

--- a/src/console.ts
+++ b/src/console.ts
@@ -26,7 +26,7 @@ interface Console {
      *
      * To safely log unescaped messages on any environment, use `(console.logUnsafe ?? console.log)(...)`.
      */
-    logUnsafe?(...data: any[]): void;
+    logUnsafe(...data: any[]): void;
 }
 
 declare var console: Console;


### PR DESCRIPTION
### Brief Description

The logUnsafe change has been out long enough that by the time this change is released, anyone using it will be running code on servers using node 24.

Marking this function as non-optional allows it to be referenced without unnecessary non-null assertions or null-coalesce operations.

### Checklists

<!-- Put an 'x' inside the '[ ]' next to each completed items -->

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run build` to update `index.d.ts`
