### PR TITLE
fix!: Narrow return type of ConstructionSite.remove

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1102,9 +1102,8 @@ interface ConstructionSite<T extends BuildableStructureConstant = BuildableStruc
     structureType: T;
     /**
      * Remove the construction site.
-     * @returns Result Code: OK, ERR_NOT_OWNER
      */
-    remove(): number;
+    remove(): OK | ERR_NOT_OWNER;
 }
 
 interface ConstructionSiteConstructor extends _Constructor<ConstructionSite>, _ConstructorById<ConstructionSite> {}

--- a/src/construction-site.ts
+++ b/src/construction-site.ts
@@ -37,9 +37,8 @@ interface ConstructionSite<T extends BuildableStructureConstant = BuildableStruc
     structureType: T;
     /**
      * Remove the construction site.
-     * @returns Result Code: OK, ERR_NOT_OWNER
      */
-    remove(): number;
+    remove(): OK | ERR_NOT_OWNER;
 }
 
 interface ConstructionSiteConstructor extends _Constructor<ConstructionSite>, _ConstructorById<ConstructionSite> {}


### PR DESCRIPTION
### Brief Description

`ConstructionSite.remove()` previously had a return type of `number`. While this is technically correct, it's too broad to be useful. For example, an error will occur if the result is passed as an argument for a `ScreepsReturnCode` parameter.

This change narrows the return type of `ConstructionSite.remove()` to only its possible return values: `OK | ERR_NOT_OWNER`.

### Checklists

- [x] Test passed
- [x] Coding style (indentation, etc)
- [x] Edits have been made to `src/` files not `index.d.ts`
- [x] Run `npm run build` to update `index.d.ts`
